### PR TITLE
Fix tests `--keep-workdirs` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [UNRELEASED] - 2023-??-??
+## [0.13.1] - 2023-09-15
 
 ### Added
 
-### Fixed
-
 ### Changed
 
-* Removed docstring linting it tests
+### Fixed
+
+* Fix an issue where `--keep-workdirs` option for pytest was not available when running pytest without
+  restricting the testdir to `tests/integration`.
 
 ### Removed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ version = "0.0.0"
 homepage = "https://github.com/PixelgenTechnologies/pixelator"
 repository = "https://github.com/PixelgenTechnologies/pixelator"
 documentation = "https://software.pixelgen.com"
-description = "A commandline tool and library to process and analyze sequencing data from Molecular Pixelation (MPX) assays."
+description = "A command-line tool and library to process and analyze sequencing data from Molecular Pixelation (MPX) assays."
 authors = ["Pixelgen Technologies AB <developers@pixelgen.com>",]
 maintainers = [
     "Alvaro Martinez Barrio <alvaro.martinez.barrio@pixelgen.com>"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,20 @@ from tests.graph.test_graph import (
 DATA_ROOT = Path(__file__).parent / "data"
 
 
+def pytest_addoption(parser: pytest.Parser):
+    """Register a command line option for pytest.
+    This flag is used in workflow integration tests defined in
+    tests/integration.
+    :param parser: the pytest parser instance
+    """
+    parser.addoption(
+        "--keep-workdirs",
+        action="store_true",
+        default=False,
+        help="Do not delete the working directory.",
+    )
+
+
 @pytest.fixture(name="adata", scope="module")
 def adata_fixture(edgelist: pd.DataFrame, panel: AntibodyPanel):
     """Create an anndata instance."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -47,19 +47,6 @@ def handle_unhandled_exception(
 sys.excepthook = handle_unhandled_exception
 
 
-def pytest_addoption(parser: pytest.Parser):
-    """Register a command line option for pytest.
-
-    :param parser: the pytest parser instance
-    """
-    parser.addoption(
-        "--keep-workdirs",
-        action="store_true",
-        default=False,
-        help="Do not delete the working directory.",
-    )
-
-
 def pytest_collect_file(
     parent: YamlIntegrationTestsCollector, file_path: PathType
 ) -> YamlIntegrationTestsCollector:


### PR DESCRIPTION
<!--
# Pixelgen Technologies pull request template

Many thanks for contributing to it if you think it could be improved. This is a self-improving process!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/PixelgenTechnologies/pixelator/blob/main/CONTRIBUTING.md)
-->

## Description

Fix an issue where the pytest `--keep-workdirs` cli option would only work when running integration tests using `pytest tests/integration` and when running all tests from the project root.

Fixes: EXE-1055

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
