### PR TITLE
update poetry-dynamic-versioning to 1.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ furo = "^2023.5.20"
 pixelator = 'pixelator.cli:main_cli'
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.1"]
 build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Description

This fixes an issue with pixelator 1.7.0 which has removed a deprecated module that poetry-dynamic-versioning depends on.

https://github.com/mtkennerly/poetry-dynamic-versioning/issues/139

Fixes: [EXE-1067](https://linear.app/pixelgen-technologies/issue/EXE-1067/update-pyprojecttoml-build-dependencies-with-poetry-dynamic-versioning)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update