### PR TITLE
fix: dynamic version not working with "dev mode" installs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* Fix an issue where `--keep-workdirs` option for pytest was not available when running pytest without
-  restricting the testdir to `tests/integration`.
-* Fix an issue where pixelator --version would return 0.0.0.
+* Fix an issue where pixelator --version would return 0.0.0 when installing in editable mode.
 
 ### Removed
 

--- a/src/pixelator/__init__.py
+++ b/src/pixelator/__init__.py
@@ -7,7 +7,7 @@ from importlib import metadata
 __version__ = "0.0.0"
 
 try:
-    __version__ = metadata.version("pixelator")
+    __version__ = metadata.version("pixelgen-pixelator")
 except metadata.PackageNotFoundError:
     pass
 


### PR DESCRIPTION
# Description

Fix an issue where editable installations with pip and poetry would still return the dynamic versioning placeholder `0.0.0` instead of the real version.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update