### PR TITLE
Remove adapterqc pbs flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Types on the edge list in memory will utilize the `pandas` `category` type for string, and
   `uint16` for numeric values to lower the memory consumption when working with the
   edge list
+* Remove `--pbs1` and `--pbs2` commandline arguments to `pixelator single-cell adapterqc`.
 
 ### Fixed
 

--- a/src/pixelator/cli/adapterqc.py
+++ b/src/pixelator/cli/adapterqc.py
@@ -1,5 +1,4 @@
-"""
-Console script for pixelator (adapterqc)
+"""Console script for pixelator (adapterqc).
 
 Copyright (c) 2022 Pixelgen Technologies AB.
 """
@@ -44,28 +43,6 @@ from pixelator.utils import (
     show_default=True,
     help="The number of mismatches allowed (in percentage)",
 )
-@click.option(
-    "--pbs1",
-    default=None,
-    required=False,
-    type=click.STRING,
-    show_default=False,
-    help=(
-        "The PBS1 sequence that must be present in the reads.\n"
-        "If you set this argument it will overrule the value from the chosen design"
-    ),
-)
-@click.option(
-    "--pbs2",
-    default=None,
-    required=False,
-    type=click.STRING,
-    show_default=False,
-    help=(
-        "The PBS2 sequence that must be present in the reads.\n"
-        "If you set this argument it will overrule the value from the chosen design"
-    ),
-)
 @output_option
 @design_option
 @click.pass_context
@@ -74,15 +51,10 @@ def adapterqc(
     ctx,
     input_files,
     mismatches,
-    pbs1,
-    pbs2,
     output,
     design,
 ):
-    """
-    Process Molecular Pixelation data (FASTQ) to check for the presence of
-    PBS1/2 sequences
-    """
+    """Check for the presence of PBS1/2 sequences in FASTQ input files."""
     from pixelator.config import config
 
     # log input parameters
@@ -91,8 +63,6 @@ def adapterqc(
         input_files=input_files,
         output=output,
         mismatches=mismatches,
-        pbs1=pbs1,
-        pbs2=pbs2,
         design=design,
     )
 
@@ -102,10 +72,8 @@ def adapterqc(
     # update arguments from config file (CLI arguments have priority)
     try:
         amplicon = config.get_assay(design).get_region_by_id("amplicon")
-        if pbs1 is None:
-            pbs1 = amplicon.get_region_by_id("pbs-1").get_sequence()
-        if pbs2 is None:
-            pbs2 = amplicon.get_region_by_id("pbs-2").get_sequence()
+        pbs1 = amplicon.get_region_by_id("pbs-1").get_sequence()
+        pbs2 = amplicon.get_region_by_id("pbs-2").get_sequence()
     except KeyError as exc:
         raise click.ClickException(f"Parsing attribute from config file {exc}")
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,6 +2,8 @@
 
 Pytest configuration for integration testing pixelator
 """
+from pathlib import Path
+
 import pytest
 from types import TracebackType
 from typing import Optional, Type
@@ -49,7 +51,7 @@ sys.excepthook = handle_unhandled_exception
 
 def pytest_collect_file(
     parent: YamlIntegrationTestsCollector, file_path: PathType
-) -> YamlIntegrationTestsCollector:
+) -> Optional[YamlIntegrationTestsCollector]:
     """Collect test into a specific instance of :class:`YamlIntegrationTestsCollector`.
 
     :param parent: the parent object
@@ -57,7 +59,10 @@ def pytest_collect_file(
     :return: A custom pytest collector that generates tests from yaml files.
     :rtype: YamlIntegrationTestsCollector
     """
+    file_path = Path(file_path)
     if file_path.suffix == ".yaml" and file_path.name.startswith("test_"):
         yaml_tests = YamlIntegrationTestsCollector.from_parent(parent, path=file_path)
         yaml_tests.add_marker(pytest.mark.workflow_test)
         return yaml_tests
+
+    return None


### PR DESCRIPTION
## Description

Remove unneeded --pbs1 and --pbs2 flags to adapterqc.
Customizig these values should happen through assay files.

Fixes: EXE-943

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
