### PR TITLE
Feature/exe 1095 make graph backend switchable

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-extend-ignore = E501,E402,W503,E203,D213,D203,DOC301
+extend-ignore = E501,E402,W503,E203,D213,D203,DOC301,DOC501,DOC502
 exclude = .git,__pycache__,docs/source/conf.py,old,build,dist,cue.mod
 docstring-convention = all
 style = sphinx

--- a/src/pixelator/graph/backends/__init__.py
+++ b/src/pixelator/graph/backends/__init__.py
@@ -1,0 +1,4 @@
+"""Graph backends used by pixelator.
+
+Copyright (c) 2023 Pixelgen Technologies AB.
+"""

--- a/src/pixelator/graph/backends/implementations.py
+++ b/src/pixelator/graph/backends/implementations.py
@@ -1,0 +1,572 @@
+"""Concrete implementations of graph backends used by pixelator.
+
+Copyright (c) 2023 Pixelgen Technologies AB.
+"""
+
+
+import logging
+from typing import Dict, List, Optional, Tuple
+
+import igraph
+import networkx as nx
+import numpy as np
+import pandas as pd
+from scipy.sparse import csr_matrix
+
+from pixelator.graph.backends.protocol import _GraphBackend
+
+logger = logging.getLogger(__name__)
+
+
+class IgraphBasedVertexSequence:
+    """Proxy for a igraph.VertexSeq."""
+
+    def __init__(self, raw) -> None:
+        """Instantiate a new IgraphBasedVertexSequence."""
+        self._raw = raw
+
+    def select(self, **kwargs):
+        """Select a subset of vertices.
+
+        See https://python.igraph.org/en/stable/api/igraph.VertexSeq.html#select
+        """
+        return self._raw.select(**kwargs)
+
+    @property
+    def attributes(self):
+        """Get all attributes associated with the vertices."""
+        return self._raw.attributes
+
+    def __getitem__(self, vertex):
+        """Get the provide vertex."""
+        return self._raw[vertex]
+
+    def __setitem__(self, attribute, attribute_vector):
+        """Set the given vertex attribute to the values in the attribute vector."""
+        self._raw[attribute] = attribute_vector
+
+
+class IgraphBasedEdgeSequence:
+    """Proxy for a igraph.EdgeSeq."""
+
+    def __init__(self, raw) -> None:
+        """Instantiate a new IgraphBasedEdgeSequence."""
+        self._raw = raw
+
+    def select(self, **kwargs):
+        """Select a subset of vertices.
+
+        See https://python.igraph.org/en/stable/api/igraph.EdgeSeq.html#select
+        """
+        return self._raw.select(**kwargs)
+
+    def __getitem__(self, edge):
+        """Get the provided edge."""
+        return self._raw[edge]
+
+    def __setitem__(self, key, newvalue):
+        """Set the given edge attribute to the values in the attribute vector."""
+        self._raw[key] = newvalue
+
+
+class IgraphBasedVertexClustering:
+    """Wrapper class for a cluster of vertexes."""
+
+    def __init__(self, raw) -> None:
+        """Instantiate a VertexClustering."""
+        self._raw = raw
+
+    def __len__(self):
+        """Get the number of clusters."""
+        return len(self._raw)
+
+    def __iter__(self):
+        """Provide an iterator over the clusters."""
+        for cluster in self._raw:
+            yield cluster
+
+    @property
+    def modularity(self):
+        """Get the modularity of the clusters."""
+        return self._raw.modularity
+
+    def crossing(self):
+        """Get any crossing edges."""
+        return self._raw.crossing()
+
+    def giant(self):
+        """Get the largest component."""
+        return self._raw.giant()
+
+    def subgraphs(self):
+        """Get subgraphs of each cluster."""
+        # Avoid a circular import at init time, for now...
+        from pixelator.graph import Graph
+
+        return [Graph(g) for g in self._raw.subgraphs()]
+
+
+class IgraphGraphBackend(_GraphBackend):
+    """`IGraphGraphBackend` represents a graph, using igraph."""
+
+    def __init__(
+        self,
+        raw: Optional[igraph.Graph] = None,
+    ):
+        """Create a new Graph instance.
+
+        Create a Graph instance (as an end-user this is probably not the interface
+        you are looking for). Try `Graph.from_edgelist`.
+
+        :param raw: The underlying raw representation of the graph, defaults to None
+        """
+        if not raw:
+            raw = igraph.Graph()
+        self._raw = raw
+
+    @staticmethod
+    def from_edgelist(
+        edgelist: pd.DataFrame,
+        add_marker_counts: bool,
+        simplify: bool,
+        use_full_bipartite: bool,
+    ) -> "IgraphGraphBackend":
+        """Build a graph from an edgelist.
+
+        Build a Graph from an edge list (pd.DataFrame). Multiple options are available
+        to build the graph, `add_marker_counts` will add a dictionary of marker counts
+        to each node, `simplify` will remove redundant edges and `use_full_bipartite`
+        will not project the graph (UPIA).
+
+        The graph will contain the edge attributes present in the edge list when
+        `use_full_bipartite` is True and a dictionary of marker counts in each
+        vertex (node) when `add_marker_counts` is True. If `use_full_bipartite` is
+        False or `simplify` is True the edge attributes will be lost.
+
+        :param edgelist: the edge list (dataframe) corresponding to the graph
+        :param add_marker_counts: add a dictionary of marker counts to each node
+        :param simplify: simplifies the graph (remove redundant edges)
+        :param use_full_bipartite: use the bipartite graph instead of the projection
+                                  (UPIA)
+        :returns: a GraphBackend instance
+        :rtype: IgraphGraphBackend
+        :raises: AssertionError when the input edge list is not valid
+        """
+        logger.debug(
+            "Creating graph from edge list with %i edges",
+            edgelist.shape[0],
+        )
+
+        # igraph requires these types to work properly with indexing the vertices
+        edgelist = edgelist.astype({"upia": "object", "upib": "object"})
+
+        vertices = pd.DataFrame(
+            set(edgelist["upia"].unique()).union(set(edgelist["upib"].unique()))
+        )
+
+        graph = igraph.Graph.DataFrame(
+            edgelist,
+            vertices=vertices,
+            directed=False,
+            use_vids=False,
+        )
+        if "sequence" in edgelist.columns:
+            all_sequences = edgelist["sequence"].unique()
+            logger.debug(
+                "Edge list contains %i sequences",
+                len(all_sequences),
+            )
+        else:
+            logger.warning(
+                "Edge list with no sequence found",
+            )
+
+        if add_marker_counts:
+            if "marker" not in edgelist.columns:
+                raise AssertionError("Edge list is missing the marker column")
+
+            all_markers = edgelist.marker.unique()
+            logger.debug(
+                "Adding %i markers information to graph from edge list",
+                len(all_markers),
+            )
+
+            graph.vs["markers"] = [{m: 0 for m in all_markers} for _ in graph.vs]
+            for e in graph.es:
+                marker = e["marker"]
+                v1, v2 = e.vertex_tuple
+                v1["markers"][marker] += 1
+                v2["markers"][marker] += 1
+
+        # the type attribute is needed to project (True means second projection
+        # which in out case is upib, the first projection would be upia)
+        dest_pixels = set(edgelist["upib"])
+        graph.vs["type"] = [v["name"] in dest_pixels for v in graph.vs]
+        graph.vs["pixel_type"] = list(
+            map(lambda x: "B" if x else "A", graph.vs["type"])
+        )
+
+        if not use_full_bipartite:
+            logger.debug("Projecting graph on UPIA")
+            # which argument defines which projection to retrieve (first (0) or
+            # second (1))
+            graph = graph.simplify().bipartite_projection(
+                types="type", multiplicity=False, which=0
+            )
+
+        logger.debug("Graph created")
+        return IgraphGraphBackend(
+            graph.simplify() if use_full_bipartite and simplify else graph
+        )
+
+    @staticmethod
+    def from_raw(graph: igraph.Graph) -> "IgraphGraphBackend":
+        """Generate a Graph from an igraph.Graph object.
+
+        :param graph: input igraph to use
+        :return: A pixelator Graph object
+        :rtype: IgraphGraphBackend
+        """
+        return IgraphGraphBackend(graph)
+
+    @property
+    def raw(self):
+        """Get the raw underlying graph representation."""
+        return self._raw
+
+    @property
+    def vs(self):
+        """Get a sequence of the vertices in the Graph instance."""
+        return IgraphBasedVertexSequence(self._raw.vs)
+
+    @property
+    def es(self):
+        """A sequence of the edges in the Graph instance."""
+        return IgraphBasedEdgeSequence(self._raw.es)
+
+    def vcount(self):
+        """Get the total number of vertices in the Graph instance."""
+        return self._raw.vcount()
+
+    def ecount(self):
+        """Get the total number of edges in the Graph instance."""
+        return self._raw.ecount()
+
+    def get_adjacency_sparse(self) -> csr_matrix:
+        """Get the sparse adjacency matrix."""
+        return self._raw.get_adjacency_sparse()
+
+    def connected_components(self):
+        """Get the connected components in the Graph instance."""
+        return IgraphBasedVertexClustering(self._raw.connected_components())
+
+    def community_leiden(self, **kwargs):
+        """Run community detection using the Leiden algorithm."""
+        return IgraphBasedVertexClustering(self._raw.community_leiden(**kwargs))
+
+    def layout_coordinates(
+        self,
+        layout_algorithm: str = "fruchterman_reingold",
+        only_keep_a_pixels: bool = True,
+        get_node_marker_matrix: bool = True,
+    ) -> pd.DataFrame:
+        """Generate coordinates and (optionally) node marker counts for plotting.
+
+        Generate a dataframe with coordinates, and (optionally) node marker
+        counts to use that can be used for plotting.
+
+        The layout options are:
+          - fruchterman_reingold
+          - fruchterman_reingold_3d
+          - kamada_kawai
+          - kamada_kawai_3d
+
+
+        The `fruchterman_reingold` options are in general faster, but less
+        accurate than the `kamada_kawai` ones.
+
+        :param layout_algorithm: the layout algorithm to use to generate the coordinates
+        :param only_keep_a_pixels: If true, only keep the a-pixels
+        :param get_node_marker_matrix: Add a matrix of marker counts to each
+                                       node if True.
+        :return: the coordinates and markers (if activated) as a dataframe
+        :rtype: pd.DataFrame
+        :raises: AssertionError if the provided `layout_algorithm` is not valid
+        :raises: ValueError if the provided current graph instance is empty
+        """
+        layout_options = [
+            "fruchterman_reingold",
+            "fruchterman_reingold_3d",
+            "kamada_kawai",
+            "kamada_kawai_3d",
+        ]
+        if layout_algorithm not in layout_options:
+            raise AssertionError(
+                (
+                    f"{layout_algorithm} not allowed `layout_algorithm` option. "
+                    f"Options are: {'/'.join(layout_options)}"
+                )
+            )
+
+        if not self._raw:
+            raise ValueError("Trying to get layout for empty Graph instance.")
+        raw = self._raw  # type: igraph.Graph
+
+        if layout_algorithm == "kamada_kawai":
+            layout_inst = raw.layout_kamada_kawai(seed=raw.layout_random(dim=2))
+        if layout_algorithm == "kamada_kawai_3d":
+            layout_inst = raw.layout_kamada_kawai_3d(seed=raw.layout_random(dim=3))
+        if layout_algorithm == "fruchterman_reingold":
+            layout_inst = raw.layout_fruchterman_reingold()
+        if layout_algorithm == "fruchterman_reingold_3d":
+            layout_inst = raw.layout_fruchterman_reingold_3d()
+
+        coordinates = pd.DataFrame(
+            layout_inst.coords,
+            columns=["x", "y"] if layout_inst.dim == 2 else ["x", "y", "z"],
+        )
+
+        # If we are doing a 3D layout we add the option of normalized
+        # vectors where we scale the length of each point vector to be one, so that
+        # we have the option of doing a spherical projection of the graph
+        if layout_inst.dim == 3:
+            coordinates[["x_norm", "y_norm", "z_norm"]] = (
+                coordinates[["x", "y", "z"]]
+                / (1 * np.linalg.norm(np.asarray(coordinates), axis=1))[:, None]
+            )
+
+        if get_node_marker_matrix:
+            # Added here to avoid circular imports
+            from pixelator.graph.utils import create_node_markers_counts
+
+            node_marker_counts = create_node_markers_counts(raw)
+            df = pd.concat([coordinates, node_marker_counts], axis=1)
+        else:
+            df = coordinates
+
+        if only_keep_a_pixels:
+            df = df[~np.array(raw.vs["type"])]
+
+        return df
+
+    def get_edge_dataframe(self):
+        """Get the edges as a pandas DataFrame."""
+        return self._raw.get_edge_dataframe()
+
+    def get_vertex_dataframe(self):
+        """Get all vertices as a pandas DataFrame."""
+        return self._raw.get_vertex_dataframe()
+
+    def add_edges(self, edges: List[Tuple[int]]) -> None:
+        """Add edges to the graph instance.
+
+        :param edges: Add the following edges to the graph instance.
+        """
+        if not self._raw:
+            self._raw = igraph.Graph()
+        self._raw.add_edges(edges)
+
+    def add_vertices(self, n_vertices: int, attrs: Dict[str, List]) -> None:
+        """Add some number of vertices to the graph instance.
+
+        :param n_vertices: the number of vertices to be added to the graph instance.
+        :param attrs: dict of sequences, all of length equal to the number of vertices
+                      to be added, containing the attributes of the new vertices. If
+                      `n_vertices=1` then they have to be lists of length 1.
+        :raises IndexError: if the number of graph vertices to add and lists of
+                            attributes are of different lengths
+        """
+        if not self._raw:
+            self._raw = igraph.Graph()
+        for k, v in attrs.items():
+            if n_vertices != len(v):
+                raise IndexError(
+                    (
+                        "Number of vertices in graph to add not matching input "
+                        f"attributes: ({n_vertices} vs {len(v)})"
+                    )
+                )
+        # this is relying in the underlying igraph implementation
+        self._raw.add_vertices(n_vertices, attrs)
+
+    def add_names_to_vertexes(self, vs_names: List[str]) -> None:
+        """Rename the current vertices on the graph instance.
+
+        :param vs_names: Add the following vertices to the graph instance.
+        :raises ValueError: if the graph is empty
+        :raises IndexError: if the number of graph vertices and list of names are
+                            of different length
+        """
+        if not self._raw:
+            raise ValueError("Graph is empty")
+        if len(self.vs) != len(vs_names):
+            raise IndexError(
+                (
+                    "Number of vertices in graph different than input vertices "
+                    f"({len(self.vs)} vs {len(vs_names)})"
+                )
+            )
+        for vertex in self.vs:
+            vertex["name"] = vs_names
+
+
+class NetworkXGraphBackend(_GraphBackend):
+    """`IGraphGraphBackend` represents a graph, using networkx."""
+
+    def __init__(
+        self,
+        raw: Optional[nx.Graph] = None,
+    ):
+        """Create a new Graph instance.
+
+        Create a Graph instance (as an end-user this is probably not the interface
+        you are looking for). Try `Graph.from_edgelist`.
+
+        :param raw: The underlying raw representation of the graph, defaults to None
+        """
+        self._raw = raw
+
+    @staticmethod
+    def from_edgelist(
+        edgelist: pd.DataFrame,
+        add_marker_counts: bool,
+        simplify: bool,
+        use_full_bipartite: bool,
+    ) -> "NetworkXGraphBackend":
+        """Build a graph from an edgelist.
+
+        Build a Graph from an edge list (pd.DataFrame). Multiple options are available
+        to build the graph, `add_marker_counts` will add a dictionary of marker counts
+        to each node, `simplify` will remove redundant edges and `use_full_bipartite`
+        will not project the graph (UPIA).
+
+        The graph will contain the edge attributes present in the edge list when
+        `use_full_bipartite` is True and a dictionary of marker counts in each
+        vertex (node) when `add_marker_counts` is True. If `use_full_bipartite` is
+        False or `simplify` is True the edge attributes will be lost.
+
+        :param edgelist: the edge list (dataframe) corresponding to the graph
+        :param add_marker_counts: add a dictionary of marker counts to each node
+        :param simplify: simplifies the graph (remove redundant edges)
+        :param use_full_bipartite: use the bipartite graph instead of the projection
+                                  (UPIA)
+        :returns: a GraphBackend instance
+        :rtype: NetworkXGraphBackend
+        :raises: AssertionError when the input edge list is not valid
+        """
+        raise NotImplementedError()
+
+    @staticmethod
+    def from_raw(graph: nx.Graph) -> "NetworkXGraphBackend":
+        """Generate a Graph from an networkx.Graph object.
+
+        :param graph: input igraph to use
+        :return: A pixelator Graph object
+        :rtype: NetworkXGraphBackend
+        """
+        raise NotImplementedError()
+
+    @property
+    def raw(self):
+        """Get the raw underlying graph representation."""
+        return self._raw
+
+    @property
+    def vs(self):
+        """Get a sequence of the vertices in the Graph instance."""
+        raise NotImplementedError()
+
+    @property
+    def es(self):
+        """A sequence of the edges in the Graph instance."""
+        raise NotImplementedError()
+
+    def vcount(self):
+        """Get the total number of vertices in the Graph instance."""
+        raise NotImplementedError()
+
+    def ecount(self):
+        """Get the total number of edges in the Graph instance."""
+        raise NotImplementedError()
+
+    def get_adjacency_sparse(self):
+        """Get the sparse adjacency matrix."""
+        raise NotImplementedError()
+
+    @property
+    def connected_components(self):
+        """Get the connected components in the Graph instance."""
+        raise NotImplementedError()
+
+    def community_leiden(self, **kwargs):
+        """Run community detection using the Leiden algorithm."""
+        raise NotImplementedError()
+
+    def layout_coordinates(
+        self,
+        layout_algorithm: str = "fruchterman_reingold",
+        only_keep_a_pixels: bool = True,
+        get_node_marker_matrix: bool = True,
+    ) -> pd.DataFrame:
+        """Generate coordinates and (optionally) node marker counts for plotting.
+
+        Generate a dataframe with coordinates, and (optionally) node marker
+        counts to use that can be used for plotting.
+
+        The layout options are:
+          - fruchterman_reingold
+          - fruchterman_reingold_3d
+          - kamada_kawai
+          - kamada_kawai_3d
+
+
+        The `fruchterman_reingold` options are in general faster, but less
+        accurate than the `kamada_kawai` ones.
+
+        :param layout_algorithm: the layout algorithm to use to generate the coordinates
+        :param only_keep_a_pixels: If true, only keep the a-pixels
+        :param get_node_marker_matrix: Add a matrix of marker counts to each
+                                       node if True.
+        :return: the coordinates and markers (if activated) as a dataframe
+        :rtype: pd.DataFrame
+        :raises: AssertionError if the provided `layout_algorithm` is not valid
+        :raises: ValueError if the provided current graph instance is empty
+        """
+        raise NotImplementedError()
+
+    def get_edge_dataframe(self):
+        """Get the edges as a pandas DataFrame."""
+        raise NotImplementedError()
+
+    def get_vertex_dataframe(self):
+        """Get all vertices as a pandas DataFrame."""
+        raise NotImplementedError()
+
+    def add_edges(self, edges: List[Tuple[int]]) -> None:
+        """Add edges to the graph instance.
+
+        :param edges: Add the following edges to the graph instance.
+        """
+        raise NotImplementedError()
+
+    def add_vertices(self, n_vertices: int, attrs: Dict[str, List]) -> None:
+        """Add some number of vertices to the graph instance.
+
+        :param n_vertices: the number of vertices to be added to the graph instance.
+        :param attrs: dict of sequences, all of length equal to the number of vertices
+                      to be added, containing the attributes of the new vertices. If
+                      `n_vertices=1` then they have to be lists of length 1.
+        :raises IndexError: if the number of graph vertices to add and lists of
+                            attributes are of different lengths
+        """
+        raise NotImplementedError()
+
+    def add_names_to_vertexes(self, vs_names: List[str]) -> None:
+        """Rename the current vertices on the graph instance.
+
+        :param vs_names: Add the following vertices to the graph instance.
+        :raises ValueError: if the graph is empty
+        :raises IndexError: if the number of graph vertices and list of names are
+                            of different length
+        """
+        raise NotImplementedError()

--- a/src/pixelator/graph/backends/implementations.py
+++ b/src/pixelator/graph/backends/implementations.py
@@ -6,7 +6,7 @@ Copyright (c) 2023 Pixelgen Technologies AB.
 from __future__ import annotations
 
 import logging
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple
 
 import igraph
 import networkx as nx
@@ -358,7 +358,7 @@ class IgraphGraphBackend(_GraphBackend):
         """Get all vertices as a pandas DataFrame."""
         return self._raw.get_vertex_dataframe()
 
-    def add_edges(self, edges: List[Tuple[int]]) -> None:
+    def add_edges(self, edges: Iterable[Tuple[int]]) -> None:
         """Add edges to the graph instance.
 
         :param edges: Add the following edges to the graph instance.
@@ -542,7 +542,7 @@ class NetworkXGraphBackend(_GraphBackend):
         """Get all vertices as a pandas DataFrame."""
         raise NotImplementedError()
 
-    def add_edges(self, edges: List[Tuple[int]]) -> None:
+    def add_edges(self, edges: Iterable[Tuple[int]]) -> None:
         """Add edges to the graph instance.
 
         :param edges: Add the following edges to the graph instance.

--- a/src/pixelator/graph/backends/implementations.py
+++ b/src/pixelator/graph/backends/implementations.py
@@ -3,6 +3,7 @@
 Copyright (c) 2023 Pixelgen Technologies AB.
 """
 
+from __future__ import annotations
 
 import logging
 from typing import Dict, List, Optional, Tuple
@@ -130,7 +131,7 @@ class IgraphGraphBackend(_GraphBackend):
         add_marker_counts: bool,
         simplify: bool,
         use_full_bipartite: bool,
-    ) -> "IgraphGraphBackend":
+    ) -> IgraphGraphBackend:
         """Build a graph from an edgelist.
 
         Build a Graph from an edge list (pd.DataFrame). Multiple options are available
@@ -432,7 +433,7 @@ class NetworkXGraphBackend(_GraphBackend):
         add_marker_counts: bool,
         simplify: bool,
         use_full_bipartite: bool,
-    ) -> "NetworkXGraphBackend":
+    ) -> NetworkXGraphBackend:
         """Build a graph from an edgelist.
 
         Build a Graph from an edge list (pd.DataFrame). Multiple options are available
@@ -493,7 +494,6 @@ class NetworkXGraphBackend(_GraphBackend):
         """Get the sparse adjacency matrix."""
         raise NotImplementedError()
 
-    @property
     def connected_components(self):
         """Get the connected components in the Graph instance."""
         raise NotImplementedError()

--- a/src/pixelator/graph/backends/protocol.py
+++ b/src/pixelator/graph/backends/protocol.py
@@ -3,6 +3,8 @@
 Copyright (c) 2023 Pixelgen Technologies AB.
 """
 
+from __future__ import annotations
+
 from typing import Dict, List, Protocol, Tuple
 
 import networkx as nx
@@ -19,7 +21,7 @@ class _GraphBackend(Protocol):
         add_marker_counts: bool,
         simplify: bool,
         use_full_bipartite: bool,
-    ) -> "_GraphBackend":
+    ) -> _GraphBackend:
         """Build a graph from an edgelist.
 
         Build a Graph from an edge list (pd.DataFrame). Multiple options are available
@@ -44,7 +46,7 @@ class _GraphBackend(Protocol):
         ...
 
     @staticmethod
-    def from_raw(graph: nx.Graph) -> "_GraphBackend":
+    def from_raw(graph: nx.Graph) -> _GraphBackend:
         """Generate a Graph from an networkx.Graph object.
 
         :param graph: input igraph to use

--- a/src/pixelator/graph/backends/protocol.py
+++ b/src/pixelator/graph/backends/protocol.py
@@ -1,38 +1,17 @@
-"""Functions related to the graph dataclass used in pixelator graph operations.
+"""Protocol of graph backends used by pixelator.
 
 Copyright (c) 2023 Pixelgen Technologies AB.
 """
 
-import logging
-import os
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Protocol, Tuple
 
-import igraph
-import pandas as pd
 import networkx as nx
+import pandas as pd
 from scipy.sparse import csr_matrix
 
-from pixelator.graph.backends.implementations import (
-    IgraphGraphBackend,
-    NetworkXGraphBackend,
-)
-from pixelator.graph.backends.protocol import _GraphBackend
 
-logger = logging.getLogger(__name__)
-
-
-class Graph:
-    """`Graph` represents a graph, i.e. a collection of vertices and edges."""
-
-    def __init__(self, backend: _GraphBackend):
-        """Create a new Graph instance.
-
-        Create a Graph instance (as an end-user this is probably not the interface
-        you are looking for). Try `Graph.from_edgelist`.
-
-        :param backend: The backend used to represent the graph
-        """
-        self._backend = backend
+class _GraphBackend(Protocol):
+    """Protocol for graph backends."""
 
     @staticmethod
     def from_edgelist(
@@ -40,7 +19,7 @@ class Graph:
         add_marker_counts: bool,
         simplify: bool,
         use_full_bipartite: bool,
-    ) -> "Graph":
+    ) -> "_GraphBackend":
         """Build a graph from an edgelist.
 
         Build a Graph from an edge list (pd.DataFrame). Multiple options are available
@@ -59,73 +38,55 @@ class Graph:
         :param use_full_bipartite: use the bipartite graph instead of the projection
                                   (UPIA)
         :returns: a Graph instance
-        :rtype: Graph
+        :rtype: _GraphBackend
         :raises: AssertionError when the input edge list is not valid
         """
-        if os.environ.get("ENABLE_NETWORKX_BACKEND", False):
-            return Graph(
-                backend=NetworkXGraphBackend.from_edgelist(
-                    edgelist=edgelist,
-                    add_marker_counts=add_marker_counts,
-                    simplify=simplify,
-                    use_full_bipartite=use_full_bipartite,
-                )
-            )
-
-        return Graph(
-            backend=IgraphGraphBackend.from_edgelist(
-                edgelist=edgelist,
-                add_marker_counts=add_marker_counts,
-                simplify=simplify,
-                use_full_bipartite=use_full_bipartite,
-            )
-        )
+        ...
 
     @staticmethod
-    def from_raw(graph: Union[igraph.Graph, nx.Graph]) -> "Graph":
-        """Generate a Graph from an igraph.Graph object.
+    def from_raw(graph: nx.Graph) -> "_GraphBackend":
+        """Generate a Graph from an networkx.Graph object.
 
         :param graph: input igraph to use
         :return: A pixelator Graph object
-        :rtype: Graph
+        :rtype: _GraphBackend
         """
-        if os.environ.get("ENABLE_NETWORKX_BACKEND", False):
-            return Graph(backend=NetworkXGraphBackend(graph))
-        return Graph(backend=IgraphGraphBackend(graph))
+        ...
 
     @property
-    def _raw(self):
-        return self._backend._raw
+    def raw(self):
+        """Get the raw underlying graph representation."""
+        ...
 
     @property
     def vs(self):
         """Get a sequence of the vertices in the Graph instance."""
-        return self._backend.vs
+        ...
 
     @property
     def es(self):
         """A sequence of the edges in the Graph instance."""
-        return self._backend.es
+        ...
 
     def vcount(self):
         """Get the total number of vertices in the Graph instance."""
-        return self._backend.vcount()
+        ...
 
     def ecount(self):
         """Get the total number of edges in the Graph instance."""
-        return self._backend.ecount()
+        ...
 
     def get_adjacency_sparse(self) -> csr_matrix:
         """Get the sparse adjacency matrix."""
-        return self._backend.get_adjacency_sparse()
+        ...
 
     def connected_components(self):
         """Get the connected components in the Graph instance."""
-        return self._backend.connected_components()
+        ...
 
     def community_leiden(self, **kwargs):
         """Run community detection using the Leiden algorithm."""
-        return self._backend.community_leiden(**kwargs)
+        ...
 
     def layout_coordinates(
         self,
@@ -157,28 +118,22 @@ class Graph:
         :raises: AssertionError if the provided `layout_algorithm` is not valid
         :raises: ValueError if the provided current graph instance is empty
         """
-        return self._backend.layout_coordinates(
-            layout_algorithm=layout_algorithm,
-            only_keep_a_pixels=only_keep_a_pixels,
-            get_node_marker_matrix=get_node_marker_matrix,
-        )
+        ...
 
     def get_edge_dataframe(self):
         """Get the edges as a pandas DataFrame."""
-        return self._backend.get_edge_dataframe()
+        ...
 
     def get_vertex_dataframe(self):
         """Get all vertices as a pandas DataFrame."""
-        return self._backend.get_vertex_dataframe()
+        ...
 
     def add_edges(self, edges: List[Tuple[int]]) -> None:
         """Add edges to the graph instance.
 
         :param edges: Add the following edges to the graph instance.
         """
-        if not self._backend.raw:
-            self._backend.from_raw(igraph.Graph())
-        self._backend.add_edges(edges)
+        ...
 
     def add_vertices(self, n_vertices: int, attrs: Dict[str, List]) -> None:
         """Add some number of vertices to the graph instance.
@@ -190,7 +145,7 @@ class Graph:
         :raises IndexError: if the number of graph vertices to add and lists of
                             attributes are of different lengths
         """
-        self._backend.add_vertices(n_vertices=n_vertices, attrs=attrs)
+        ...
 
     def add_names_to_vertexes(self, vs_names: List[str]) -> None:
         """Rename the current vertices on the graph instance.
@@ -200,4 +155,4 @@ class Graph:
         :raises IndexError: if the number of graph vertices and list of names are
                             of different length
         """
-        self._backend.add_names_to_vertexes(vs_names=vs_names)
+        ...

--- a/src/pixelator/graph/backends/protocol.py
+++ b/src/pixelator/graph/backends/protocol.py
@@ -5,7 +5,7 @@ Copyright (c) 2023 Pixelgen Technologies AB.
 
 from __future__ import annotations
 
-from typing import Dict, List, Protocol, Tuple
+from typing import Dict, Iterable, List, Protocol, Tuple
 
 import networkx as nx
 import pandas as pd
@@ -130,7 +130,7 @@ class _GraphBackend(Protocol):
         """Get all vertices as a pandas DataFrame."""
         ...
 
-    def add_edges(self, edges: List[Tuple[int]]) -> None:
+    def add_edges(self, edges: Iterable[Tuple[int]]) -> None:
         """Add edges to the graph instance.
 
         :param edges: Add the following edges to the graph instance.

--- a/src/pixelator/graph/graph.py
+++ b/src/pixelator/graph/graph.py
@@ -5,11 +5,11 @@ Copyright (c) 2023 Pixelgen Technologies AB.
 
 import logging
 import os
-from typing import Dict, List, Tuple, Union
+from typing import Dict, Iterable, List, Tuple, Union
 
 import igraph
-import pandas as pd
 import networkx as nx
+import pandas as pd
 from scipy.sparse import csr_matrix
 
 from pixelator.graph.backends.implementations import (
@@ -171,7 +171,7 @@ class Graph:
         """Get all vertices as a pandas DataFrame."""
         return self._backend.get_vertex_dataframe()
 
-    def add_edges(self, edges: List[Tuple[int]]) -> None:
+    def add_edges(self, edges: Iterable[Tuple[int]]) -> None:
         """Add edges to the graph instance.
 
         :param edges: Add the following edges to the graph instance.

--- a/tests/analysis/colocalization/test_prepare.py
+++ b/tests/analysis/colocalization/test_prepare.py
@@ -34,7 +34,7 @@ def test_prepare_from_graph(edgelist):
         simplify=True,
         use_full_bipartite=False,
     )
-    for component in graph.components().subgraphs():
+    for component in graph.connected_components().subgraphs():
         result = prepare_from_graph(component, n_neighbours=0)
         assert len(result) == len(component.vs)
         unique_markers_in_component = functools.reduce(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,8 @@ import pandas as pd
 import pytest
 from anndata import AnnData
 from pixelator.config import AntibodyPanel
-from pixelator.graph import Graph, update_edgelist_membership
+from pixelator.graph import update_edgelist_membership
+from pixelator.graph.utils import union as graph_union
 from pixelator.pixeldataset import (
     PixelDataset,
     edgelist_to_anndata,
@@ -73,7 +74,8 @@ def edgelist_with_communities_fixture():
     # Make sure to retain the bipartite structure after joining
     source = graph1.vs.select(type=True)[0]["name"]
     target = graph2.vs.select(type=False)[0]["name"]
-    joined_graph = Graph.union([graph1, graph2])
+
+    joined_graph = graph_union([graph1, graph2])
     joined_graph.add_edges([(source, target)])
 
     def data():

--- a/tests/test_pixeldataset.py
+++ b/tests/test_pixeldataset.py
@@ -240,7 +240,7 @@ def test_pixeldataset_graph(setup_basic_pixel_dataset):
     dataset, *_ = setup_basic_pixel_dataset
     full_graph = dataset.graph()
     assert isinstance(full_graph, Graph)
-    assert len(full_graph.components()) == 5
+    assert len(full_graph.connected_components()) == 5
 
 
 def test_pixeldataset_graph_raises_when_component_not_found(setup_basic_pixel_dataset):
@@ -253,7 +253,7 @@ def test_pixeldataset_graph_finds_component(setup_basic_pixel_dataset):
     dataset, *_ = setup_basic_pixel_dataset
     component_graph = dataset.graph("PXLCMP0000000")
     assert isinstance(component_graph, Graph)
-    assert len(component_graph.components()) == 1
+    assert len(component_graph.connected_components()) == 1
 
 
 def test_pixeldataset_from_file_csv(setup_basic_pixel_dataset, tmp_path):


### PR DESCRIPTION
## Description

This makes the Pixelator's graph backend switchable using an environment variable (`ENABLE_NETWORKX_BACKEND=TRUE`). For now, nothing to the proposed networkx based graph backend is implemented, but that will come later PRs.

It also:
 - remove the redundant `components` method, since it is equivalent with `connected_components`
 - ignores all DOC501,DOC502 doc lint warnings. These complain when there is a `raises` section in the docs, but there is now raise statement in the function. However, it is not able to handle cases when the called function is the one who raises, so I would argue that we need to keep track of this manually since otherwise the user cannot see which exceptions to actually expect from a function/method

Fixes: EXE-1095

## Type of change

Refactoring.

## How Has This Been Tested?

Tested using the unit test suite.

## PR checklist:

- [ ] This comment contains a description of changes (with reason).
- [ ] My code follows the style guidelines of this project
- [ ] Make sure your code lints, is well-formatted and type checks
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If you've added a new stage - have you followed the pipeline CLI conventions in the [USAGE guide](../USAGE.md)
- [ ] [README.md](./README.md) is updated
- [ ] If a new tool or package is included, update poetry.lock, [the conda recipe](../conda-recipe/pixelator/meta.yaml) and [cited it properly](../CITATIONS.md)
- [ ] Include any new [authors/contributors](../AUTHORS.md)
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] Usage Documentation is updated
- [ ] If you are doing a [release](../RELEASING.md#Releasing), or a significant change to the code, update [CHANGELOG.md](../CHANGELOG.md)
