### PR TITLE
feat: add cla check action

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.3.0
+        uses: contributor-assistant/github-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret
@@ -26,20 +26,8 @@ jobs:
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURES_REPO_TOKEN }}
         with:
           path-to-signatures: 'signatures/pixelator/version1/cla.json'
-          # TODO: Add path to CLA document
-          path-to-document: 'TODO: ' # e.g. a CLA or a DCO document
-          # branch should not be protected
+          path-to-document: 'https://software.pixelgen.com/assets/files/Pixelgen_Individual_Contributor_License_Agreement_(CLA)-671dac61b4e5458371c420b857122e5a.pdf' # e.g. a CLA or a DCO document
           branch: 'main'
-          allowlist: ambarrio,fbdtemme,johandahlberg,dependabot[bot]
+          allowlist: johandahlberg,fbdtemme,ptajvar,maxkarlsson,ludvigla,vincent-van-hoef,dependabot[bot]
           remote-organization-name: PixelgenTechnologies
           remote-repository-name: cla-signatures
-
-          # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
-          #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
-          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
-          #signed-commit-message: 'For example: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
-          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
-          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
-          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
-          #lock-pullrequest-aftermerge: false - if you don't want this bot to automatically lock the pull request after merging (default - true)
-          #use-dco-flag: true - If you are using DCO instead of CLA

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,45 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # the below token should have repo scope and must be manually added by you in the repository's secret
+          # This token is required only if you have configured to store the signatures in a remote repository/organization
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURES_REPO_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/pixelator/version1/cla.json'
+          # TODO: Add path to CLA document
+          path-to-document: 'TODO: ' # e.g. a CLA or a DCO document
+          # branch should not be protected
+          branch: 'main'
+          allowlist: ambarrio,fbdtemme,johandahlberg,dependabot[bot]
+          remote-organization-name: PixelgenTechnologies
+          remote-repository-name: cla-signatures
+
+          # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
+          #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
+          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
+          #signed-commit-message: 'For example: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
+          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
+          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
+          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
+          #lock-pullrequest-aftermerge: false - if you don't want this bot to automatically lock the pull request after merging (default - true)
+          #use-dco-flag: true - If you are using DCO instead of CLA


### PR DESCRIPTION
## Description

Add a simple CLA checking & signing workflow.

Users that have not signed the CLA can do so by simply commenting on the PR.

> I have read the CLA Document and I hereby sign the CLA

To trigger the bot to recheck the CLA again you can comment

 > recheck

A list of signatures will be stored in [PixelgenTechnologies/cla-signatures](https://github.com/PixelgenTechnologies/cla-signatures).

Fixes: EXE-1092


## Post Merge actions

- [ ] Make CLAAssistant a required check by activating [this rule](https://github.com/PixelgenTechnologies/pixelator/settings/rules/117315)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested in a seperate private test repo.

