### PR TITLE
feat: Add support for python 3.11

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/setup-python@v4
         id: setup-python
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       #----------------------------------------------
       #   install & configure poetry
@@ -157,7 +157,7 @@ jobs:
           uses: actions/setup-python@v4
           id: setup-python
           with:
-            python-version: '3.10'
+            python-version: '3.11'
 
         - name: Download build artifacts
           uses: actions/download-artifact@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] - UNRELEASED
+
+### Added
+
+* Add support for Python 3.11
+
 ## [0.14.0] - 2023-10-05
 
 ### Added

--- a/containers/dev.Dockerfile
+++ b/containers/dev.Dockerfile
@@ -6,4 +6,4 @@ ARG MAKEJOBS=4
 FROM pixelator-base
 WORKDIR /pixelator
 RUN poetry export --output requirements.txt --without-hashes --no-interaction --no-ansi --with dev
-RUN pip3.10 install -r requirements.txt && rm requirements.txt
+RUN pip3.11 install -r requirements.txt && rm requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,16 @@ classifiers=[
     'Natural Language :: English',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
-    'Programming Language :: Python :: 3.10']
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11'
+]
 
 packages = [
     { include = "pixelator", from = "src" },
     { include = "tests", format = "sdist" }]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.11"
+python = ">=3.8,<3.12"
 click = "*"
 yapf = "*"
 cutadapt = ">=4.2"

--- a/src/pixelator/pixeldataset.py
+++ b/src/pixelator/pixeldataset.py
@@ -1250,7 +1250,7 @@ def update_metrics_anndata(adata: AnnData, inplace: bool = True) -> Optional[Ann
     df = adata.to_df()
 
     # update the var layer (antibody metrics)
-    adata.var["antibody_count"] = df.sum()
+    adata.var["antibody_count"] = df.sum().astype(int)
     adata.var["components"] = (df != 0).sum()
     adata.var["antibody_pct"] = (
         adata.var["antibody_count"] / adata.var["antibody_count"].sum()

--- a/tests/annotate/test_aggregates.py
+++ b/tests/annotate/test_aggregates.py
@@ -64,7 +64,7 @@ def mixed_data_fixture(aggregates, normals, unspecifics):
 
 
 def generate_anndata(x):
-    adata = AnnData(X=x)
+    adata = AnnData(X=x, dtype=np.float32)
     components = [f"CMP{idx}" for idx in range(len(x))]
     adata.obs = pd.DataFrame({"component": components})
     adata.obs_names = components


### PR DESCRIPTION
## Description

Add python 3.11 to supported versions now that all depencies support 3.11.
This also changes github actions and the docker containers to use 3.11.

Fixes [EXE-798](https://linear.app/pixelgen-technologies/issue/EXE-798/support-python-311-in-pixelator)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Test suite, test suite in updated containers