### PR TITLE
Fix sample column missing from concatenated edgelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Add support for Python 3.11
 
+### Fixed
+
+* A bug where aggregating data did not add the correct sample, and unique component columns
+
+
 ## [0.14.0] - 2023-10-05
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,7 @@ classifiers=[
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
-    'Programming Language :: Python :: 3.11'
-]
+    'Programming Language :: Python :: 3.11']
 
 packages = [
     { include = "pixelator", from = "src" },

--- a/tests/test_pixeldataset.py
+++ b/tests/test_pixeldataset.py
@@ -6,6 +6,7 @@ Copyright (c) 2022 Pixelgen Technologies AB.
 
 import logging
 import random
+import re
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import mock
@@ -515,6 +516,7 @@ def test_edgelist_to_anndata(
     assert set(adata.obs_names) == set(edgelist["component"].unique())
 
 
+@pytest.mark.test_this
 def test_simple_aggregate(setup_basic_pixel_dataset):
     """test_simple_aggregate."""
     dataset_1, *_ = setup_basic_pixel_dataset
@@ -537,6 +539,13 @@ def test_simple_aggregate(setup_basic_pixel_dataset):
     )
 
     assert len(result.edgelist) == 2 * len(dataset_1.edgelist)
+    assert "sample" in result.edgelist.columns
+    row = result.edgelist.iloc[0]
+    assert re.match(r"PXLCMP(\d+)_sample\d", row["component"])
+    assert result.edgelist["sample"].dtype == pd.CategoricalDtype(
+        categories=["sample1", "sample2"], ordered=False
+    )
+    assert isinstance(result.edgelist["component"].dtype, pd.CategoricalDtype)
 
     assert len(result.adata) == 2 * len(dataset_1.adata)
     assert len(result.adata.var) == len(dataset_1.adata.var)


### PR DESCRIPTION
## Description

The sample name was missing from the concatenated edge lists. This bug was introduced when I switched to using polars for concatenating the edge lists. This fixes that, and makes sure that the tests catches this problem.

Fixes: EXE-1174

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested with the unit test suite, including new test code to verify that this bug has been fixed.