### PR TITLE
Fixes to pixeldataset aggregation and parquet file indexeing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* Fixed broken pixeldataset aggregation for more than two sample
-* Fixed bug in graph generation caused by accidentally written index in parquet file.
+* Fixed broken pixeldataset aggregation for more than two samples.
+* Fixed a bug in graph generation caused by accidentally writing the index to the parquet file.
   For backwards compatiblity, if there is an column named `index`` in the edgelist, this
   will be removed and the user will get a warning indicating that this has happened.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED] - ...
+
+### Fixed
+
+* Fixed broken pixeldataset aggregation for more than two sample
+* Fixed bug in graph generation caused by accidentally written index in parquet file.
+  For backwards compatiblity, if there is an column named `index`` in the edgelist, this
+  will be removed and the user will get a warning indicating that this has happened.
+
 ## [0.15.1] - 2023-10-18
 
 ### Fixed

--- a/src/pixelator/pixeldataset.py
+++ b/src/pixelator/pixeldataset.py
@@ -85,7 +85,7 @@ def _concatenate_edgelists(datasets, sample_names):
         )
         concatenated = concatenated.collect()
 
-        for idx, subsequent in enumerate(datasets[:1], start=1):
+        for idx, subsequent in enumerate(datasets[1:], start=1):
             concatenated = concatenated.extend(
                 subsequent.edgelist_lazy.collect().with_columns(
                     sample=pl.lit(sample_names[idx], dtype=pl.Categorical)

--- a/tests/test_pixeldataset.py
+++ b/tests/test_pixeldataset.py
@@ -719,7 +719,7 @@ def test_filter_should_return_proper_typed_edgelist_data(setup_basic_pixel_datas
 # TODO Write test to check for write/read round-trips on parquet files
 
 
-def test_not_passing_unique_sample_names_should_raise(
+def test_on_aggregation_not_passing_unique_sample_names_should_raise(
     tmp_path,
     setup_basic_pixel_dataset,
 ):
@@ -739,6 +739,59 @@ def test_not_passing_unique_sample_names_should_raise(
                 read(file_target_2),
             ],
         )
+
+
+def test_aggregation_all_samples_show_up(
+    tmp_path,
+    setup_basic_pixel_dataset,
+):
+    dataset_1, *_ = setup_basic_pixel_dataset
+    dataset_2 = dataset_1.copy()
+    dataset_3 = dataset_1.copy()
+    dataset_4 = dataset_1.copy()
+
+    file_target_1 = tmp_path / "dataset_1.pxl"
+    dataset_1.save(str(file_target_1))
+    file_target_2 = tmp_path / "dataset_2.pxl"
+    dataset_2.save(str(file_target_2))
+    file_target_3 = tmp_path / "dataset_3.pxl"
+    dataset_3.save(str(file_target_3))
+    file_target_4 = tmp_path / "dataset_4.pxl"
+    dataset_4.save(str(file_target_4))
+
+    result = simple_aggregate(
+        sample_names=["sample1", "sample2", "sample3", "sample4"],
+        datasets=[
+            read(file_target_1),
+            read(file_target_2),
+            read(file_target_3),
+            read(file_target_4),
+        ],
+    )
+    assert set(result.edgelist["sample"].unique()) == {
+        "sample1",
+        "sample2",
+        "sample3",
+        "sample4",
+    }
+    assert set(result.polarization["sample"].unique()) == {
+        "sample1",
+        "sample2",
+        "sample3",
+        "sample4",
+    }
+    assert set(result.colocalization["sample"].unique()) == {
+        "sample1",
+        "sample2",
+        "sample3",
+        "sample4",
+    }
+    assert set(result.adata.obs["sample"].unique()) == {
+        "sample1",
+        "sample2",
+        "sample3",
+        "sample4",
+    }
 
 
 def test_lazy_edgelist_should_warn_and_rm_on_index_column(setup_basic_pixel_dataset):


### PR DESCRIPTION
## Description

Fixes the following issues:
 - aggregation of more than two pixeldatasets was broken.
 - indexes were written to the parquet files, which caused downstream issues.

Fixes: EXE-1184

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

With unit tests, as well as by manually verifying that it works in the scenario where the bug was originally reported.