### PR TITLE
Feature/exe 1201 nicer error messages for one node graphs in colocalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [VERSION] - UNRELEASED
+
+### Fixed
+
+* Nicer error messages when there are no components valid for computing colocalization.
+
+
 ## [0.15.2] - 2023-10-23
 
 ### Fixed

--- a/tests/analysis/colocalization/test_colocalization.py
+++ b/tests/analysis/colocalization/test_colocalization.py
@@ -146,6 +146,6 @@ def test_colocalization_scores_should_warn_when_no_data(full_graph_edgelist, cap
             random_seed=1477,
         )
     assert (
-        "No data was found to compute colocalization, probably because "
-        "all components had less than a single node."
+        "No data was found to compute colocalization, probably "
+        "because all components only had a single node."
     ) in caplog.text


### PR DESCRIPTION
## Description

Nicer error messages when there are no components that are valid for computing colocalization.

Fixes: EXE-1201

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

With the unit tests, and on the dataset where I found the problem.

## PR checklist:

- [ ] This comment contains a description of changes (with reason).
- [ ] My code follows the style guidelines of this project
- [ ] Make sure your code lints, is well-formatted and type checks
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If you've added a new stage - have you followed the pipeline CLI conventions in the [USAGE guide](../USAGE.md)
- [ ] [README.md](./README.md) is updated
- [ ] If a new tool or package is included, update poetry.lock, [the conda recipe](../conda-recipe/pixelator/meta.yaml) and [cited it properly](../CITATIONS.md)
- [ ] Include any new [authors/contributors](../AUTHORS.md)
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] Usage Documentation is updated
- [ ] If you are doing a [release](../RELEASING.md#Releasing), or a significant change to the code, update [CHANGELOG.md](../CHANGELOG.md)
