### PR TITLE
Feature/exe 1210 using parquet as interchange format

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,3 +9,6 @@ arg-type-hints-in-docstring = False
 # Ignore documentation linting in tests
 per-file-ignores =
     tests/**: D101, D102, D103, D200, D202, D205, D212, D121, D400, D401, D403, D404, D415, DOC
+    # Since click uses a different layout for the docs strings to generate the
+    # cli docs, we ignore these rules here.
+    src/pixelator/cli/**: D200, D212, D400, D415

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `mean_reads` and `median_reads` in adata.obs to `mean_reads_per_molecule` and `median_reads_per_molecule` respectively.
 * Drop support for python 3.8 and 3.9.
+* Change output format of `collapse` from csv to parquet.
+* Change input and output format of `graph` from csv to parquet.
+* Change input format of `annotate` from csv to parquet.
 
 ### Fixed
 
 * Nicer error messages when there are no components valid for computing colocalization.
 
+### Removed
+
+* `graph` no longer outputs the raw edge list
 
 ## [0.15.2] - 2023-10-23
 

--- a/src/pixelator/annotate/__init__.py
+++ b/src/pixelator/annotate/__init__.py
@@ -10,7 +10,7 @@ from typing import Literal, Optional
 
 import numba
 import numpy as np
-import pandas as pd
+import polars as pl
 import scanpy as sc
 from anndata import AnnData
 
@@ -136,7 +136,7 @@ def annotate_components(
     - a dataframe with the components metrics before filtering (csv)
     - a PixelDataset with the filtered AnnData and edge list (zip)
 
-    :param input: the path to the edge list dataframe (csv)
+    :param input: the path to the edge list dataframe (parquet)
     :param panel: the AntibodyPanel of the panel used to generate the data
     :param output: the path to the output folder
     :param output_prefix: the prefix to prepend to the files (sample name)
@@ -153,7 +153,7 @@ def annotate_components(
     logger.debug("Parsing edge list %s", input)
 
     # load data (edge list in data frame format)
-    edgelist = pd.read_csv(input)
+    edgelist = pl.read_parquet(input).to_pandas()
 
     # get component metrics from the edge list
     component_metrics = components_metrics(edgelist=edgelist)

--- a/src/pixelator/cli/annotate.py
+++ b/src/pixelator/cli/annotate.py
@@ -1,5 +1,4 @@
-"""
-Console script for pixelator (annotate)
+"""Console script for pixelator (annotate).
 
 Copyright (c) 2022 Pixelgen Technologies AB.
 """
@@ -32,7 +31,7 @@ from pixelator.utils import (
     nargs=-1,
     required=True,
     type=click.Path(exists=True),
-    metavar="CSV",
+    metavar="parquet",
 )
 @click.option(
     "--panel",
@@ -109,7 +108,7 @@ def annotate(
     )
 
     # some basic sanity check on the input files
-    sanity_check_inputs(input_files, allowed_extensions="csv.gz")
+    sanity_check_inputs(input_files, allowed_extensions="parquet")
 
     # sanity check on thresholds and input parameters
     if min_size is not None and min_size < 0:

--- a/src/pixelator/cli/graph.py
+++ b/src/pixelator/cli/graph.py
@@ -30,7 +30,7 @@ from pixelator.utils import (
     nargs=-1,
     required=True,
     type=click.Path(exists=True),
-    metavar="CSV",
+    metavar="parquet",
 )
 @click.option(
     "--multiplet-recovery",
@@ -84,7 +84,7 @@ def graph(
     )
 
     # some basic sanity check on the input files
-    sanity_check_inputs(input_files, allowed_extensions="csv.gz")
+    sanity_check_inputs(input_files, allowed_extensions="parquet")
 
     # create output folder if it does not exist
     graph_output = create_output_stage_dir(output, "graph")

--- a/src/pixelator/graph/backends/implementations.py
+++ b/src/pixelator/graph/backends/implementations.py
@@ -391,6 +391,10 @@ class NetworkXGraphBackend(GraphBackend):
     ) -> Union[nx.Graph, nx.MultiGraph]:
         g = nx.empty_graph(0, create_using)
 
+        # TODO Look at how to deal with setting project_pushdown=False
+        # here. If it is needed or not seems to depend on the
+        # exact call context, so it might be that we can actually
+        # enable it again here and improve the memory usage.
         for idx, row in enumerate(
             df.collect(streaming=True, projection_pushdown=False).iter_rows(
                 named=False, buffer_size=1000

--- a/src/pixelator/graph/backends/implementations.py
+++ b/src/pixelator/graph/backends/implementations.py
@@ -392,7 +392,9 @@ class NetworkXGraphBackend(GraphBackend):
         g = nx.empty_graph(0, create_using)
 
         for idx, row in enumerate(
-            df.collect(streaming=True).iter_rows(named=False, buffer_size=1000)
+            df.collect(streaming=True, projection_pushdown=False).iter_rows(
+                named=False, buffer_size=1000
+            )
         ):
             g.add_edge(row[0], row[1], index=idx)
         return g
@@ -486,7 +488,7 @@ class NetworkXGraphBackend(GraphBackend):
         edgelist: pl.LazyFrame, simplify: bool, use_full_bipartite: bool
     ) -> Union[nx.Graph, nx.MultiGraph]:
         graph = NetworkXGraphBackend._build_plain_graph_from_edgelist(
-            edgelist.select(["upia", "upib", "umi"]),
+            edgelist.select(pl.col("upia"), pl.col("upib")),
             create_using=nx.Graph if simplify else nx.MultiGraph,
         )
         a_nodes = set(edgelist.select(["upia"]).unique().collect()["upia"].to_list())

--- a/src/pixelator/graph/community_detection.py
+++ b/src/pixelator/graph/community_detection.py
@@ -263,7 +263,7 @@ def recovered_component_info(
     new_memberships = new_edgelist.select(pl.col("upi"), pl.col("component"))
     merged = old_memberships.join(new_memberships, how="left", on="upi", suffix="_new")
     return dict(
-        merged.select(pl.col("component"), pl.col("component_new"))
+        merged.select(pl.col("component"), pl.col("component_new"))  # type: ignore
         .group_by(pl.col("component"))
         .agg(pl.col("component_new").unique().drop_nulls())
         .collect(streaming=True, projection_pushdown=False)
@@ -356,7 +356,7 @@ def recover_technical_multiplets(
         # save the discarded edges to a file
         masked_df = edgelist.filter(pl.col("upi").is_in(edges_to_remove))
         masked_df.collect().write_parquet(
-            removed_edges_edgelist_file,
+            removed_edges_edgelist_file,  # type: ignore
             compression="zstd",
         )
 

--- a/src/pixelator/graph/community_detection.py
+++ b/src/pixelator/graph/community_detection.py
@@ -74,7 +74,7 @@ def connect_components(
     logger.debug("Parsing edge list %s", input)
 
     # load data (edge list in data frame format)
-    edgelist = pl.scan_parquet(input)
+    edgelist = pl.scan_parquet(input, low_memory=True)
 
     nbr_of_rows = edgelist.select(pl.count()).collect()[0, 0]
     # filter data by count

--- a/src/pixelator/graph/community_detection.py
+++ b/src/pixelator/graph/community_detection.py
@@ -360,9 +360,11 @@ def recover_technical_multiplets(
             compression="zstd",
         )
 
+    logger.debug("Preparing edge list for computing new components")
     old_edgelist = edgelist.select(pl.col("upi"), pl.col("component"))
     edgelist = edgelist.filter(~pl.col("upi").is_in(edges_to_remove))
 
+    logger.debug("Creating updated edgelist")
     edgelist = update_edgelist_membership(
         edgelist=edgelist,
         graph=None,  # We need to make sure that a new graph is built

--- a/src/pixelator/graph/utils.py
+++ b/src/pixelator/graph/utils.py
@@ -370,7 +370,7 @@ def _update_edgelist_membership_data_frame(
     return edgelist
 
 
-def _update_edgelist_membership_lazyframe(
+def _update_edgelist_membership_lazy_frame(
     edgelist: pl.LazyFrame,
     graph: Optional[Graph] = None,
     prefix: Optional[str] = None,
@@ -379,7 +379,7 @@ def _update_edgelist_membership_lazyframe(
         prefix = DEFAULT_COMPONENT_PREFIX
 
     if "component" in edgelist.columns:
-        logger.info("The input edge list already contain a component column")
+        logger.info("The input edge list already contains a component column")
 
     if not graph:
         graph = Graph.from_edgelist(
@@ -459,7 +459,7 @@ def update_edgelist_membership(
 
     if isinstance(edgelist, pl.LazyFrame):
         logger.debug("Updating edgelist where type is pl.LazyFrame")
-        return _update_edgelist_membership_lazyframe(
+        return _update_edgelist_membership_lazy_frame(
             edgelist=edgelist, graph=graph, prefix=prefix
         )
 

--- a/src/pixelator/graph/utils.py
+++ b/src/pixelator/graph/utils.py
@@ -290,7 +290,7 @@ def _edgelist_metrics_polars_lazy_frame(
         edgelist.select(pl.col("count")).mean().collect()[0, 0], 2
     )
 
-    upia_degree = edgelist.group_by(pl.col("upia")).agg(pl.col("upib").unique().count())
+    upia_degree = edgelist.group_by(pl.col("upia")).agg(pl.n_unique("upib"))
     metrics["upia_degree_mean"] = round(upia_degree.mean().collect()[0, 1], 2)
     metrics["upia_degree_median"] = round(upia_degree.median().collect()[0, 1], 2)
 

--- a/src/pixelator/test_utils/annotate.py
+++ b/src/pixelator/test_utils/annotate.py
@@ -1,4 +1,5 @@
-"""
+"""Integration tests for the annotate command.
+
 Copyright (c) 2023 Pixelgen Technologies AB.
 """
 import logging
@@ -12,8 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 class BaseAnnotateTestsMixin(BaseWorkflowTestMixin):
-    """
-    Base class for annotate command tests.
+    """Base class for annotate command tests.
 
     Test cases (defined in this class or in subclasses)
     that depend on the output should be marked with:
@@ -26,13 +26,14 @@ class BaseAnnotateTestsMixin(BaseWorkflowTestMixin):
 
     @pytest.mark.dependency(name="test_annotate_run", depends=["test_graph_run"])
     def test_annotate_run(self):
+        """Run method for the test."""
         params = self.__get_parameters()
         verbose = self.__get_options("common").get("verbose")
         panel = self.__get_data("panel")
         panel_file = self.__get_data("panel_file")
 
         input_files = list(
-            map(lambda f: str(f), (self.workdir / "graph").glob("*.edgelist.csv.gz"))
+            map(lambda f: str(f), (self.workdir / "graph").glob("*.edgelist.parquet"))
         )
 
         command = [
@@ -66,18 +67,21 @@ class BaseAnnotateTestsMixin(BaseWorkflowTestMixin):
 
     @pytest.mark.dependency(depends=["test_annotate_run"])
     def test_annotate_dataset_exists(self):
+        """Check that the pixel file is created."""
         dataset_files = (self.workdir / "annotate").glob("*.dataset.pxl")
         for f in dataset_files:
             assert f.is_file()
 
     @pytest.mark.dependency(depends=["test_annotate_run"])
     def test_annotate_report_exists(self):
+        """Check that the json report exists."""
         json_files = (self.workdir / "annotate").glob("*.report.json")
         for f in json_files:
             assert f.is_file()
 
     @pytest.mark.dependency(depends=["test_annotate_run"])
     def test_annotate_images_exist(self):
+        """Check that the rank size plot has been created."""
         png_files = (self.workdir / "annotate").glob("*.rank_vs_size.png")
 
         if "--verbose" not in self.__this_command:
@@ -90,6 +94,7 @@ class BaseAnnotateTestsMixin(BaseWorkflowTestMixin):
 
     @pytest.mark.dependency(depends=["test_annotate_run"])
     def test_raw_component_metrics_exist(self):
+        """Check that the raw metrics exists."""
         metric_files = (self.workdir / "annotate").glob(
             "*.raw_components_metrics.csv.gz"
         )
@@ -104,6 +109,7 @@ class BaseAnnotateTestsMixin(BaseWorkflowTestMixin):
 
     @pytest.mark.dependency(depends=["test_annotate_run"])
     def test_doublet_calling_vertex_communities_exists(self):
+        """Check that the vertex community file has been created."""
         vertex_files = (self.workdir / "annotate").glob("*.vertex_communities.csv.gz")
 
         if "--doublet-calling" not in self.__this_command:
@@ -123,6 +129,7 @@ class BaseAnnotateTestsMixin(BaseWorkflowTestMixin):
 
     @pytest.mark.dependency(depends=["test_annotate_run"])
     def test_umap_png_exists(self):
+        """Check that the umap png exists."""
         png_files = (self.workdir / "annotate").glob("*.umap.png")
 
         if "--verbose" not in self.__this_command:

--- a/src/pixelator/test_utils/graph.py
+++ b/src/pixelator/test_utils/graph.py
@@ -1,4 +1,5 @@
-"""
+"""Annotation tests for the graph step.
+
 Copyright (c) 2023 Pixelgen Technologies AB.
 """
 
@@ -12,8 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 class BaseGraphTestsMixin(BaseWorkflowTestMixin):
-    """
-    Base class for graph command tests.
+    """Base class for graph command tests.
 
     Test cases (defined in this class or in subclasses)
     that depend on the output should be marked with:
@@ -26,12 +26,14 @@ class BaseGraphTestsMixin(BaseWorkflowTestMixin):
 
     @pytest.mark.dependency(name="test_graph_run", depends=["test_collapse_run"])
     def test_graph_run(self):
+        """Run the graph command."""
         params = self.__get_parameters()
         verbose = self.__get_options("common").get("verbose")
 
         input_files = list(
             map(
-                lambda f: str(f), (self.workdir / "collapse").glob("*.collapsed.csv.gz")
+                lambda f: str(f),
+                (self.workdir / "collapse").glob("*.collapsed.parquet"),
             )
         )
 
@@ -55,20 +57,24 @@ class BaseGraphTestsMixin(BaseWorkflowTestMixin):
         self.context.run_command("graph", command, input_files)
         assert self.__this_result.exit_code == 0
 
+    # TODO I think we should remove this test. Look at it later.
     @pytest.mark.dependency(depends=["test_graph_run"])
     def test_graph_raw_edgelist_exists(self):
-        raw_edge_files = (self.workdir / "graph").glob("*.raw_edgelist.csv.gz")
+        """Check that the raw edgelist has been created."""
+        raw_edge_files = (self.workdir / "graph").glob("*.raw_edgelist.parquet")
         for f in raw_edge_files:
             assert f.is_file()
 
     @pytest.mark.dependency(depends=["test_graph_run"])
     def test_graph_edgelist_exists(self):
-        edge_files = (self.workdir / "graph").glob("*.edgelist.csv.gz")
+        """Check that the edgelist exists."""
+        edge_files = (self.workdir / "graph").glob("*.edgelist.parquet")
         for f in edge_files:
             assert f.is_file()
 
     @pytest.mark.dependency(depends=["test_graph_run"])
     def test_graph_report_exists(self):
+        """Check that the json report exists."""
         json_files = (self.workdir / "graph").glob("*.report.json")
         for f in json_files:
             assert f.is_file()

--- a/src/pixelator/test_utils/graph.py
+++ b/src/pixelator/test_utils/graph.py
@@ -57,14 +57,6 @@ class BaseGraphTestsMixin(BaseWorkflowTestMixin):
         self.context.run_command("graph", command, input_files)
         assert self.__this_result.exit_code == 0
 
-    # TODO I think we should remove this test. Look at it later.
-    @pytest.mark.dependency(depends=["test_graph_run"])
-    def test_graph_raw_edgelist_exists(self):
-        """Check that the raw edgelist has been created."""
-        raw_edge_files = (self.workdir / "graph").glob("*.raw_edgelist.parquet")
-        for f in raw_edge_files:
-            assert f.is_file()
-
     @pytest.mark.dependency(depends=["test_graph_run"])
     def test_graph_edgelist_exists(self):
         """Check that the edgelist exists."""

--- a/tests/annotate/test_annotate.py
+++ b/tests/annotate/test_annotate.py
@@ -90,10 +90,8 @@ def test_annotate_adata(edgelist: pd.DataFrame, tmp_path: Path, panel: AntibodyP
 
     # TODO test dynamic_filter ON (need to change distribution of test data)
 
-    tmp_edgelist_file = tmp_path / "tmp_edgelist.csv.gz"
-    edgelist.to_csv(
-        tmp_edgelist_file, header=True, index=False, sep=",", compression="gzip"
-    )
+    tmp_edgelist_file = tmp_path / "tmp_edgelist.parquet"
+    edgelist.to_parquet(tmp_edgelist_file, index=False)
 
     annotate_components(
         input=str(tmp_edgelist_file),

--- a/tests/graph/conftest.py
+++ b/tests/graph/conftest.py
@@ -13,7 +13,6 @@ from pixelator.graph import Graph
 
 from tests.graph.igraph.test_tools import full_graph
 from tests.graph.test_graph_utils import add_random_names_to_vertexes
-from tests.test_tools import enforce_edgelist_types_for_tests
 
 
 @pytest.fixture(name="output_dir")
@@ -34,15 +33,9 @@ def metrics_file_fixture(tmp_path):
 @pytest.fixture(name="input_edgelist")
 def input_edgelist_fixture(tmp_path, edgelist_with_communities: pd.DataFrame):
     """Fix an input edgelist."""
-    input_edgelist = tmp_path / "tmp_edgelist.csv"
-    edgelist_with_communities.to_csv(
-        input_edgelist,
-        header=True,
-        index=False,
-    )
-    assert len(edgelist_with_communities["component"].unique()) == 1
-    edgelist_with_communities = enforce_edgelist_types_for_tests(
-        edgelist_with_communities
+    input_edgelist = tmp_path / "tmp_edgelist.parquet"
+    edgelist_with_communities.to_parquet(
+        input_edgelist, engine="fastparquet", compression="zstd", index=False
     )
     yield input_edgelist
 

--- a/tests/graph/test_graph_utils.py
+++ b/tests/graph/test_graph_utils.py
@@ -4,17 +4,18 @@ Copyright (c) 2023 Pixelgen Technologies AB.
 """
 import random
 
+import numpy as np
 import pandas as pd
 import polars as pl
 import pytest
 from pandas.testing import assert_frame_equal
+from pixelator.graph import Graph
 from pixelator.graph.utils import (
     components_metrics,
     create_node_markers_counts,
     edgelist_metrics,
     update_edgelist_membership,
 )
-from pixelator.graph import Graph
 
 
 def add_random_names_to_vertexes(graph: Graph) -> None:
@@ -77,7 +78,7 @@ def test_components_metrics(full_graph_edgelist: pd.DataFrame):
                     "upia": 50,
                     "upib": 50,
                     "umi": 1908,
-                    "reads": 2500,
+                    "reads": np.uint64(2500),
                     "mean_reads_per_molecule": 1.0,
                     "median_reads_per_molecule": 1.0,
                     "mean_upia_degree": 50.0,

--- a/tests/graph/test_graph_utils.py
+++ b/tests/graph/test_graph_utils.py
@@ -4,7 +4,6 @@ Copyright (c) 2023 Pixelgen Technologies AB.
 """
 import random
 
-import numpy as np
 import pandas as pd
 import polars as pl
 import pytest
@@ -78,7 +77,7 @@ def test_components_metrics(full_graph_edgelist: pd.DataFrame):
                     "upia": 50,
                     "upib": 50,
                     "umi": 1908,
-                    "reads": np.uint64(2500),
+                    "reads": 2500,
                     "mean_reads_per_molecule": 1.0,
                     "median_reads_per_molecule": 1.0,
                     "mean_upia_degree": 50.0,

--- a/tests/report/test_report.py
+++ b/tests/report/test_report.py
@@ -7,7 +7,6 @@ import json
 from pathlib import Path
 from unittest import mock
 
-import numpy as np
 import pandas as pd
 import pytest
 from anndata import AnnData
@@ -255,7 +254,7 @@ def test_cell_calling_metrics(adata: AnnData, edgelist: pd.DataFrame, tmp_path: 
                 "cells_filtered": [5, 5],
                 "total_markers": [22, 22],
                 "total_umis": [5, 5],
-                "total_reads_cell": np.array([30000, 30000], dtype=np.uint64),
+                "total_reads_cell": [30000, 30000],
                 "median_reads_cell": [6000.0, 6000.0],
                 "mean_reads_cell": [6000.0, 6000.0],
                 "median_upi_cell": [1996.0, 1996.0],
@@ -271,7 +270,7 @@ def test_cell_calling_metrics(adata: AnnData, edgelist: pd.DataFrame, tmp_path: 
                 "median_markers_cell": [7.0, 7.0],
                 "mean_markers_cell": [7.0, 7.0],
                 "upib_per_upia": [1.0, 1.0],
-                "reads_of_aggregates": np.array([18000, 18000], dtype=np.uint64),
+                "reads_of_aggregates": [18000, 18000],
                 "umis_of_aggregates": [3, 3],
                 "number_of_aggregates": [3, 3],
                 "fraction_of_aggregates": [0.6, 0.6],

--- a/tests/report/test_report.py
+++ b/tests/report/test_report.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 from unittest import mock
 
+import numpy as np
 import pandas as pd
 import pytest
 from anndata import AnnData
@@ -254,7 +255,7 @@ def test_cell_calling_metrics(adata: AnnData, edgelist: pd.DataFrame, tmp_path: 
                 "cells_filtered": [5, 5],
                 "total_markers": [22, 22],
                 "total_umis": [5, 5],
-                "total_reads_cell": [30000, 30000],
+                "total_reads_cell": np.array([30000, 30000], dtype=np.uint64),
                 "median_reads_cell": [6000.0, 6000.0],
                 "mean_reads_cell": [6000.0, 6000.0],
                 "median_upi_cell": [1996.0, 1996.0],
@@ -270,7 +271,7 @@ def test_cell_calling_metrics(adata: AnnData, edgelist: pd.DataFrame, tmp_path: 
                 "median_markers_cell": [7.0, 7.0],
                 "mean_markers_cell": [7.0, 7.0],
                 "upib_per_upia": [1.0, 1.0],
-                "reads_of_aggregates": [18000, 18000],
+                "reads_of_aggregates": np.array([18000, 18000], dtype=np.uint64),
                 "umis_of_aggregates": [3, 3],
                 "number_of_aggregates": [3, 3],
                 "fraction_of_aggregates": [0.6, 0.6],


### PR DESCRIPTION
## Description

This PR changes:
 * Change output format of `collapse` from csv to parquet.
 * Change input and output format of `graph` from csv to parquet.
 * Change input format of `annotate` from csv to parquet.

It also removes the writing of the raw edgelist form the graph step.

Fixes: EXE-1212, EXE-1213

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

With unit and integration tests, and by manually running the `graph` step locally.

## PR checklist:

- [ ] This comment contains a description of changes (with reason).
- [ ] My code follows the style guidelines of this project
- [ ] Make sure your code lints, is well-formatted and type checks
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If you've added a new stage - have you followed the pipeline CLI conventions in the [USAGE guide](../USAGE.md)
- [ ] [README.md](./README.md) is updated
- [ ] If a new tool or package is included, update poetry.lock, [the conda recipe](../conda-recipe/pixelator/meta.yaml) and [cited it properly](../CITATIONS.md)
- [ ] Include any new [authors/contributors](../AUTHORS.md)
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] Usage Documentation is updated
- [ ] If you are doing a [release](../RELEASING.md#Releasing), or a significant change to the code, update [CHANGELOG.md](../CHANGELOG.md)
