### PR TITLE
Feature/exe 1242 `add_edges` was always assuming backend is igraph based

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Remove placeholder warning of missing data for not yet implemented features.
 * Change "Median antibody molecules per cell" to "Average antibody molecules per cell" in the qc report.
 * Refactoring of the graph backend implementations module.
+* Activating networkx as the backend is now done by setting `PIXELATOR_GRAPH_BACKEND="NetworkXGraphBackend"`
+  (previously `PIXELATOR_GRAPH_BACKEND=True` was used).
 
 ### Fixed
 
 * Nicer error messages when there are no components valid for computing colocalization.
+* Cleaned out remaining igraph remnants from `Graph` class
 
 ### Removed
 

--- a/src/pixelator/graph/backends/implementations/__init__.py
+++ b/src/pixelator/graph/backends/implementations/__init__.py
@@ -28,7 +28,7 @@ def graph_backend(
 
     Pick up a GraphBackend. Defaults to `IgraphGraphBackend` unless
     the the following variable is set in the environment:
-    `ENABLE_NETWORKX_BACKEND=True`
+    `PIXELATOR_GRAPH_BACKEND=True`
     :param graph_backend_class: name of the graph backend class to try to pickup.
     :returns: A concrete graph backend instance
     :rtype: GraphBackend
@@ -56,11 +56,7 @@ def graph_backend(
             f"Class name {graph_backend_class} not recognized as `GraphBackend`"
         )
 
-    if str(os.environ.get("ENABLE_NETWORKX_BACKEND", False)) in (
-        "True",
-        "true",
-        "1",
-    ):
+    if str(os.environ.get("PIXELATOR_GRAPH_BACKEND", None)) == "NetworkXGraphBackend":
         return _load_nx()
 
     return _load_ig()

--- a/src/pixelator/graph/backends/implementations/__init__.py
+++ b/src/pixelator/graph/backends/implementations/__init__.py
@@ -5,7 +5,10 @@ Copyright (c) 2023 Pixelgen Technologies AB.
 
 import logging
 import os
-from typing import Literal, Optional
+from typing import Literal, Optional, Union
+
+import networkx as nx
+import igraph
 
 from pixelator.graph.backends.protocol import GraphBackend
 from pixelator.graph.backends.implementations._igraph import IgraphGraphBackend
@@ -42,22 +45,31 @@ def graph_backend(
         logger.debug("Setting up an igraph based backend")
         return IgraphGraphBackend
 
-    if not graph_backend_class:
-        if str(os.environ.get("ENABLE_NETWORKX_BACKEND", False)) in (
-            "True",
-            "true",
-            "1",
-        ):
+    if graph_backend_class:
+        if graph_backend_class == "NetworkXGraphBackend":
             return _load_nx()
 
-        return _load_ig()
+        if graph_backend_class == "IgraphGraphBackend":
+            return _load_ig()
 
-    if graph_backend_class == "NetworkXGraphBackend":
+        raise ValueError(
+            f"Class name {graph_backend_class} not recognized as `GraphBackend`"
+        )
+
+    if str(os.environ.get("ENABLE_NETWORKX_BACKEND", False)) in (
+        "True",
+        "true",
+        "1",
+    ):
         return _load_nx()
 
-    if graph_backend_class == "IgraphGraphBackend":
-        return _load_ig()
+    return _load_ig()
 
-    raise ValueError(
-        f"Class name {graph_backend_class} not recognized as `GraphBackend`"
-    )
+
+def graph_backend_from_graph_type(graph: Union[nx.Graph, nx.MultiGraph, igraph.Graph]):
+    """Pick the correct backend type based on the graph type."""
+    if isinstance(graph, nx.Graph):
+        return graph_backend("NetworkXGraphBackend")
+    if isinstance(graph, igraph.Graph):
+        return graph_backend("IgraphGraphBackend")
+    raise ValueError("Cannot recognize type of `graph`")

--- a/src/pixelator/graph/backends/implementations/_networkx.py
+++ b/src/pixelator/graph/backends/implementations/_networkx.py
@@ -224,10 +224,10 @@ class NetworkXGraphBackend(GraphBackend):
         return NetworkXGraphBackend(raw=graph)
 
     @staticmethod
-    def from_raw(graph: nx.Graph) -> NetworkXGraphBackend:
+    def from_raw(graph: Union[nx.Graph, nx.MultiGraph]) -> NetworkXGraphBackend:
         """Generate a Graph from an networkx.Graph object.
 
-        :param graph: input igraph to use
+        :param graph: input networkx graph to use
         :return: A pixelator Graph object
         :rtype: NetworkXGraphBackend
         """

--- a/src/pixelator/graph/backends/protocol.py
+++ b/src/pixelator/graph/backends/protocol.py
@@ -18,7 +18,6 @@ from typing import (
     Union,
 )
 
-import networkx as nx
 import pandas as pd
 import polars as pl
 from scipy.sparse import csr_matrix
@@ -61,11 +60,16 @@ class GraphBackend(Protocol):
         ...
 
     @staticmethod
-    def from_raw(graph: nx.Graph) -> GraphBackend:
-        """Generate a Graph from an networkx.Graph object.
+    def from_raw(graph: Any) -> GraphBackend:
+        """Generate a Graph from a valid Graph object.
 
-        :param graph: input igraph to use
-        :return: A pixelator Graph object
+        What the valid graph object is depends on the underlying
+        GraphBackend implementation.
+
+        Typically what you want to use is `from_edgelist`.
+
+        :param graph: input graph to use
+        :return: A pixelator GraphBackend object
         :rtype: GraphBackend
         """
         ...

--- a/tests/graph/backends/test_implementations.py
+++ b/tests/graph/backends/test_implementations.py
@@ -8,6 +8,7 @@ import networkx as nx
 import pytest
 from pixelator.graph.backends.implementations import (
     graph_backend,
+    graph_backend_from_graph_type,
 )
 from pixelator.graph.backends.implementations._igraph import (
     IgraphBasedEdge,
@@ -46,6 +47,24 @@ def test_graph_backend_request_networkx():
 def test_graph_backend_request_networkx_when_env_var_set(enable_backend):
     result = graph_backend()
     assert isinstance(result(), NetworkXGraphBackend)
+
+
+def test_graph_backend_from_graph_type_igraph():
+    result = graph_backend_from_graph_type(graph=ig.Graph())
+    assert isinstance(result(), IgraphGraphBackend)
+
+
+def test_graph_backend_from_graph_type_networkx():
+    result = graph_backend_from_graph_type(graph=nx.Graph())
+    assert isinstance(result(), NetworkXGraphBackend)
+
+    result = graph_backend_from_graph_type(graph=nx.MultiGraph())
+    assert isinstance(result(), NetworkXGraphBackend)
+
+
+def test_graph_backend_from_graph_type_unknown():
+    with pytest.raises(ValueError):
+        graph_backend_from_graph_type(graph="hello")
 
 
 @pytest.fixture

--- a/tests/graph/conftest.py
+++ b/tests/graph/conftest.py
@@ -61,7 +61,7 @@ def graph_without_communities_fixture():
     # Somewhat hacky solution make sure this works with both
     # the igraph and networkx tests
 
-    if os.environ.get("ENABLE_NETWORKX_BACKEND"):
+    if os.environ.get("PIXELATOR_GRAPH_BACKEND"):
         graph = Graph.from_raw(nx.fast_gnp_random_graph(100, p=0.1, seed=10))
         # Remove any unattached nodes, since that messes up the community
         # detection
@@ -78,7 +78,7 @@ def enable_backend(request):
     previous_environment = os.environ
     if request.param == "networkx":
         new_environment = previous_environment.copy()
-        new_environment["ENABLE_NETWORKX_BACKEND"] = True
+        new_environment["PIXELATOR_GRAPH_BACKEND"] = "NetworkXGraphBackend"
         os.environ = new_environment
     yield
     os.environ = previous_environment

--- a/tests/graph/test_graph.py
+++ b/tests/graph/test_graph.py
@@ -202,7 +202,7 @@ def test_build_graph_a_node_projected_without_simplifying(
         assert graph.vs.attributes() == {"name", "markers", "type", "pixel_type"}
 
     # We want to warn when a-node projection is requested without simplification.
-    if os.environ.get("ENABLE_NETWORKX_BACKEND"):
+    if os.environ.get("PIXELATOR_GRAPH_BACKEND"):
         with pytest.warns(UserWarning):
             _test()
     else:


### PR DESCRIPTION
## Description

`add_edges` was always assuming the backend was igraph based. This prompted me to take a closer look at how we instantiate `Graph` instances from "raw" graphs, which we only do in the tests. This PR cleans this up this interface and makes sure that we get the correct underlying backend depending on which type of "raw" graph input is given.

I also switched `PIXELATOR_GRAPH_BACKEND="NetworkXGraphBackend"` to be the mechanism for switching the graph according to @fbdtemme suggestion in #45 .

Fixes: EXE-1242

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested with the unit tests.