### PR TITLE
Make `analysis` run with networkx backend

### DIFF
--- a/src/pixelator/graph/backends/implementations/_igraph.py
+++ b/src/pixelator/graph/backends/implementations/_igraph.py
@@ -457,10 +457,6 @@ class IgraphBasedVertexSequence(VertexSequence):
         """Set the given vertex attribute to the values in the attribute vector."""
         self._vertex_seq[attribute] = attribute_vector
 
-    def attribute(self, attr: str) -> Iterable[Any]:
-        """Get all attributes associated with the vertices."""
-        return self._vertex_seq[attr]
-
 
 class IgraphBasedEdgeSequence(EdgeSequence):
     """Proxy for a igraph.EdgeSeq."""

--- a/src/pixelator/graph/backends/implementations/_networkx.py
+++ b/src/pixelator/graph/backends/implementations/_networkx.py
@@ -262,7 +262,7 @@ class NetworkXGraphBackend(GraphBackend):
 
     def get_adjacency_sparse(self) -> csr_matrix:
         """Get the sparse adjacency matrix."""
-        raise NotImplementedError()
+        return nx.to_scipy_sparse_array(self._raw)
 
     def connected_components(self) -> NetworkxBasedVertexClustering:
         """Get the connected components in the Graph instance."""

--- a/src/pixelator/graph/utils.py
+++ b/src/pixelator/graph/utils.py
@@ -174,9 +174,11 @@ def create_node_markers_counts(
 
     if "markers" not in graph.vs.attributes():
         raise AssertionError("Could not find 'markers' in vertex attributes")
-    markers = list(sorted(graph.vs.get_vertex(0)["markers"].keys()))
+    markers = list(sorted(next(iter(graph.vs))["markers"].keys()))
     node_marker_counts = pd.DataFrame.from_records(
-        graph.vs.attribute("markers"), columns=markers, index=graph.vs.attribute("name")
+        list(graph.vs.get_attribute("markers")),
+        columns=markers,
+        index=list(graph.vs.get_attribute("name")),
     )
     node_marker_counts = node_marker_counts.reindex(
         sorted(node_marker_counts.columns), axis=1
@@ -184,7 +186,7 @@ def create_node_markers_counts(
     node_marker_counts.columns.name = "markers"
     node_marker_counts.columns = node_marker_counts.columns.astype("string[pyarrow]")
     node_marker_counts.index = pd.Index(
-        graph.vs.attribute("name"), dtype="string[pyarrow]", name="node"
+        list(graph.vs.get_attribute("name")), dtype="string[pyarrow]", name="node"
     )
     if k == 0:
         return node_marker_counts
@@ -216,7 +218,7 @@ def create_node_markers_counts(
         data=neighbourhood_counts,
         columns=node_marker_counts.columns.copy(),
         index=pd.Index(
-            graph.vs.attribute("name"), dtype="string[pyarrow]", name="node"
+            list(graph.vs.get_attribute("name")), dtype="string[pyarrow]", name="node"
         ),
     )
     df.columns.name = "markers"

--- a/tests/analysis/colocalization/test_colocalization.py
+++ b/tests/analysis/colocalization/test_colocalization.py
@@ -14,7 +14,10 @@ from pixelator.analysis.colocalization import (
 )
 
 
-def test_colocalization_from_component_edgelist(full_graph_edgelist: pd.DataFrame):
+@pytest.mark.parametrize("enable_backend", ["igraph", "networkx"], indirect=True)
+def test_colocalization_from_component_edgelist(
+    enable_backend, full_graph_edgelist: pd.DataFrame
+):
     # TODO we should test more scenarios here (no overlapping and half overlapping)
     result = colocalization_from_component_edgelist(
         edgelist=full_graph_edgelist,
@@ -39,14 +42,19 @@ def test_colocalization_from_component_edgelist(full_graph_edgelist: pd.DataFram
             "jaccard_stdev": {0: 0.0, 1: 0.0, 2: 0.0},
             "jaccard_z": {0: np.nan, 1: np.nan, 2: np.nan},
             "jaccard_p_value": {0: np.nan, 1: np.nan, 2: np.nan},
-            "component": {0: "PXLCMP0000000", 1: "PXLCMP0000000", 2: "PXLCMP0000000"},
+            "component": {
+                0: "PXLCMP0000000",
+                1: "PXLCMP0000000",
+                2: "PXLCMP0000000",
+            },
         }
     )
 
     assert_frame_equal(result, expected)
 
 
-def test_colocalization_scores(full_graph_edgelist: pd.DataFrame):
+@pytest.mark.parametrize("enable_backend", ["igraph", "networkx"], indirect=True)
+def test_colocalization_scores(enable_backend, full_graph_edgelist: pd.DataFrame):
     # TODO we should test more scenarios here (no overlapping and half overlapping)
     result = colocalization_scores(
         edgelist=full_graph_edgelist,
@@ -73,14 +81,19 @@ def test_colocalization_scores(full_graph_edgelist: pd.DataFrame):
             "jaccard_z": {0: np.nan, 1: np.nan, 2: np.nan},
             "jaccard_p_value": {0: np.nan, 1: np.nan, 2: np.nan},
             "jaccard_p_value_adjusted": {0: np.nan, 1: np.nan, 2: np.nan},
-            "component": {0: "PXLCMP0000000", 1: "PXLCMP0000000", 2: "PXLCMP0000000"},
+            "component": {
+                0: "PXLCMP0000000",
+                1: "PXLCMP0000000",
+                2: "PXLCMP0000000",
+            },
         }
     )
 
     assert_frame_equal(result, expected)
 
 
-def test_colocalization_scores_log1p(full_graph_edgelist: pd.DataFrame):
+@pytest.mark.parametrize("enable_backend", ["igraph", "networkx"], indirect=True)
+def test_colocalization_scores_log1p(enable_backend, full_graph_edgelist: pd.DataFrame):
     result = colocalization_scores(
         edgelist=full_graph_edgelist,
         use_full_bipartite=True,
@@ -100,21 +113,31 @@ def test_colocalization_scores_log1p(full_graph_edgelist: pd.DataFrame):
             "pearson_stdev": {0: 0.0, 1: 0.00010716932087924583, 2: 0.0},
             "pearson_z": {0: np.nan, 1: -2.708503319504645, 2: np.nan},
             "pearson_p_value": {0: np.nan, 1: 0.0033793717998496305, 2: np.nan},
-            "pearson_p_value_adjusted": {0: np.nan, 1: 0.010138115400118594, 2: np.nan},
+            "pearson_p_value_adjusted": {
+                0: np.nan,
+                1: 0.010138115400118594,
+                2: np.nan,
+            },
             "jaccard": {0: 1.0, 1: 1.0, 2: 1.0},
             "jaccard_mean": {0: 1.0, 1: 1.0, 2: 1.0},
             "jaccard_stdev": {0: 0.0, 1: 0.0, 2: 0.0},
             "jaccard_z": {0: np.nan, 1: np.nan, 2: np.nan},
             "jaccard_p_value": {0: np.nan, 1: np.nan, 2: np.nan},
             "jaccard_p_value_adjusted": {0: np.nan, 1: np.nan, 2: np.nan},
-            "component": {0: "PXLCMP0000000", 1: "PXLCMP0000000", 2: "PXLCMP0000000"},
+            "component": {
+                0: "PXLCMP0000000",
+                1: "PXLCMP0000000",
+                2: "PXLCMP0000000",
+            },
         }
     )
 
     assert_frame_equal(result, expected)
 
 
+@pytest.mark.parametrize("enable_backend", ["igraph", "networkx"], indirect=True)
 def test_colocalization_scores_should_not_fail_when_one_component_has_single_node(
+    enable_backend,
     full_graph_edgelist,
 ):
     edgelist = full_graph_edgelist.copy()
@@ -132,7 +155,10 @@ def test_colocalization_scores_should_not_fail_when_one_component_has_single_nod
     )
 
 
-def test_colocalization_scores_should_warn_when_no_data(full_graph_edgelist, caplog):
+@pytest.mark.parametrize("enable_backend", ["igraph", "networkx"], indirect=True)
+def test_colocalization_scores_should_warn_when_no_data(
+    enable_backend, full_graph_edgelist, caplog
+):
     with pytest.raises(ValueError):
         edgelist = full_graph_edgelist.copy()
         edgelist = edgelist.iloc[[0]]

--- a/tests/analysis/colocalization/test_prepare.py
+++ b/tests/analysis/colocalization/test_prepare.py
@@ -6,9 +6,9 @@ Copyright (c) 2023 Pixelgen Technologies AB.
 import functools
 
 import pandas as pd
+import pytest
 from numpy.random import default_rng
 from pandas.testing import assert_frame_equal
-
 from pixelator.analysis.colocalization.prepare import (
     filter_by_marker_counts,
     filter_by_region_counts,
@@ -27,7 +27,8 @@ def test_prepare_from_edgelist(edgelist):
     assert len(result.columns) == edgelist["marker"].nunique()
 
 
-def test_prepare_from_graph(edgelist):
+@pytest.mark.parametrize("enable_backend", ["igraph", "networkx"], indirect=True)
+def test_prepare_from_graph(enable_backend, edgelist):
     graph = Graph.from_edgelist(
         edgelist=edgelist,
         add_marker_counts=True,
@@ -47,7 +48,8 @@ def test_prepare_from_graph(edgelist):
         assert len(result.columns) == len(unique_markers_in_component)
 
 
-def test_prepare_from_graph_and_edgelist_eq_for_no_neigbours(edgelist):
+@pytest.mark.parametrize("enable_backend", ["igraph", "networkx"], indirect=True)
+def test_prepare_from_graph_and_edgelist_eq_for_no_neigbours(enable_backend, edgelist):
     for _, component_df in edgelist.groupby("component"):
         graph = Graph.from_edgelist(
             edgelist=component_df,

--- a/tests/analysis/polarization/test_polarization.py
+++ b/tests/analysis/polarization/test_polarization.py
@@ -6,6 +6,7 @@ Copyright (c) 2023 Pixelgen Technologies AB.
 import random
 
 import pandas as pd
+import pytest
 from pandas.testing import assert_frame_equal
 from pixelator.analysis.polarization import (
     polarization_scores,
@@ -15,7 +16,8 @@ from pixelator.analysis.polarization import (
 from tests.graph.igraph.test_tools import create_randomly_connected_bipartite_graph
 
 
-def test_polarization(full_graph_edgelist: pd.DataFrame):
+@pytest.mark.parametrize("enable_backend", ["igraph", "networkx"], indirect=True)
+def test_polarization(enable_backend, full_graph_edgelist: pd.DataFrame):
     # TODO we should test more scenarios here (sparse and clustered patterns)
     scores = polarization_scores(edgelist=full_graph_edgelist)
 
@@ -34,6 +36,7 @@ def test_polarization(full_graph_edgelist: pd.DataFrame):
     assert_frame_equal(scores, expected)
 
 
+# TODO Add test here that tests networkx backend
 def test_polarization_with_differentially_polarized_markers():
     # Set seed to get same graph every time
     graph = create_randomly_connected_bipartite_graph(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 Copyright (c) 2022 Pixelgen Technologies AB.
 """
+import os
 import random
 from pathlib import Path
 
@@ -187,3 +188,14 @@ def setup_basic_pixel_dataset(edgelist: pd.DataFrame, adata: AnnData):
         polarization_scores,
         colocalization_scores,
     )
+
+
+@pytest.fixture
+def enable_backend(request):
+    previous_environment = os.environ
+    if request.param == "networkx":
+        new_environment = previous_environment.copy()
+        new_environment["PIXELATOR_GRAPH_BACKEND"] = "NetworkXGraphBackend"
+        os.environ = new_environment
+    yield
+    os.environ = previous_environment

--- a/tests/graph/conftest.py
+++ b/tests/graph/conftest.py
@@ -10,9 +10,9 @@ import networkx as nx
 import pandas as pd
 import pytest
 from pixelator.graph import Graph
+from pixelator.graph.backends.implementations import graph_backend
 
-from tests.graph.igraph.test_tools import full_graph
-from tests.graph.test_graph_utils import add_random_names_to_vertexes
+from tests.graph.igraph.test_tools import add_random_names_to_vertexes, full_graph
 
 
 @pytest.fixture(name="output_dir")
@@ -73,12 +73,38 @@ def graph_without_communities_fixture():
     return graph
 
 
-@pytest.fixture
-def enable_backend(request):
-    previous_environment = os.environ
-    if request.param == "networkx":
-        new_environment = previous_environment.copy()
-        new_environment["PIXELATOR_GRAPH_BACKEND"] = "NetworkXGraphBackend"
-        os.environ = new_environment
-    yield
-    os.environ = previous_environment
+@pytest.fixture(name="pentagram_graph")
+def pentagram_graph_fixture():
+    """Build a graph in the shape of a five pointed star."""
+    # Construct a graph in the shape of a five pointed
+    # star with a single marker in each point
+    edges = [
+        (0, 2),
+        (0, 3),
+        (1, 3),
+        (1, 4),
+        (2, 0),
+        (2, 4),
+        (3, 0),
+        (3, 1),
+        (4, 1),
+        (4, 2),
+    ]
+    edgelist = pd.DataFrame(edges, columns=["upia", "upib"])
+    GraphBackend = graph_backend()
+    g = Graph(
+        backend=GraphBackend.from_edgelist(
+            edgelist=edgelist,
+            add_marker_counts=False,
+            simplify=True,
+            use_full_bipartite=True,
+        )
+    )
+
+    default_marker = {"A": 0, "B": 0, "C": 0, "D": 0, "E": 0}
+    g.vs.get_vertex(0)["markers"] = dict(default_marker, A=1)
+    g.vs.get_vertex(1)["markers"] = dict(default_marker, B=1)
+    g.vs.get_vertex(2)["markers"] = dict(default_marker, C=1)
+    g.vs.get_vertex(3)["markers"] = dict(default_marker, D=1)
+    g.vs.get_vertex(4)["markers"] = dict(default_marker, E=1)
+    return g

--- a/tests/graph/igraph/test_tools.py
+++ b/tests/graph/igraph/test_tools.py
@@ -12,8 +12,6 @@ import igraph
 import numpy as np
 from pixelator.graph.utils import Graph
 
-from tests.graph.test_graph_utils import add_random_names_to_vertexes
-
 
 def create_random_graph(n_nodes: int, prob: float) -> Graph:
     """
@@ -56,3 +54,14 @@ def create_randomly_connected_bipartite_graph(
 
 def full_graph(n: int) -> Graph:
     return Graph.from_raw(igraph.Graph.Full(n=n))
+
+
+def add_random_names_to_vertexes(graph: Graph) -> None:
+    """Add some random names to vertices on the graph."""
+    for vertex in graph.vs:
+        vertex["name"] = random_sequence(21)
+
+
+def random_sequence(size: int) -> str:
+    """Create a random sequence of size (size)."""
+    return "".join(random.choices("CGTA", k=size))


### PR DESCRIPTION
## Description

This adds all the changes need to make the `analysis` command run with networkx as its backend. The main thing here is the implementation of the `get_adjacency_sparse` method (which as you will see was a very small change).

Fixes EXE-1099

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Tested with the unit tests, and also by running `analysis` locally.

## PR checklist:

- [ ] This comment contains a description of changes (with reason).
- [ ] My code follows the style guidelines of this project
- [ ] Make sure your code lints, is well-formatted and type checks
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If you've added a new stage - have you followed the pipeline CLI conventions in the [USAGE guide](../USAGE.md)
- [ ] [README.md](./README.md) is updated
- [ ] If a new tool or package is included, update poetry.lock, [the conda recipe](../conda-recipe/pixelator/meta.yaml) and [cited it properly](../CITATIONS.md)
- [ ] Include any new [authors/contributors](../AUTHORS.md)
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] Usage Documentation is updated
- [ ] If you are doing a [release](../RELEASING.md#Releasing), or a significant change to the code, update [CHANGELOG.md](../CHANGELOG.md)
