### PR TITLE
Feature/fix a bunch of warnings

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -74,6 +74,8 @@ jobs:
 
       - name: Check code lints with Black
         uses: psf/black@stable
+        with:
+          version: 23.12.0
 
       # If the above check failed, post a comment on the PR explaining the failure
       - name: Post PR comment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Nicer error messages when there are no components valid for computing colocalization.
 * Cleaned out remaining igraph remnants from `Graph` class
+* A bunch of warnings
 
 ### Removed
 

--- a/src/pixelator/analysis/colocalization/__init__.py
+++ b/src/pixelator/analysis/colocalization/__init__.py
@@ -232,7 +232,7 @@ def colocalization_scores(
     )
 
     def data():
-        grouped = edgelist.groupby("component")
+        grouped = edgelist.groupby("component", observed=True)
         unique_components = len(edgelist["component"].unique())
         for idx, (component_id, component_df) in enumerate(grouped):
             logger.debug(

--- a/src/pixelator/analysis/colocalization/estimate.py
+++ b/src/pixelator/analysis/colocalization/estimate.py
@@ -31,8 +31,8 @@ def estimate_observation_statistics(
                 ["marker_1", "marker_2"]
             ).agg(
                 **{
-                    f"{func_name}_mean": pd.NamedAgg(f"{func_name}_perm", np.nanmean),
-                    f"{func_name}_stdev": pd.NamedAgg(f"{func_name}_perm", np.nanstd),
+                    f"{func_name}_mean": pd.NamedAgg(f"{func_name}_perm", "mean"),
+                    f"{func_name}_stdev": pd.NamedAgg(f"{func_name}_perm", "std"),
                 }
             )
 

--- a/src/pixelator/analysis/colocalization/statistics.py
+++ b/src/pixelator/analysis/colocalization/statistics.py
@@ -34,7 +34,7 @@ def _wide_correlation_matrix_to_long_correlation_results(
     # in the stack operation above. It's not pretty, but it's the only
     # way I've figured out to solve this.
     dx = (df.isna() & lower_triangle).values
-    nn = pd.DataFrame(dx, index=df.index, columns=df.columns).stack()
+    nn = pd.DataFrame(dx, index=df.index, columns=df.columns, dtype="object").stack()
     nn = nn[nn]
     nn[:] = pd.NA
 

--- a/src/pixelator/analysis/polarization/__init__.py
+++ b/src/pixelator/analysis/polarization/__init__.py
@@ -183,7 +183,7 @@ def polarization_scores(
     # we make the computation in parallel (for each component)
     with futures.ThreadPoolExecutor() as executor:
         tasks = []
-        for component_id, component_df in edgelist.groupby("component"):
+        for component_id, component_df in edgelist.groupby("component", observed=True):
             # build the graph from the component
             graph = Graph.from_edgelist(
                 edgelist=component_df,

--- a/src/pixelator/collapse/process.py
+++ b/src/pixelator/collapse/process.py
@@ -19,14 +19,18 @@ from typing import (
     Set,
     Tuple,
 )
+import warnings
 
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import pyfastx
 from annoy import AnnoyIndex
-from umi_tools._dedup_umi import edit_distance
-from umi_tools.network import breadth_first_search
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", module="umi_tools")
+    from umi_tools._dedup_umi import edit_distance
+    from umi_tools.network import breadth_first_search
 
 from pixelator.collapse.constants import SEED
 from pixelator.exception import FileFqGzEmpty

--- a/src/pixelator/config/panel.py
+++ b/src/pixelator/config/panel.py
@@ -181,16 +181,15 @@ class AntibodyPanel:
         :param df: DataFrame with data of the panel to validate
         :returns: The in-place modified input dataframe
         """
-        # update control and nuclear column to boolean
-        TR_TABLE = {
-            "(?i)yes": True,
-            "(?i)no": False,
-        }
+        df = df.copy()
 
-        df.replace({"control": TR_TABLE}, regex=True, inplace=True)
-        df["control"].fillna(False, inplace=True)
-        df.replace({"nuclear": TR_TABLE}, regex=True, inplace=True)
-        df["nuclear"].fillna(False, inplace=True)
+        # update control and nuclear column to boolean
+        TR_TABLE = {"(?i)yes": True, "(?i)no": False}
+
+        df["control"] = df["control"].replace(TR_TABLE, regex=True)
+        df["control"] = df["control"].fillna(False)
+        df["nuclear"] = df["nuclear"].replace(TR_TABLE, regex=True)
+        df["nuclear"] = df["nuclear"].fillna(False)
 
         return df
 

--- a/src/pixelator/graph/backends/implementations/_networkx.py
+++ b/src/pixelator/graph/backends/implementations/_networkx.py
@@ -25,7 +25,13 @@ import networkx as nx
 import numpy as np
 import pandas as pd
 import polars as pl
-from graspologic.partition import leiden
+
+with warnings.catch_warnings():
+    # Graspologic raises a numba related warning here, that we can
+    # safely ignore.
+    warnings.filterwarnings("ignore", module="graspologic.models.edge_swaps")
+    from graspologic.partition import leiden
+
 from networkx.algorithms import bipartite as nx_bipartite
 from scipy.sparse import csr_matrix
 

--- a/src/pixelator/graph/utils.py
+++ b/src/pixelator/graph/utils.py
@@ -71,7 +71,7 @@ def components_metrics(edgelist: pd.DataFrame) -> pd.DataFrame:
     cmetrics = []
     index = []
     # iterate the components to obtain the metrics of each component
-    for component_id, group_df in edgelist.groupby("component"):
+    for component_id, group_df in edgelist.groupby("component", observed=True):
         # compute metrics
         n_edges = group_df.shape[0]
         n_vertices = len(

--- a/tests/analysis/colocalization/test_prepare.py
+++ b/tests/analysis/colocalization/test_prepare.py
@@ -50,7 +50,7 @@ def test_prepare_from_graph(enable_backend, edgelist):
 
 @pytest.mark.parametrize("enable_backend", ["igraph", "networkx"], indirect=True)
 def test_prepare_from_graph_and_edgelist_eq_for_no_neigbours(enable_backend, edgelist):
-    for _, component_df in edgelist.groupby("component"):
+    for _, component_df in edgelist.groupby("component", observed=True):
         graph = Graph.from_edgelist(
             edgelist=component_df,
             add_marker_counts=True,

--- a/tests/analysis/colocalization/test_statistics.py
+++ b/tests/analysis/colocalization/test_statistics.py
@@ -4,6 +4,7 @@ Tests for the colocalization modules
 Copyright (c) 2023 Pixelgen Technologies AB.
 """
 import pandas as pd
+import numpy as np
 from pandas.testing import assert_frame_equal
 
 from pixelator.analysis.colocalization.statistics import (
@@ -59,19 +60,19 @@ def test_pearson_no_variation():
     )
     results = pearson(df)
     # Check that the data conforms to the expected shape, i.e. the upper-
-    # triagonal matrix of all vs all comparissons
+    # triagonal matrix of all vs all comparisons
     cols = ["marker1", "marker2", "pearson"]
     data = [
         ["marker1", "marker1", 1.000000],
         ["marker1", "marker2", 0.973223],
         ["marker2", "marker2", 1.000000],
-        ["marker1", "marker3", pd.NA],
-        ["marker2", "marker3", pd.NA],
-        ["marker3", "marker3", pd.NA],
-        ["marker1", "marker4", pd.NA],
-        ["marker2", "marker4", pd.NA],
-        ["marker3", "marker4", pd.NA],
-        ["marker4", "marker4", pd.NA],
+        ["marker1", "marker3", np.nan],
+        ["marker2", "marker3", np.nan],
+        ["marker3", "marker3", np.nan],
+        ["marker1", "marker4", np.nan],
+        ["marker2", "marker4", np.nan],
+        ["marker3", "marker4", np.nan],
+        ["marker4", "marker4", np.nan],
     ]
 
     expected = pd.DataFrame(data, columns=cols)

--- a/tests/annotate/test_aggregates.py
+++ b/tests/annotate/test_aggregates.py
@@ -64,7 +64,7 @@ def mixed_data_fixture(aggregates, normals, unspecifics):
 
 
 def generate_anndata(x):
-    adata = AnnData(X=x, dtype=np.float32)
+    adata = AnnData(X=x)
     components = [f"CMP{idx}" for idx in range(len(x))]
     adata.obs = pd.DataFrame({"component": components})
     adata.obs_names = components


### PR DESCRIPTION
## Description

Fixes a bunch of warnings.

Fixes: EXE-1243, EXE-1203, EXE-1224

## Type of change

Cleaning up warnings.

## How Has This Been Tested?

Tested with unit test suite.

## PR checklist:

- [ ] This comment contains a description of changes (with reason).
- [ ] My code follows the style guidelines of this project
- [ ] Make sure your code lints, is well-formatted and type checks
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If you've added a new stage - have you followed the pipeline CLI conventions in the [USAGE guide](../USAGE.md)
- [ ] [README.md](./README.md) is updated
- [ ] If a new tool or package is included, update poetry.lock, [the conda recipe](../conda-recipe/pixelator/meta.yaml) and [cited it properly](../CITATIONS.md)
- [ ] Include any new [authors/contributors](../AUTHORS.md)
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] Usage Documentation is updated
- [ ] If you are doing a [release](../RELEASING.md#Releasing), or a significant change to the code, update [CHANGELOG.md](../CHANGELOG.md)
