### PR TITLE
Formatting fixes, and exposing `raw` as public property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Optional caching of layouts to speed up computations in some scenarios
 * `experimental` mark that can be added to functions that are not yet production ready
 * Graph layout computations using networkx as the graph backend (experimental feature).
+* The underlying graph instance e.g. a igraph or networkx instance is exposed as a property called `raw` from the `Graph` class.
 
 ### Changed
 

--- a/src/pixelator/cli/analysis.py
+++ b/src/pixelator/cli/analysis.py
@@ -97,7 +97,7 @@ from pixelator.utils import (
     type=click.IntRange(min=0),
     show_default=True,
     help=(
-        "Select the size of the neighborhood to use when computing"
+        "Select the size of the neighborhood to use when computing "
         "colocalization metrics on each component"
     ),
 )
@@ -108,7 +108,7 @@ from pixelator.utils import (
     type=click.IntRange(min=5),
     show_default=True,
     help=(
-        "Set the number of permutations use to compute the empirical"
+        "Set the number of permutations use to compute the empirical "
         "p-value for the colocalization score"
     ),
 )
@@ -119,7 +119,7 @@ from pixelator.utils import (
     type=click.IntRange(min=0),
     show_default=True,
     help=(
-        "The minimum number of counts in a region for it to be considered"
+        "The minimum number of counts in a region for it to be considered "
         "valid for computing colocalization"
     ),
 )

--- a/src/pixelator/graph/graph.py
+++ b/src/pixelator/graph/graph.py
@@ -101,7 +101,7 @@ class Graph:
         with other graph libraries that work e.g. with a
         networkx graph instance.
         """
-        return self._backend._raw
+        return self._backend.raw
 
     @property
     def vs(self):

--- a/src/pixelator/graph/graph.py
+++ b/src/pixelator/graph/graph.py
@@ -93,7 +93,14 @@ class Graph:
         return Graph(backend=Backend(graph))
 
     @property
-    def _raw(self):
+    def raw(self):
+        """Get the underlying raw graph implementation.
+
+        The type of this will depend on the underlying backend.
+        This property is useful when you need to inter-operate
+        with other graph libraries that work e.g. with a
+        networkx graph instance.
+        """
         return self._backend._raw
 
     @property

--- a/tests/analysis/polarization/test_polarization.py
+++ b/tests/analysis/polarization/test_polarization.py
@@ -13,7 +13,7 @@ from pixelator.analysis.polarization import (
     polarization_scores_component,
 )
 
-from tests.graph.igraph.test_tools import create_randomly_connected_bipartite_graph
+from tests.graph.networkx.test_tools import create_randomly_connected_bipartite_graph
 
 
 @pytest.mark.parametrize("enable_backend", ["igraph", "networkx"], indirect=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ from pixelator.pixeldataset import (
 )
 from pixelator.pixeldataset.utils import edgelist_to_anndata
 
-from tests.graph.igraph.test_tools import (
+from tests.graph.networkx.test_tools import (
     create_fully_connected_bipartite_graph,
     create_random_graph,
 )

--- a/tests/graph/conftest.py
+++ b/tests/graph/conftest.py
@@ -12,7 +12,7 @@ import pytest
 from pixelator.graph import Graph
 from pixelator.graph.backends.implementations import graph_backend
 
-from tests.graph.igraph.test_tools import add_random_names_to_vertexes, full_graph
+from tests.graph.networkx.test_tools import add_random_names_to_vertexes, full_graph
 
 
 @pytest.fixture(name="output_dir")

--- a/tests/graph/networkx/__init__.py
+++ b/tests/graph/networkx/__init__.py
@@ -1,5 +1,5 @@
 """
-Functionality from igraph to produce pixelator Graph
+Functionality from networkx to produce pixelator Graph
 of certain types required for testing
 
 Copyright (c) 2023 Pixelgen Technologies AB.

--- a/tests/graph/networkx/test_tools.py
+++ b/tests/graph/networkx/test_tools.py
@@ -1,5 +1,5 @@
 """
-Functionality from igraph to produce pixelator Graph
+Functionality from networkx to produce pixelator Graph
 of certain types required for testing
 
 Copyright (c) 2023 Pixelgen Technologies AB.

--- a/tests/graph/test_graph.py
+++ b/tests/graph/test_graph.py
@@ -14,7 +14,7 @@ from numpy.testing import assert_array_equal
 from pandas.testing import assert_frame_equal
 from pixelator.graph import Graph
 
-from tests.graph.igraph.test_tools import random_sequence
+from tests.graph.networkx.test_tools import random_sequence
 from tests.test_tools import enforce_edgelist_types_for_tests
 
 


### PR DESCRIPTION
## Description

- Fixes incorrect formatting in analysis command cli docs.
- Exposes that `raw` property of the `Graph` object as a public property.

## Type of change

With unit tests and by manually looking at the docs.