### PR TITLE
Feature/exe 1127

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Finding connected components and doing Lieden based community detection using
+* Finding connected components and doing Lieden based community detection using.
   networkx/graspologic (experimental feature).
-* Experimental 3D heatmap plotting feature
-* Optional caching of layouts to speed up computations in some scenarios
-* `experimental` mark that can be added to functions that are not yet production ready
+* Experimental 3D heatmap plotting feature.
+* Optional caching of layouts to speed up computations in some scenarios.
+* `experimental` mark that can be added to functions that are not yet production ready.
 * Graph layout computations using networkx as the graph backend (experimental feature).
+* Monte Carlo permutation support for calculated Moran's I (`morans_z_sim`) in `polarization_scores`.
 
 ### Changed
 

--- a/src/pixelator/analysis/__init__.py
+++ b/src/pixelator/analysis/__init__.py
@@ -54,7 +54,7 @@ def analyse_pixels(
 ) -> None:
     """Calculate Moran's I statistics for a PixelDataset.
 
-    This function takes a `PixelDataset` (zip) that has been generated
+    This function takes a pxl file that has been generated
     with `pixelator annotate`. The function then uses the `edge list` and
     the `AnnData` to compute the scores (polarization, co-abundance and
     co-localization) which are then added to the `PixelDataset` (depending

--- a/src/pixelator/analysis/__init__.py
+++ b/src/pixelator/analysis/__init__.py
@@ -6,19 +6,17 @@ import json
 import logging
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Literal
 
 from pixelator.analysis.colocalization import colocalization_scores
 from pixelator.analysis.colocalization.types import TransformationTypes
 from pixelator.analysis.polarization import polarization_scores
+from pixelator.analysis.polarization.types import PolarizationNormalizationTypes
 from pixelator.pixeldataset import (
     PixelDataset,
 )
 from pixelator.utils import np_encoder
 
 logger = logging.getLogger(__name__)
-
-PolarizationNormalizationTypes = Literal["raw", "clr"]
 
 
 @dataclass(frozen=True)
@@ -44,7 +42,7 @@ def analyse_pixels(
     compute_polarization: bool,
     compute_colocalization: bool,
     use_full_bipartite: bool,
-    polarization_normalization: Literal["raw", "clr"],
+    polarization_normalization: PolarizationNormalizationTypes,
     polarization_n_permutations: int,
     colocalization_transformation: TransformationTypes,
     colocalization_neighbourhood_size: int,

--- a/src/pixelator/analysis/polarization/__init__.py
+++ b/src/pixelator/analysis/polarization/__init__.py
@@ -8,10 +8,8 @@ from esda.moran import Moran
 
 from pixelator.graph.utils import Graph, create_node_markers_counts
 from pixelator.statistics import (
-    binarize_counts,
     clr_transformation,
     correct_pvalues,
-    denoise,
 )
 
 with warnings.catch_warnings():

--- a/src/pixelator/analysis/polarization/__init__.py
+++ b/src/pixelator/analysis/polarization/__init__.py
@@ -47,7 +47,6 @@ def morans_autocorr(w: np.ndarray, y: np.ndarray, permutations: int) -> Any:
     """
     # Default Moran's transformation is row-standardized "r".
     # https://github.com/pysal/esda/blob/main/esda/moran.py
-    np.random.seed(1)
     return Moran(y, w, permutations=permutations)
 
 
@@ -122,7 +121,7 @@ def polarization_scores_component(
 
     if permutations:
 
-        # create the dataframe
+        # create scores dataframe
         df = pd.DataFrame(
             data={
                 "morans_i": [m.I for m in statistics],
@@ -132,13 +131,12 @@ def polarization_scores_component(
                 "morans_z_sim": [m.z_sim for m in statistics],
             },
         ).fillna(0)
-        # the p-values are adjusted per-component
         df["marker"] = counts_df.columns.tolist()
         df["component"] = component_id
 
     else:
 
-        # create the dataframe
+        # create scores dataframe
         df = pd.DataFrame(
             data={
                 "morans_i": [m.I for m in statistics],
@@ -146,7 +144,6 @@ def polarization_scores_component(
                 "morans_z": [m.z_rand for m in statistics],
             },
         ).fillna(0)
-        # the p-values are adjusted per-component
         df["marker"] = counts_df.columns.tolist()
         df["component"] = component_id
 
@@ -227,3 +224,5 @@ def polarization_scores(
 
     logger.debug("Polarization scores for edge list computed")
     return scores
+
+

--- a/src/pixelator/analysis/polarization/__init__.py
+++ b/src/pixelator/analysis/polarization/__init__.py
@@ -188,7 +188,7 @@ def polarization_scores(
     # we make the computation in parallel (for each component)
     with futures.ThreadPoolExecutor() as executor:
         tasks = []
-        for component_id, component_df in edgelist.groupby("component"):
+        for component_id, component_df in edgelist.groupby("component", observed=True):
             # build the graph from the component
             graph = Graph.from_edgelist(
                 edgelist=component_df,

--- a/src/pixelator/analysis/polarization/types.py
+++ b/src/pixelator/analysis/polarization/types.py
@@ -1,0 +1,8 @@
+"""Types associated with polarization.
+
+Copyright (c) 2023 Pixelgen Technologies AB.
+"""
+
+from typing import Literal
+
+PolarizationNormalizationTypes = Literal["raw", "clr"]

--- a/src/pixelator/cli/analysis.py
+++ b/src/pixelator/cli/analysis.py
@@ -72,7 +72,7 @@ from pixelator.utils import (
     "--polarization-n-permutations",
     default=None,
     required=False,
-    type=click.IntRange(min=5),
+    type=click.IntRange(min=0),
     show_default=True,
     help=(
         "Set the number of permutations use to compute the empirical"

--- a/src/pixelator/cli/analysis.py
+++ b/src/pixelator/cli/analysis.py
@@ -199,7 +199,7 @@ def analysis(
                     compute_colocalization=compute_colocalization,
                     use_full_bipartite=use_full_bipartite,
                     polarization_normalization=polarization_normalization,
-                    polarization_permutations=polarization_permutations
+                    polarization_permutations=polarization_permutations,
                     colocalization_transformation=colocalization_transformation,
                     colocalization_neighbourhood_size=colocalization_neighbourhood_size,
                     colocalization_n_permutations=colocalization_n_permutations,

--- a/src/pixelator/cli/analysis.py
+++ b/src/pixelator/cli/analysis.py
@@ -69,10 +69,10 @@ from pixelator.utils import (
     ),
 )
 @click.option(
-    "--polarization-permutations",
+    "--polarization-n-permutations",
     default=None,
     required=False,
-    type=click.IntRange(),
+    type=click.IntRange(min=5),
     show_default=True,
     help=(
         "Set the number of permutations use to compute the empirical"
@@ -134,7 +134,7 @@ def analysis(
     compute_colocalization,
     use_full_bipartite,
     polarization_normalization,
-    polarization_permutations,
+    polarization_n_permutations,
     colocalization_transformation,
     colocalization_neighbourhood_size,
     colocalization_n_permutations,
@@ -152,7 +152,7 @@ def analysis(
         compute_polarization=compute_polarization,
         compute_colocalization=compute_colocalization,
         normalization=polarization_normalization,
-        polarization_permutations=polarization_permutations,
+        polarization_n_permutations=polarization_n_permutations,
         colocalization_transformation=colocalization_transformation,
         colocalization_neighbourhood_size=colocalization_neighbourhood_size,
         colocalization_n_permutations=colocalization_n_permutations,
@@ -199,7 +199,7 @@ def analysis(
                     compute_colocalization=compute_colocalization,
                     use_full_bipartite=use_full_bipartite,
                     polarization_normalization=polarization_normalization,
-                    polarization_permutations=polarization_permutations,
+                    polarization_n_permutations=polarization_n_permutations,
                     colocalization_transformation=colocalization_transformation,
                     colocalization_neighbourhood_size=colocalization_neighbourhood_size,
                     colocalization_n_permutations=colocalization_n_permutations,

--- a/src/pixelator/cli/analysis.py
+++ b/src/pixelator/cli/analysis.py
@@ -60,23 +60,24 @@ from pixelator.utils import (
     "--polarization-normalization",
     default="clr",
     required=False,
-    type=click.Choice(["raw", "clr", "denoise"]),
+    type=click.Choice(["raw", "clr"]),
     show_default=True,
     help=(
         "Which approach to use to normalize the antibody counts:"
         " \n\traw will use the raw counts\n\tclr will use the"
-        " CLR transformed counts\n\tdenoise will use"
-        " CLR transformed counts and subtract the counts of the"
-        " control antibodies"
+        " CLR transformed counts"
     ),
 )
 @click.option(
-    "--polarization-binarization",
+    "--polarization-permutations",
+    default=None,
     required=False,
-    is_flag=True,
+    type=click.IntRange(),
+    show_default=True,
     help=(
-        "Transform the antibody counts to 0-1 (binarized) when computing"
-        " polarization scores"
+        "Set the number of permutations use to compute the empirical"
+        " z-score and p-value for the polarization score. If set to"
+        " None, only the analytical z-score estimation will be performed"
     ),
 )
 @click.option(
@@ -133,7 +134,6 @@ def analysis(
     compute_colocalization,
     use_full_bipartite,
     polarization_normalization,
-    polarization_binarization,
     colocalization_transformation,
     colocalization_neighbourhood_size,
     colocalization_n_permutations,
@@ -151,7 +151,6 @@ def analysis(
         compute_polarization=compute_polarization,
         compute_colocalization=compute_colocalization,
         normalization=polarization_normalization,
-        binarization=polarization_binarization,
         colocalization_transformation=colocalization_transformation,
         colocalization_neighbourhood_size=colocalization_neighbourhood_size,
         colocalization_n_permutations=colocalization_n_permutations,
@@ -198,7 +197,6 @@ def analysis(
                     compute_colocalization=compute_colocalization,
                     use_full_bipartite=use_full_bipartite,
                     polarization_normalization=polarization_normalization,
-                    polarization_binarization=polarization_binarization,
                     colocalization_transformation=colocalization_transformation,
                     colocalization_neighbourhood_size=colocalization_neighbourhood_size,
                     colocalization_n_permutations=colocalization_n_permutations,

--- a/src/pixelator/cli/analysis.py
+++ b/src/pixelator/cli/analysis.py
@@ -76,8 +76,8 @@ from pixelator.utils import (
     show_default=True,
     help=(
         "Set the number of permutations use to compute the empirical"
-        " z-score and p-value for the polarization score. If set to"
-        " None, only the analytical z-score estimation will be performed"
+        " z-score and p-value for the polarization score. If not set,"
+        " only the analytical z-score estimation will be performed"
     ),
 )
 @click.option(

--- a/src/pixelator/cli/analysis.py
+++ b/src/pixelator/cli/analysis.py
@@ -134,6 +134,7 @@ def analysis(
     compute_colocalization,
     use_full_bipartite,
     polarization_normalization,
+    polarization_permutations,
     colocalization_transformation,
     colocalization_neighbourhood_size,
     colocalization_n_permutations,
@@ -151,6 +152,7 @@ def analysis(
         compute_polarization=compute_polarization,
         compute_colocalization=compute_colocalization,
         normalization=polarization_normalization,
+        polarization_permutations=polarization_permutations,
         colocalization_transformation=colocalization_transformation,
         colocalization_neighbourhood_size=colocalization_neighbourhood_size,
         colocalization_n_permutations=colocalization_n_permutations,
@@ -197,6 +199,7 @@ def analysis(
                     compute_colocalization=compute_colocalization,
                     use_full_bipartite=use_full_bipartite,
                     polarization_normalization=polarization_normalization,
+                    polarization_permutations=polarization_permutations
                     colocalization_transformation=colocalization_transformation,
                     colocalization_neighbourhood_size=colocalization_neighbourhood_size,
                     colocalization_n_permutations=colocalization_n_permutations,

--- a/src/pixelator/statistics.py
+++ b/src/pixelator/statistics.py
@@ -14,39 +14,6 @@ import pandas as pd
 logger = logging.getLogger(__name__)
 
 
-def binarize_counts(
-    df: pd.DataFrame,
-    quantile: float = 0.0,
-) -> pd.DataFrame:
-    """Binarize a dataframe of antibody counts.
-
-    The input antibody counts will be binarized (convert to 0-1) using
-    a distribution cutoff based on the value of the `quantile` argument.
-
-    :param df: the dataframe with the antibody counts
-    :param quantile: the quantile to use (0-1) to binarize
-    :raises AssertionError: when the input quantile is not valid
-    :return: a pd.DataFrame with the counts binarized (0 or 1)
-    :rtype: pd.DataFrame
-    """
-    if quantile < 0 or quantile > 1:
-        raise AssertionError("quantile value must be betwen 0-1")
-
-    logger.debug(
-        "Binarizing antibody counts with %i nodes and %i markers",
-        df.shape[0],
-        df.shape[1],
-    )
-
-    df = df.copy()
-    mask = df > df.quantile(quantile)
-    df[mask] = 1
-    df[~mask] = 0
-
-    logger.debug("Antibody counts binarized")
-    return df
-
-
 def clr_transformation(
     df: pd.DataFrame,
     axis: Literal[0, 1] = 0,

--- a/src/pixelator/statistics.py
+++ b/src/pixelator/statistics.py
@@ -18,7 +18,7 @@ def binarize_counts(
     df: pd.DataFrame,
     quantile: float = 0.0,
 ) -> pd.DataFrame:
-    """Binarize a dataframe of antibody cstuffounts.
+    """Binarize a dataframe of antibody counts.
 
     The input antibody counts will be binarized (convert to 0-1) using
     a distribution cutoff based on the value of the `quantile` argument.

--- a/tests/analysis/polarization/test_polarization.py
+++ b/tests/analysis/polarization/test_polarization.py
@@ -27,6 +27,8 @@ def test_polarization(enable_backend, full_graph_edgelist: pd.DataFrame):
             "morans_p_value": [0.0006289900162095327, 0.0006289959783166696],
             "morans_p_adjusted": [0.0006289959783166696, 0.0006289959783166696],
             "morans_z": [-3.41879540404497, -3.4187928246970136],
+            "morans_p_value_sim": {0: 0.001, 1: 0.336},
+            "morans_z_sim": {0: 11.242690771061561, 1: -0.052831436479260474},
             "marker": ["A", "B"],
             "component": ["PXLCMP0000000", "PXLCMP0000000"],
         },
@@ -62,6 +64,8 @@ def test_polarization_with_differentially_polarized_markers():
             "morans_i": {0: 0.43226508763528637, 1: -0.008836689038031321},
             "morans_p_value": {0: 3.0133748632157652e-33, 1: 0.6982377399841404},
             "morans_z": {0: 12.01362576145691, 1: -0.3877004266942152},
+            "morans_p_value_sim": {0: 0.001, 1: 0.336},
+            "morans_z_sim": {0: 11.242690771061561, 1: -0.052831436479260474},
             "marker": {0: "A", 1: "C"},
             "component": {0: "PXLCMP0000000", 1: "PXLCMP0000000"},
         }

--- a/tests/analysis/polarization/test_polarization.py
+++ b/tests/analysis/polarization/test_polarization.py
@@ -6,6 +6,7 @@ Copyright (c) 2023 Pixelgen Technologies AB.
 import random
 
 import pandas as pd
+import numpy as np
 import pytest
 from pandas.testing import assert_frame_equal
 from pixelator.analysis.polarization import (
@@ -19,7 +20,8 @@ from tests.graph.igraph.test_tools import create_randomly_connected_bipartite_gr
 @pytest.mark.parametrize("enable_backend", ["igraph", "networkx"], indirect=True)
 def test_polarization(enable_backend, full_graph_edgelist: pd.DataFrame):
     # TODO we should test more scenarios here (sparse and clustered patterns)
-    scores = polarization_scores(edgelist=full_graph_edgelist)
+    
+    scores = polarization_scores(edgelist=full_graph_edgelist, permutations=None, use_full_bipartite=True)
 
     expected = pd.DataFrame(
         data={
@@ -27,8 +29,30 @@ def test_polarization(enable_backend, full_graph_edgelist: pd.DataFrame):
             "morans_p_value": [0.0006289900162095327, 0.0006289959783166696],
             "morans_p_adjusted": [0.0006289959783166696, 0.0006289959783166696],
             "morans_z": [-3.41879540404497, -3.4187928246970136],
-            "morans_p_value_sim": {0: 0.001, 1: 0.336},
-            "morans_z_sim": {0: 11.242690771061561, 1: -0.052831436479260474},
+            "marker": ["A", "B"],
+            "component": ["PXLCMP0000000", "PXLCMP0000000"],
+        },
+        index=pd.Index([0, 1]),
+    )
+    # test polarization scores
+    assert_frame_equal(scores, expected)
+
+    
+@pytest.mark.parametrize("enable_backend", ["networkx"], indirect=True)
+def test_permuted_polarization(enable_backend, full_graph_edgelist: pd.DataFrame):
+    # TODO we should test more scenarios here (sparse and clustered patterns)
+    np.random.seed(1)
+
+    scores = polarization_scores(edgelist=full_graph_edgelist, permutations=999, use_full_bipartite=True)
+
+    expected = pd.DataFrame(
+        data={
+            "morans_i": [-0.05841822339465653, -0.05841818713383407],
+            "morans_p_value": [0.0006289900162095327, 0.0006289959783166696],
+            "morans_p_adjusted": [0.0006289959783166696, 0.0006289959783166696],
+            "morans_z": [-3.41879540404497, -3.4187928246970136],
+            "morans_p_value_sim": {0: 0.02, 1: 0.01},
+            "morans_z_sim": {0: -3.2672829000275208, 1: -3.973415289418734},
             "marker": ["A", "B"],
             "component": ["PXLCMP0000000", "PXLCMP0000000"],
         },
@@ -44,6 +68,7 @@ def test_polarization_with_differentially_polarized_markers():
         n1=50, n2=100, p=0.1, random_seed=2
     )
 
+    random.seed(1)
     for v in graph.vs:
         v["markers"] = {"A": 0, "B": 1, "C": 0}
     random_vertex = graph.vs.get_vertex(random.randint(0, graph.vcount()))
@@ -61,14 +86,52 @@ def test_polarization_with_differentially_polarized_markers():
     # Hence it is filtered out.
     expected = pd.DataFrame.from_dict(
         {
-            "morans_i": {0: 0.43226508763528637, 1: -0.008836689038031321},
-            "morans_p_value": {0: 3.0133748632157652e-33, 1: 0.6982377399841404},
-            "morans_z": {0: 12.01362576145691, 1: -0.3877004266942152},
-            "morans_p_value_sim": {0: 0.001, 1: 0.336},
-            "morans_z_sim": {0: 11.242690771061561, 1: -0.052831436479260474},
+            "morans_i": {0: 0.37307837882553935, 1: -0.0037658463832960496},
+            "morans_p_value": {0: 1.317601591958555e-17, 1: 0.5910333410276116},
+            "morans_z": {0: 8.54213868598478, 1: 0.537339187874427},
             "marker": {0: "A", 1: "C"},
             "component": {0: "PXLCMP0000000", 1: "PXLCMP0000000"},
         }
     )
     # test polarization scores
     assert_frame_equal(scores, expected, check_exact=False, atol=1e-3)
+
+
+def test_permuted_polarization_with_differentially_polarized_markers():
+    # Set seed to get same graph every time
+    graph = create_randomly_connected_bipartite_graph(
+        n1=50, n2=100, p=0.1, random_seed=2
+    )
+
+    random.seed(1)
+    for v in graph.vs:
+        v["markers"] = {"A": 0, "B": 1, "C": 0}
+    random_vertex = graph.vs.get_vertex(random.randint(0, graph.vcount()))
+    random_vertex["markers"]["A"] = 5
+    neighbors = random_vertex.neighbors()
+    for n in neighbors:
+        n["markers"]["A"] = 2
+
+    random_vertex = graph.vs.get_vertex(random.randint(0, graph.vcount()))
+    random_vertex["markers"]["C"] = 10
+
+    np.random.seed(1)
+    scores = polarization_scores_component(graph, component_id="PXLCMP0000000", permutations=999)
+
+    # We don't expect to get a value for B, since it has only one value in it.
+    # Hence it is filtered out.
+    expected = pd.DataFrame.from_dict(
+        {
+            "morans_i": {0: 0.37307837882553935, 1: -0.0037658463832960496},
+            "morans_p_value": {0: 1.317601591958555e-17, 1: 0.5910333410276116},
+            "morans_z": {0: 8.54213868598478, 1: 0.537339187874427},
+            "morans_p_value_sim": {0: 0.001, 1: 0.411},
+            "morans_z_sim": {0: 8.91274668296225, 1: 0.5422508893213437},
+            "marker": {0: "A", 1: "C"},
+            "component": {0: "PXLCMP0000000", 1: "PXLCMP0000000"},
+        }
+    )
+    # test polarization scores
+    assert_frame_equal(scores, expected, check_exact=False, atol=1e-3)
+
+

--- a/tests/analysis/polarization/test_polarization.py
+++ b/tests/analysis/polarization/test_polarization.py
@@ -20,8 +20,10 @@ from tests.graph.igraph.test_tools import create_randomly_connected_bipartite_gr
 @pytest.mark.parametrize("enable_backend", ["igraph", "networkx"], indirect=True)
 def test_polarization(enable_backend, full_graph_edgelist: pd.DataFrame):
     # TODO we should test more scenarios here (sparse and clustered patterns)
-    
-    scores = polarization_scores(edgelist=full_graph_edgelist, permutations=None, use_full_bipartite=True)
+
+    scores = polarization_scores(
+        edgelist=full_graph_edgelist, permutations=0, use_full_bipartite=True
+    )
 
     expected = pd.DataFrame(
         data={
@@ -37,13 +39,15 @@ def test_polarization(enable_backend, full_graph_edgelist: pd.DataFrame):
     # test polarization scores
     assert_frame_equal(scores, expected)
 
-    
+
 @pytest.mark.parametrize("enable_backend", ["networkx"], indirect=True)
 def test_permuted_polarization(enable_backend, full_graph_edgelist: pd.DataFrame):
     # TODO we should test more scenarios here (sparse and clustered patterns)
     np.random.seed(1)
 
-    scores = polarization_scores(edgelist=full_graph_edgelist, permutations=999, use_full_bipartite=True)
+    scores = polarization_scores(
+        edgelist=full_graph_edgelist, permutations=999, use_full_bipartite=True
+    )
 
     expected = pd.DataFrame(
         data={
@@ -116,7 +120,9 @@ def test_permuted_polarization_with_differentially_polarized_markers():
     random_vertex["markers"]["C"] = 10
 
     np.random.seed(1)
-    scores = polarization_scores_component(graph, component_id="PXLCMP0000000", permutations=999)
+    scores = polarization_scores_component(
+        graph, component_id="PXLCMP0000000", permutations=999
+    )
 
     # We don't expect to get a value for B, since it has only one value in it.
     # Hence it is filtered out.
@@ -133,5 +139,3 @@ def test_permuted_polarization_with_differentially_polarized_markers():
     )
     # test polarization scores
     assert_frame_equal(scores, expected, check_exact=False, atol=1e-3)
-
-

--- a/tests/integration/test_small_D21.yaml
+++ b/tests/integration/test_small_D21.yaml
@@ -28,7 +28,7 @@ small-D21:
          "--compute-colocalization",
          "--use-full-bipartite",
          "--polarization-n-permutations",
-         "None",
+         "0",
          "--colocalization-min-region-count",
          "0",
          "--colocalization-n-permutations",

--- a/tests/integration/test_small_D21.yaml
+++ b/tests/integration/test_small_D21.yaml
@@ -27,6 +27,8 @@ small-D21:
          "--compute-polarization",
          "--compute-colocalization",
          "--use-full-bipartite",
+         "--polarization-n-permutations",
+         "None",
          "--colocalization-min-region-count",
          "0",
          "--colocalization-n-permutations",

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -4,27 +4,16 @@ Copyright (c) 2023 Pixelgen Technologies AB.
 
 import numpy as np
 import pandas as pd
-from numpy.testing import assert_allclose, assert_array_almost_equal, assert_array_equal
+from numpy.testing import assert_allclose, assert_array_almost_equal
 from pandas.testing import assert_frame_equal
 
 from pixelator.statistics import (
-    binarize_counts,
     clr_transformation,
     correct_pvalues,
     denoise,
     log1p_transformation,
     rel_normalization,
 )
-
-
-def test_binarize():
-    counts = pd.DataFrame(data=np.array([[1250, 1250], [100, 100]]))
-
-    counts = binarize_counts(df=counts, quantile=0.0)
-    assert_array_equal(
-        counts.to_numpy(),
-        np.array([[1, 1], [0, 0]]),
-    )
 
 
 def test_correct_p_values_basic():


### PR DESCRIPTION
## Description

Implemented permuted polarity scores using the permutation argument available in `esda.moran.Moran()`. Setting `permutations>0` in either of the functions to calculate polarity score (`polarization_scores_component`, `polarization_scores`) will turn on permuted polarity scores and include columns `morans_p_value_sim` and `morans_z_sim` in the resulting dataframe. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested all analysis tests, including new ones for testing the permuted scores specifically. 

## PR checklist:

- [ ] This comment contains a description of changes (with reason).
- [ ] My code follows the style guidelines of this project
- [ ] Make sure your code lints, is well-formatted and type checks
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If you've added a new stage - have you followed the pipeline CLI conventions in the [USAGE guide](../USAGE.md)
- [ ] [README.md](./README.md) is updated
- [ ] If a new tool or package is included, update poetry.lock, [the conda recipe](../conda-recipe/pixelator/meta.yaml) and [cited it properly](../CITATIONS.md)
- [ ] Include any new [authors/contributors](../AUTHORS.md)
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] Usage Documentation is updated
- [ ] If you are doing a [release](../RELEASING.md#Releasing), or a significant change to the code, update [CHANGELOG.md](../CHANGELOG.md)
