### PR TITLE
Check exected groups in leiden cluster test

### DIFF
--- a/tests/annotate/test_annotate.py
+++ b/tests/annotate/test_annotate.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
-from pandas.testing import assert_frame_equal
+
 from anndata import AnnData
 from pixelator.annotate import cluster_components, filter_components_sizes
 from pixelator.cli.annotate import annotate_components
@@ -95,28 +95,18 @@ def test_cluster_components(data_root):
 
     assert not adata.obs["leiden"].empty
 
-    expected = pd.DataFrame.from_dict(
-        {
-            "leiden": {
-                "RCVCMP0000000": 0,
-                "RCVCMP0000002": 3,
-                "RCVCMP0000003": 1,
-                "RCVCMP0000005": 2,
-                "RCVCMP0000006": 0,
-                "RCVCMP0000007": 3,
-                "RCVCMP0000008": 3,
-                "RCVCMP0000010": 6,
-                "RCVCMP0000012": 3,
-                "RCVCMP0000013": 2,
-            }
-        }
-    )
-    expected = expected.astype({"leiden": "category"})
-    expected.index.name = "component"
+    expected_groups = [
+        ["RCVCMP0000000", "RCVCMP0000006"],
+        ["RCVCMP0000007", "RCVCMP0000008", "RCVCMP0000012", "RCVCMP0000002"],
+        ["RCVCMP0000005", "RCVCMP0000013"],
+        ["RCVCMP0000003"],
+        ["RCVCMP0000010"],
+    ]
 
-    assert_frame_equal(
-        pd.DataFrame(adata.obs["leiden"].iloc[:10]), expected, check_categorical=False
-    )
+    # We check the groups to be the same here, because the integer name
+    # of the leiden groups are not the same across runs.
+    for group in expected_groups:
+        assert len(set(adata.obs["leiden"].loc[group])) == 1
 
 
 @pytest.mark.integration_test


### PR DESCRIPTION
## Description

The Leiden cluster test was failing, since the naming of the clusters is not deterministic.

Fixes: EXE-1323

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested by running unit test suite.

## PR checklist:

- [ ] This comment contains a description of changes (with reason).
- [ ] My code follows the style guidelines of this project
- [ ] Make sure your code lints, is well-formatted and type checks
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If you've added a new stage - have you followed the pipeline CLI conventions in the [USAGE guide](../USAGE.md)
- [ ] [README.md](./README.md) is updated
- [ ] If a new tool or package is included, update poetry.lock, [the conda recipe](../conda-recipe/pixelator/meta.yaml) and [cited it properly](../CITATIONS.md)
- [ ] Include any new [authors/contributors](../AUTHORS.md)
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] Usage Documentation is updated
- [ ] If you are doing a [release](../RELEASING.md#Releasing), or a significant change to the code, update [CHANGELOG.md](../CHANGELOG.md)
