### PR TITLE
Fix deflated counts in edgelist after collapse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Performance improvements and reduced bundle size in QC report.
+* Fix deflated counts in the edgelist after collapse.
 
 ## [0.16.1] - 2024-01-12
 

--- a/src/pixelator/cli/analysis.py
+++ b/src/pixelator/cli/analysis.py
@@ -70,7 +70,7 @@ from pixelator.utils import (
 )
 @click.option(
     "--polarization-n-permutations",
-    default=None,
+    default=0,
     required=False,
     type=click.IntRange(min=0),
     show_default=True,

--- a/src/pixelator/collapse/process.py
+++ b/src/pixelator/collapse/process.py
@@ -5,9 +5,9 @@ This module contains functions for the collapse and error correction of MPX data
 
 Copyright (c) 2023 Pixelgen Technologies AB.
 """
-import dataclasses
 import logging
 import tempfile
+import typing
 from collections import Counter, defaultdict
 from typing import (
     Dict,
@@ -48,8 +48,7 @@ UniqueFragmentToUpiB = Dict[UniqueFragment, List[UpiB]]
 UniqueFragmentAndCount = Tuple[str, int]
 
 
-@dataclasses.dataclass(frozen=True, slots=True, repr=True, order=True, eq=True)
-class CollapsedFragment:
+class CollapsedFragment(typing.NamedTuple):
     """A collapsed fragment.
 
     :attr sequence: the consensus sequence for a list of similar fragments
@@ -62,11 +61,6 @@ class CollapsedFragment:
     sequence: str
     unique_fragments_count: int
     reads_count: int
-
-    def __iter__(self) -> Iterable:
-        """Iterate over the dataclass fields."""
-        # Used to support tuple unpacking
-        return iter(dataclasses.asdict(self).values())
 
 
 def build_annoytree(data: npt.NDArray[np.uint8], n_trees: int = 10) -> AnnoyIndex:


### PR DESCRIPTION
Fix an issue were read counts in the edgelist are deflated because the counts of collapsed reads are not taken into account.
Only the reads of unique matches to the corrected read were reported and not the reads of other molecules that have mismatches.

Fixes: EXE-1250

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
