### PR TITLE
Fix bug in calculation of discarded UMIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Performance improvements and reduced bundle size in QC report.
-* Change name and description of `Avg. Reads per Cell` and `Avg. Reads Usable per Cell` in QC report.`
+* Change name and description of `Avg. Reads per Cell` and `Avg. Reads Usable per Cell` in QC report.
+* Fix a bug in how discarded UMIs are calculated and reported.
 * Fix deflated counts in the edgelist after collapse.
 
 ## [0.16.1] - 2024-01-12

--- a/src/pixelator/report/__init__.py
+++ b/src/pixelator/report/__init__.py
@@ -674,8 +674,15 @@ def create_dynamic_report(
         "fraction_predicted_cell_type_unknown": None,
     }
 
+    umi_counts = {
+        "after_collapse": summary_collapse["output_umi"],
+        "after_graph": summary_graph["umi"],
+        "after_annotate": summary_annotate["umi"],
+        "after_cell_calling": summary_cell_calling["total_umis"],
+    }
+
     fraction_discarded_umis = round(
-        summary_cell_calling["umis_of_aggregates"] / summary_cell_calling["total_umis"],
+        1 - (umi_counts["after_cell_calling"] / umi_counts["after_collapse"]),
         2,
     )
 

--- a/src/pixelator/report/__init__.py
+++ b/src/pixelator/report/__init__.py
@@ -676,8 +676,6 @@ def create_dynamic_report(
 
     umi_counts = {
         "after_collapse": summary_collapse["output_umi"],
-        "after_graph": summary_graph["umi"],
-        "after_annotate": summary_annotate["umi"],
         "after_cell_calling": summary_cell_calling["total_umis"],
     }
 

--- a/tests/report/test_report.py
+++ b/tests/report/test_report.py
@@ -339,8 +339,8 @@ def test_create_dynamic_report(tmp_path):
             ),
             summary_preqc=pd.Series({"too_short_reads": 10}),
             summary_demux=pd.Series({"input": 1000, "output": 900}),
-            summary_collapse=pd.Series({"input": 900}),
-            summary_annotate=pd.Series([1]),
+            summary_collapse=pd.Series({"input": 900, "output_umi": 200}),
+            summary_annotate=pd.Series({"umi": 50}),
             summary_graph=pd.Series(
                 {
                     "upia": 16358.0,


### PR DESCRIPTION
<!--
# Pixelgen Technologies pull request template

Many thanks for contributing to it if you think it could be improved. This is a self-improving process!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/PixelgenTechnologies/pixelator/blob/main/CONTRIBUTING.md)
-->

## Description

Calculate discarded UMIs based on data from collapse, graph, annotate and cell calling as opposed to just using discarded aggregates.

Fixes TECH-29

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Generate QC report with updated code by running:

`pixelator single-cell report`

## PR checklist:

- [x] Update [CHANGELOG.md](../CHANGELOG.md)
