### PR TITLE
Remove multi-sample processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix deflated counts in the edgelist after collapse.
 * Improved console output in verbose mode.
 * Improved logging from multiprocessing jobs.
+* Remove multi-sample processing from all `single-cell` subcommands
+* Add `--sample_name` option to `single-cell amplicon` to overwrite the name derived from the input filename.
+
+### Removed
+
+* Remove `--input1_pattern` and `--input2_pattern` from `single-cell amplicon` command.
 
 ## [0.16.1] - 2024-01-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Improved logging from multiprocessing jobs.
 * Remove multi-sample processing from all `single-cell` subcommands
 * Add `--sample_name` option to `single-cell amplicon` to overwrite the name derived from the input filename.
+* Add `--skip-input-checks` option to `single-cell amplicon` to make input filename checks warnings instead of errors.
 
 ### Removed
 

--- a/src/pixelator/cli/amplicon.py
+++ b/src/pixelator/cli/amplicon.py
@@ -17,8 +17,7 @@ from pixelator.utils import (
     create_output_stage_dir,
     get_extension,
     get_read_sample_name,
-    is_r1_read_file,
-    is_r2_read_file,
+    is_read_file,
     log_step_start,
     sanity_check_inputs,
     timer,
@@ -91,9 +90,9 @@ def amplicon(
     # Some checks on the input files
     # - check if there are read 1 and read2 identifiers in the filename
     # - check if the sample name is the same for read1 and read2
-    if not is_r1_read_file(fastq_1):
+    if not is_read_file(fastq_1, "r1"):
         logger.warning("Read 1 file does not contain a recognised read 1 suffix.")
-    if fastq_2 and not is_r2_read_file(fastq_2):
+    if fastq_2 and not is_read_file(fastq_2, "r2"):
         logger.warning("Read 2 file does not contain a recognised read 2 suffix.")
 
     r1_sample_name = get_read_sample_name(fastq_1)

--- a/src/pixelator/cli/amplicon.py
+++ b/src/pixelator/cli/amplicon.py
@@ -3,8 +3,7 @@ Console script for pixelator (amplicon)
 
 Copyright (c) 2022 Pixelgen Technologies AB.
 """
-from concurrent import futures
-from typing import List
+from __future__ import annotations
 
 import click
 
@@ -17,8 +16,7 @@ from pixelator.cli.common import (
 from pixelator.utils import (
     create_output_stage_dir,
     get_extension,
-    get_process_pool_executor,
-    group_input_reads,
+    get_read_sample_name,
     log_step_start,
     sanity_check_inputs,
     timer,
@@ -32,27 +30,29 @@ from pixelator.utils import (
     options_metavar="<options>",
 )
 @click.argument(
-    "input_files",
-    nargs=-1,
+    "fastq_1",
+    nargs=1,
     required=True,
     type=click.Path(exists=True),
-    metavar="FASTQ_FILES",
+    metavar="FASTQ_1",
+)
+@click.argument(
+    "fastq_2",
+    nargs=1,
+    required=False,
+    type=click.Path(exists=True),
+    metavar="FASTQ_2",
 )
 @click.option(
-    "--input1-pattern",
-    default="_R1",
-    required=False,
+    "--sample_name",
+    default=None,
+    show_default=False,
     type=click.STRING,
-    show_default=True,
-    help="The string pattern to use to identify forward (R1) files",
-)
-@click.option(
-    "--input2-pattern",
-    default="_R2",
-    required=False,
-    type=click.STRING,
-    show_default=True,
-    help="The string pattern to use to identify reverse (R2) files",
+    help=(
+        "Override the basename of the output fastq file. "
+        "Default is the basename of the first input file "
+        "without extension and read 1 identifier."
+    ),
 )
 @output_option
 @design_option
@@ -60,9 +60,9 @@ from pixelator.utils import (
 @timer
 def amplicon(
     ctx,
-    input_files: List[str],
-    input1_pattern: str,
-    input2_pattern: str,
+    fastq_1: str,
+    fastq_2: str | None,
+    sample_name: str | None,
     output: str,
     design: str,
 ):
@@ -73,57 +73,36 @@ def amplicon(
 
     log_step_start(
         "amplicon",
-        input_files=input_files,
+        fastq1=fastq_1,
+        fastq_2=fastq_2,
         output=output,
-        input1_pattern=input1_pattern,
-        input2_pattern=input2_pattern,
         design=design,
     )
 
     # some basic sanity check on the input files
-    sanity_check_inputs(input_files, allowed_extensions=("fastq.gz", "fq.gz"))
+    fastq_inputs = [fastq_1] + [fastq_2] if fastq_2 else []
+    sanity_check_inputs(fastq_inputs, allowed_extensions=("fastq.gz", "fq.gz"))
 
     # create output folder if it does not exist
     amplicon_output = create_output_stage_dir(output, "amplicon")
 
-    # group input file by sample id and order reads by R1 and R2
-    grouped_sorted_inputs = group_input_reads(
-        input_files, input1_pattern, input2_pattern
+    sample_name = sample_name or get_read_sample_name(fastq_1)
+    extension = get_extension(fastq_1)
+    output_file = amplicon_output / f"{sample_name}.merged.{extension}"
+    json_file = amplicon_output / f"{sample_name}.report.json"
+
+    write_parameters_file(
+        ctx,
+        amplicon_output / f"{sample_name}.meta.json",
+        command_path="pixelator single-cell amplicon",
     )
 
-    # run amplicon using parallel processing
-    with get_process_pool_executor(ctx) as executor:
-        jobs = []
-        for k, v in grouped_sorted_inputs.items():
-            extension = get_extension(v[0])
-            output_file = amplicon_output / f"{k}.merged.{extension}"
-            json_file = amplicon_output / f"{k}.report.json"
+    msg = f"Creating amplicon for {','.join(str(p) for p in fastq_inputs)}"
+    logger.info(msg)
 
-            write_parameters_file(
-                ctx,
-                amplicon_output / f"{k}.meta.json",
-                command_path="pixelator single-cell amplicon",
-            )
-
-            if len(v) > 2:
-                msg = "Found more files than needed for creating an amplicon"
-                logger.error(msg)
-                raise RuntimeError(msg)
-
-            msg = f"Creating amplicon for {','.join(str(p) for p in v)}"
-            logger.info(msg)
-
-            jobs.append(
-                executor.submit(
-                    amplicon_fastq,
-                    inputs=v,
-                    design=design,
-                    metrics=json_file,
-                    output=str(output_file),
-                )
-            )
-
-        for job in futures.as_completed(jobs):
-            exc = job.exception()
-            if exc is not None:
-                raise exc
+    amplicon_fastq(
+        inputs=fastq_inputs,
+        design=design,
+        metrics=json_file,
+        output=str(output_file),
+    )

--- a/src/pixelator/cli/amplicon.py
+++ b/src/pixelator/cli/amplicon.py
@@ -45,7 +45,7 @@ from pixelator.utils import (
     metavar="FASTQ_2",
 )
 @click.option(
-    "--sample_name",
+    "--sample-name",
     default=None,
     show_default=False,
     type=click.STRING,

--- a/src/pixelator/cli/annotate.py
+++ b/src/pixelator/cli/annotate.py
@@ -3,8 +3,6 @@
 Copyright (c) 2022 Pixelgen Technologies AB.
 """
 
-from concurrent import futures
-
 import click
 
 from pixelator.annotate import annotate_components
@@ -12,7 +10,6 @@ from pixelator.cli.common import logger, output_option
 from pixelator.config import config, load_antibody_panel
 from pixelator.utils import (
     create_output_stage_dir,
-    get_process_pool_executor,
     get_sample_name,
     log_step_start,
     sanity_check_inputs,
@@ -27,8 +24,8 @@ from pixelator.utils import (
     options_metavar="<options>",
 )
 @click.argument(
-    "input_files",
-    nargs=-1,
+    "parquet_file",
+    nargs=1,
     required=True,
     type=click.Path(exists=True),
     metavar="parquet",
@@ -84,7 +81,7 @@ from pixelator.utils import (
 @timer
 def annotate(
     ctx,
-    input_files,
+    parquet_file,
     panel,
     min_size,
     max_size,
@@ -95,6 +92,7 @@ def annotate(
     """
     Filter, annotate and call cells from an edge list
     """
+    input_files = [parquet_file]
     # log input parameters
     log_step_start(
         "annotate",
@@ -136,36 +134,26 @@ def annotate(
     panel = load_antibody_panel(config, panel)
 
     # compute graph/components using parallel processing
-    with get_process_pool_executor(ctx) as executor:
-        jobs = []
-        for ann_file in input_files:
-            logger.info(f"Computing annotation for file {ann_file}")
+    logger.info(f"Computing annotation for file {parquet_file}")
 
-            clean_name = get_sample_name(ann_file)
-            metrics_file = annotate_output / f"{clean_name}.report.json"
+    clean_name = get_sample_name(parquet_file)
+    metrics_file = annotate_output / f"{clean_name}.report.json"
 
-            write_parameters_file(
-                ctx,
-                annotate_output / f"{clean_name}.meta.json",
-                command_path="pixelator single-cell annotate",
-            )
+    write_parameters_file(
+        ctx,
+        annotate_output / f"{clean_name}.meta.json",
+        command_path="pixelator single-cell annotate",
+    )
 
-            jobs.append(
-                executor.submit(
-                    annotate_components,
-                    input=str(ann_file),
-                    panel=panel,
-                    output=str(annotate_output),
-                    output_prefix=clean_name,
-                    metrics_file=str(metrics_file),
-                    min_size=min_size,
-                    max_size=max_size,
-                    dynamic_filter=dynamic_filter,
-                    aggregate_calling=aggregate_calling,
-                    verbose=ctx.obj["VERBOSE"],
-                )
-            )
-
-        for job in futures.as_completed(jobs):
-            if job.exception() is not None:
-                raise job.exception()
+    annotate_components(
+        input=str(parquet_file),
+        panel=panel,
+        output=str(annotate_output),
+        output_prefix=clean_name,
+        metrics_file=str(metrics_file),
+        min_size=min_size,
+        max_size=max_size,
+        dynamic_filter=dynamic_filter,
+        aggregate_calling=aggregate_calling,
+        verbose=ctx.obj["VERBOSE"],
+    )

--- a/src/pixelator/cli/graph.py
+++ b/src/pixelator/cli/graph.py
@@ -3,15 +3,12 @@
 Copyright (c) 2022 Pixelgen Technologies AB.
 """
 
-from concurrent import futures
-
 import click
 
 from pixelator.cli.common import logger, output_option
 from pixelator.graph import connect_components
 from pixelator.utils import (
     create_output_stage_dir,
-    get_process_pool_executor,
     get_sample_name,
     log_step_start,
     sanity_check_inputs,
@@ -26,8 +23,8 @@ from pixelator.utils import (
     options_metavar="<options>",
 )
 @click.argument(
-    "input_files",
-    nargs=-1,
+    "parquet_file",
+    nargs=1,
     required=True,
     type=click.Path(exists=True),
     metavar="parquet",
@@ -66,7 +63,7 @@ from pixelator.utils import (
 @timer
 def graph(
     ctx,
-    input_files,
+    parquet_file,
     multiplet_recovery,
     leiden_iterations,
     min_count,
@@ -74,6 +71,7 @@ def graph(
 ):
     """Compute graph, components and other metrics from an edge list."""
     # log input parameters
+    input_files = [parquet_file]
     log_step_start(
         "graph",
         input_files=input_files,
@@ -90,33 +88,23 @@ def graph(
     graph_output = create_output_stage_dir(output, "graph")
 
     # compute graph/components using parallel processing
-    with get_process_pool_executor(ctx) as executor:
-        jobs = []
-        for pixelsf in input_files:
-            logger.info(f"Computing clusters for file {pixelsf}")
+    logger.info(f"Computing clusters for file {parquet_file}")
 
-            clean_name = get_sample_name(pixelsf)
-            metrics_file = graph_output / f"{clean_name}.report.json"
+    clean_name = get_sample_name(parquet_file)
+    metrics_file = graph_output / f"{clean_name}.report.json"
 
-            write_parameters_file(
-                ctx,
-                graph_output / f"{clean_name}.meta.json",
-                command_path="pixelator single-cell graph",
-            )
+    write_parameters_file(
+        ctx,
+        graph_output / f"{clean_name}.meta.json",
+        command_path="pixelator single-cell graph",
+    )
 
-            jobs.append(
-                executor.submit(
-                    connect_components,
-                    input=pixelsf,
-                    output=str(graph_output),
-                    output_prefix=clean_name,
-                    metrics_file=str(metrics_file),
-                    multiplet_recovery=multiplet_recovery,
-                    leiden_iterations=leiden_iterations,
-                    min_count=min_count,
-                )
-            )
-
-        for job in futures.as_completed(jobs):
-            if job.exception() is not None:
-                raise job.exception()
+    connect_components(
+        input=str(parquet_file),
+        output=str(graph_output),
+        output_prefix=clean_name,
+        metrics_file=str(metrics_file),
+        multiplet_recovery=multiplet_recovery,
+        leiden_iterations=leiden_iterations,
+        min_count=min_count,
+    )

--- a/src/pixelator/config/panel.py
+++ b/src/pixelator/config/panel.py
@@ -1,5 +1,4 @@
-"""
-Marker panel management for different Molecular Pixelation assays
+"""Marker panel management for different Molecular Pixelation assays.
 
 Copyright (c) 2022 Pixelgen Technologies AB.
 """
@@ -8,7 +7,7 @@ from __future__ import annotations
 import warnings
 from functools import cached_property
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, TYPE_CHECKING
 
 import pandas as pd
 import pydantic
@@ -19,16 +18,20 @@ from pixelator.types import PathType
 from pixelator.utils import logger
 
 
+if TYPE_CHECKING:
+    from pixelator.config import Config
+
+
 class AntibodyPanelMetadata(pydantic.BaseModel, extra=Extra.allow):  # type: ignore
+    """Class representing the metadata of a Molecular Pixelation antibody panel."""
+
     version: Optional[str]
     name: Optional[str]
     description: Optional[str]
 
 
 class AntibodyPanel:
-    """
-    Class representing a Molecular Pixelation antibody panel.
-    """
+    """Class representing a Molecular Pixelation antibody panel."""
 
     # required columns
     _REQUIRED_COLUMNS = [
@@ -51,8 +54,7 @@ class AntibodyPanel:
         metadata: AntibodyPanelMetadata,
         file_name: Optional[str] = None,
     ) -> None:
-        """
-        Load a panel from a dataframe and metadata.
+        """Load a panel from a dataframe and metadata.
 
         :param df: The dataframe containing the panel information.
         :param metadata: The metadata for the panel.
@@ -77,8 +79,12 @@ class AntibodyPanel:
 
     @classmethod
     def from_csv(cls, filename: PathType) -> "AntibodyPanel":
-        """
-        Create a AntibodyPanel from a csv panel file
+        """Create an AntibodyPanel from a csv panel file.
+
+        :param filename: The path to the panel file.
+        :returns: The AntibodyPanel object.
+        :raises AssertionError: exception if panel file is missing,
+        :rtype: AntibodyPanel
         """
         panel_file = Path(filename)
 
@@ -98,26 +104,24 @@ class AntibodyPanel:
 
     @property
     def name(self) -> Optional[str]:
-        """
-        The name defined in the panel metadata
-        """
+        """The name defined in the panel metadata."""
         return self._metadata.name
 
     @property
     def version(self) -> Optional[str]:
-        """Return the panel file version"""
+        """Return the panel file version."""
         return self._metadata.version
 
     @property
     def description(self) -> Optional[str]:
-        """Return the panel file description"""
+        """Return the panel file description."""
         return self._metadata.description
 
     @classmethod
-    def validate_antibody_panel(self, panel_df: pd.DataFrame) -> List[str]:
-        """
-        Will perform validation on a antibody panel file, trying to find
-        as many issues as possible.
+    def validate_antibody_panel(self, panel_df: pd.DataFrame) -> list[str]:
+        """Perform validation on an antibody panel file.
+
+        Will try to find as many issues as possible.
 
         This will not directly raise the issue (since that makes it difficult
         to find multiple problems at once) instead it will return a list of str
@@ -131,7 +135,7 @@ class AntibodyPanel:
         ````
 
         :param panel_df: DataFrame with data of the panel to validate
-        :returns: a list of errors (str)
+        :returns list[str]: a list of errors (str)
         """
         errors = []
 
@@ -154,7 +158,6 @@ class AntibodyPanel:
 
     @classmethod
     def _parse_panel(cls, panel_file: Path) -> pd.DataFrame:
-        """"""
         panel = pd.read_csv(str(panel_file), comment="#")
 
         # validate the panel
@@ -174,30 +177,30 @@ class AntibodyPanel:
         return panel.copy()
 
     @classmethod
-    def _transform_legacy_panels(cls, df):
-        """
-        Transform legacy panels to the new format
+    def _transform_legacy_panels(cls, df: pd.DataFrame) -> pd.DataFrame:
+        """Transform legacy panels to the new format.
 
         :param df: DataFrame with data of the panel to validate
-        :returns: The in-place modified input dataframe
+        :returns pd.DataFrame: The in-place modified input dataframe
         """
         df = df.copy()
 
         # update control and nuclear column to boolean
-        TR_TABLE = {"(?i)yes": True, "(?i)no": False}
+        TR_TABLE = {"(?i)yes": "True", "(?i)no": "False"}
 
-        df["control"] = df["control"].replace(TR_TABLE, regex=True)
-        df["control"] = df["control"].fillna(False)
-        df["nuclear"] = df["nuclear"].replace(TR_TABLE, regex=True)
-        df["nuclear"] = df["nuclear"].fillna(False)
-
+        df["control"] = (
+            df["control"].replace(TR_TABLE, regex=True).fillna("False").astype(bool)
+        )
+        df["nuclear"] = (
+            df["nuclear"].replace(TR_TABLE, regex=True).fillna("False").astype(bool)
+        )
         return df
 
     @classmethod
     def _parse_header(cls, file: Path) -> AntibodyPanelMetadata:
-        """
-        Parse front-matter YAML from a file.
+        """Parse front-matter YAML from a file.
 
+        :param file: the file to parse
         :return AntibodyPanelMetadata: a pydantic model with the metadata
         """
         yaml_loader = yaml.YAML(typ="safe")
@@ -222,55 +225,43 @@ class AntibodyPanel:
 
     @cached_property
     def markers_control(self) -> List[str]:
-        """
-        List[str]: list of marker control (names)
-        """
+        """Return a list of marker control (names)."""
         return list(self._df[self._df["control"]].marker_id.unique())
 
     @cached_property
     def markers(self) -> List[str]:
-        """
-        List[str]: list of unique markers
-        """
+        """Return the list of unique markers in the panel."""
         return list(self._df.marker_id.unique())
 
     @property
     def df(self) -> pd.DataFrame:
-        """
-        pd.DataFrame: the panel dataframe
-        """
+        """Return the panel dataframe."""
         return self._df
 
     @property
     def filename(self) -> Optional[str]:
-        """
-        str: filename of the marker panel
-        """
+        """Return the filename of the marker panel."""
         return self._filename
 
     @cached_property
     def size(self) -> int:
-        """
-        int: size of the marker panel
-        """
+        """Return the size of the marker panel."""
         return self._df.shape[0]
 
     def get_marker_id(self, seq: str) -> str:
-        """
-        str: the marker name
-        """
+        """Return the marker name."""
         return self._df.loc[seq].marker_id
 
 
-def load_antibody_panel(config, panel: PathType) -> AntibodyPanel:
-    """
-    Utility function to load an antibody panel from a file or from the config file.
+def load_antibody_panel(config: Config, panel: PathType) -> AntibodyPanel:
+    """Load an antibody panel from a file or from the config file.
 
     :param config: the config object
     :param panel: the path to the panel file or the name of the
         panel in the config file
 
     :returns: the antibody panel
+    :rtype: AntibodyPanel
     """
     panel_str = str(panel)
     panel_from_config = config.get_panel(panel_str)

--- a/src/pixelator/config/panel.py
+++ b/src/pixelator/config/panel.py
@@ -183,18 +183,23 @@ class AntibodyPanel:
         :param df: DataFrame with data of the panel to validate
         :returns pd.DataFrame: The in-place modified input dataframe
         """
-        df = df.copy()
+        new_df = df.copy()
 
         # update control and nuclear column to boolean
-        TR_TABLE = {"(?i)yes": "True", "(?i)no": "False"}
+        TR_TABLE = {"(?i)no": "False", "(?i)yes": "True"}
 
-        df["control"] = (
-            df["control"].replace(TR_TABLE, regex=True).fillna("False").astype(bool)
+        new_df.replace(
+            {
+                "control": TR_TABLE,
+                "nuclear": TR_TABLE,
+            },
+            regex=True,
+            inplace=True,
         )
-        df["nuclear"] = (
-            df["nuclear"].replace(TR_TABLE, regex=True).fillna("False").astype(bool)
-        )
-        return df
+        new_df.fillna({"control": "False", "nuclear": "False"}, inplace=True)
+        new_df["control"] = new_df["control"].map({"True": True, "False": False})
+        new_df["nuclear"] = new_df["nuclear"].map({"True": True, "False": False})
+        return new_df
 
     @classmethod
     def _parse_header(cls, file: Path) -> AntibodyPanelMetadata:

--- a/src/pixelator/utils.py
+++ b/src/pixelator/utils.py
@@ -17,7 +17,17 @@ import typing
 from concurrent import futures
 from functools import wraps
 from pathlib import Path, PurePath
-from typing import Any, Dict, List, Optional, Sequence, Set, TYPE_CHECKING, Union
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    TYPE_CHECKING,
+    Union,
+    Literal,
+)
 
 import click
 import numpy as np
@@ -390,37 +400,29 @@ def get_read_sample_name(read: str) -> str:
     return sample_name
 
 
-def is_r1_read_file(read: str) -> bool:
-    """Check if a read file is a read 1 file.
+def is_read_file(read: str, read_type: Literal["r1"] | Literal["r2"]) -> bool:
+    """Check if a read filename matches the specified read_type.
+
+    Detects the presence of a common read 1 or read 2 suffix in the filename.
 
     :param read: filename of a fastq read file
-    :return bool: True if the read file is a read 1 file
+    :param read_type: the read type to check for (r1 or r2)
+    :return bool: True if the read file is a read 1 or 2 file
     :raise ValueError: if the read file does not have a valid extension
+    :raise AssertionError: if the read_type is not 'r1' or 'r2'
     """
     if not (read.endswith("fq.gz") or read.endswith("fastq.gz")):
         raise ValueError("Invalid file extension: expected .fq.gz or .fastq.gz")
 
-    read_stem = read.removesuffix(get_extension(read, 2)).rstrip(".")
-    matches = re.findall(R"(.[Rr]1|(_[Rr]?1))", read_stem)
-
-    if len(matches) != 1:
-        return False
-
-    return True
-
-
-def is_r2_read_file(read: str) -> bool:
-    """Check if a read file is a read 2 file.
-
-    :param read: filename of a fastq read file
-    :return bool: True if the read file is a read 1 file
-    :raise ValueError: if the read file does not have a valid extension
-    """
-    if not (read.endswith("fq.gz") or read.endswith("fastq.gz")):
-        raise ValueError("Invalid file extension: expected .fq.gz or .fastq.gz")
-
-    read_stem = read.removesuffix(get_extension(read, 2)).rstrip(".")
-    matches = re.findall(R"(.[Rr]2|(_[Rr]?2))", read_stem)
+    matches = []
+    if read_type == "r1":
+        read_stem = read.removesuffix(get_extension(read, 2)).rstrip(".")
+        matches = re.findall(R"(.[Rr]1|(_[Rr]?1))", read_stem)
+    elif read_type == "r2":
+        read_stem = read.removesuffix(get_extension(read, 2)).rstrip(".")
+        matches = re.findall(R"(.[Rr]2|(_[Rr]?2))", read_stem)
+    else:
+        raise AssertionError("Invalid read type: expected 'r1' or 'r2'")
 
     if len(matches) != 1:
         return False

--- a/src/pixelator/utils.py
+++ b/src/pixelator/utils.py
@@ -380,7 +380,7 @@ def get_read_sample_name(read: str) -> str:
         raise ValueError("Invalid file extension: expected .fq.gz or .fastq.gz")
 
     read_stem = read.removesuffix(get_extension(read, 2)).rstrip(".")
-    matches = re.findall(R"(.[Rr][12]|(_[Rr]?[12]))$", read_stem)
+    matches = re.findall(R"(.[Rr][12]|(_[Rr]?[12]))", read_stem)
     if len(matches) != 1:
         raise ValueError("Invalid R1/R2 suffix.")
 

--- a/src/pixelator/utils.py
+++ b/src/pixelator/utils.py
@@ -379,7 +379,8 @@ def get_read_sample_name(read: str) -> str:
     if not (read.endswith("fq.gz") or read.endswith("fastq.gz")):
         raise ValueError("Invalid file extension: expected .fq.gz or .fastq.gz")
 
-    read_stem = read.removesuffix(get_extension(read, 2)).rstrip(".")
+    read_stem = Path(read).name
+    read_stem = read_stem.removesuffix(get_extension(read_stem, 2)).rstrip(".")
     matches = re.findall(R"(.[Rr][12]|(_[Rr]?[12]))", read_stem)
     if len(matches) != 1:
         raise ValueError("Invalid R1/R2 suffix.")
@@ -387,3 +388,41 @@ def get_read_sample_name(read: str) -> str:
     pattern, pos = matches[0]
     sample_name = read_stem.replace(pattern, "")
     return sample_name
+
+
+def is_r1_read_file(read: str) -> bool:
+    """Check if a read file is a read 1 file.
+
+    :param read: filename of a fastq read file
+    :return bool: True if the read file is a read 1 file
+    :raise ValueError: if the read file does not have a valid extension
+    """
+    if not (read.endswith("fq.gz") or read.endswith("fastq.gz")):
+        raise ValueError("Invalid file extension: expected .fq.gz or .fastq.gz")
+
+    read_stem = read.removesuffix(get_extension(read, 2)).rstrip(".")
+    matches = re.findall(R"(.[Rr]1|(_[Rr]?1))", read_stem)
+
+    if len(matches) != 1:
+        return False
+
+    return True
+
+
+def is_r2_read_file(read: str) -> bool:
+    """Check if a read file is a read 2 file.
+
+    :param read: filename of a fastq read file
+    :return bool: True if the read file is a read 1 file
+    :raise ValueError: if the read file does not have a valid extension
+    """
+    if not (read.endswith("fq.gz") or read.endswith("fastq.gz")):
+        raise ValueError("Invalid file extension: expected .fq.gz or .fastq.gz")
+
+    read_stem = read.removesuffix(get_extension(read, 2)).rstrip(".")
+    matches = re.findall(R"(.[Rr]2|(_[Rr]?2))", read_stem)
+
+    if len(matches) != 1:
+        return False
+
+    return True

--- a/src/pixelator/utils.py
+++ b/src/pixelator/utils.py
@@ -21,12 +21,12 @@ from typing import (
     Any,
     Dict,
     List,
+    Literal,
     Optional,
     Sequence,
     Set,
     TYPE_CHECKING,
     Union,
-    Literal,
 )
 
 import click

--- a/tests/amplicon/test_cli.py
+++ b/tests/amplicon/test_cli.py
@@ -3,7 +3,7 @@ Test the pixelator single-cell amplicon CLI.
 
 Copyright (c) 2022 Pixelgen Technologies AB.
 """
-
+import os
 import shutil
 import tempfile
 from pathlib import Path
@@ -39,8 +39,10 @@ def test_fastq_valid_inputs(mocker, uropod_reads):
     runner = CliRunner()
 
     mocker.patch("pixelator.cli.amplicon.amplicon_fastq")
+    pwd = Path.cwd()
 
     with tempfile.TemporaryDirectory() as d:
+        os.chdir(d)
         cmd = runner.invoke(
             cli.main_cli,
             [
@@ -58,8 +60,10 @@ def test_fastq_valid_inputs(mocker, uropod_reads):
     assert cmd.exit_code == 0
     assert pixelator.cli.amplicon.amplicon_fastq.called
 
+    os.chdir(pwd)
 
-def test_fastq_swapped_read_input(mocker, uropod_reads):
+
+def test_fastq_swapped_read_input(mocker, uropod_reads, tmp_path):
     runner = CliRunner()
 
     mocker.patch("pixelator.cli.amplicon.amplicon_fastq")

--- a/tests/amplicon/test_cli.py
+++ b/tests/amplicon/test_cli.py
@@ -11,7 +11,6 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
-import pixelator.amplicon.process
 from pixelator import cli
 
 
@@ -24,43 +23,54 @@ def uropod_reads(data_root):
 
 
 @pytest.fixture()
+def run_in_tmpdir():
+    """Run a function in a temporary directory."""
+    old_cwd = Path.cwd()
+
+    with tempfile.TemporaryDirectory() as d:
+        os.chdir(d)
+        yield d
+        os.chdir(old_cwd)
+
+
+@pytest.fixture()
 def uropod_reads_sample_mismatch(data_root):
     r1 = data_root / "uropod_control_300k_S1_R1_001.fastq.gz"
     r2 = data_root / "uropod_control_300k_S1_R2_001.fastq.gz"
 
+    pwd = Path.cwd()
+
     with tempfile.TemporaryDirectory() as d:
+        os.chdir(d)
         r1_cpy = shutil.copy(r1, Path(d) / "uropod_control_R1.fastq.gz")
         r2_cpy = shutil.copy(r2, Path(d) / "uropod_typo_R2.fastq.gz")
 
         yield (r1_cpy, r2_cpy)
 
+    os.chdir(pwd)
 
-def test_fastq_valid_inputs(mocker, uropod_reads):
+
+def test_fastq_valid_inputs(mocker, uropod_reads, run_in_tmpdir):
     runner = CliRunner()
 
     mocker.patch("pixelator.cli.amplicon.amplicon_fastq")
-    pwd = Path.cwd()
 
     with tempfile.TemporaryDirectory() as d:
-        os.chdir(d)
-        cmd = runner.invoke(
-            cli.main_cli,
-            [
-                "single-cell",
-                "amplicon",
-                str(uropod_reads[0]),
-                str(uropod_reads[1]),
-                "--output",
-                str(d),
-                "--design",
-                "D21",
-            ],
-        )
+        args = [
+            "single-cell",
+            "amplicon",
+            str(uropod_reads[0]),
+            str(uropod_reads[1]),
+            "--output",
+            str(d),
+            "--design",
+            "D21",
+        ]
+        cmd = runner.invoke(cli.main_cli, args)
+        assert cmd.exit_code == 0
 
-    assert cmd.exit_code == 0
-    assert pixelator.cli.amplicon.amplicon_fastq.called
-
-    os.chdir(pwd)
+        cmd = runner.invoke(cli.main_cli, args + ["--skip-input-checks"])
+        assert cmd.exit_code == 0
 
 
 def test_fastq_swapped_read_input(mocker, uropod_reads, tmp_path):
@@ -69,12 +79,30 @@ def test_fastq_swapped_read_input(mocker, uropod_reads, tmp_path):
     mocker.patch("pixelator.cli.amplicon.amplicon_fastq")
 
     with tempfile.TemporaryDirectory() as d:
+        args = [
+            "single-cell",
+            "amplicon",
+            str(uropod_reads[1]),
+            str(uropod_reads[0]),
+            "--output",
+            str(d),
+            "--design",
+            "D21",
+        ]
+        cmd = runner.invoke(cli.main_cli, args)
+
+        assert cmd.exit_code != 0
+        assert (
+            "ERROR: Read 1 file does not contain a recognised read 1 suffix."
+            in cmd.output
+        )
+
         cmd = runner.invoke(
             cli.main_cli,
             [
                 "single-cell",
                 "amplicon",
-                str(uropod_reads[1]),
+                str(uropod_reads[0]),
                 str(uropod_reads[0]),
                 "--output",
                 str(d),
@@ -83,38 +111,34 @@ def test_fastq_swapped_read_input(mocker, uropod_reads, tmp_path):
             ],
         )
 
-    assert cmd.exit_code == 0
-    assert (
-        "WARNING: Read 1 file does not contain a recognised read 1 suffix."
-        in cmd.output
-    )
-    assert (
-        "WARNING: Read 2 file does not contain a recognised read 2 suffix."
-        in cmd.output
-    )
-    assert pixelator.cli.amplicon.amplicon_fastq.called
+        assert (
+            "ERROR: Read 2 file does not contain a recognised read 2 suffix."
+            in cmd.output
+        )
+
+        cmd = runner.invoke(cli.main_cli, args + ["--skip-input-checks"])
+        assert cmd.exit_code == 0
 
 
 def test_fastq_sample_name_mismatch(mocker, uropod_reads_sample_mismatch):
     runner = CliRunner()
-
     mocker.patch("pixelator.cli.amplicon.amplicon_fastq")
 
     with tempfile.TemporaryDirectory() as d:
-        cmd = runner.invoke(
-            cli.main_cli,
-            [
-                "single-cell",
-                "amplicon",
-                str(uropod_reads_sample_mismatch[0]),
-                str(uropod_reads_sample_mismatch[1]),
-                "--output",
-                str(d),
-                "--design",
-                "D21",
-            ],
-        )
+        args = [
+            "single-cell",
+            "amplicon",
+            str(uropod_reads_sample_mismatch[0]),
+            str(uropod_reads_sample_mismatch[1]),
+            "--output",
+            str(d),
+            "--design",
+            "D21",
+        ]
+        cmd = runner.invoke(cli.main_cli, args)
 
-    assert cmd.exit_code == 0
-    assert "WARNING: The sample name for read1 and read2 is different" in cmd.output
-    assert pixelator.cli.amplicon.amplicon_fastq.called
+        assert cmd.exit_code != 0
+        assert "ERROR: The sample name for read1 and read2 is different" in cmd.output
+
+        cmd = runner.invoke(cli.main_cli, args + ["--skip-input-checks"])
+        assert cmd.exit_code == 0

--- a/tests/amplicon/test_cli.py
+++ b/tests/amplicon/test_cli.py
@@ -1,0 +1,116 @@
+"""
+Test the pixelator single-cell amplicon CLI.
+
+Copyright (c) 2022 Pixelgen Technologies AB.
+"""
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+import pixelator.amplicon.process
+from pixelator import cli
+
+
+@pytest.fixture()
+def uropod_reads(data_root):
+    """Paired end reads from Uropod control sample."""
+    r1 = data_root / "uropod_control_300k_S1_R1_001.fastq.gz"
+    r2 = data_root / "uropod_control_300k_S1_R2_001.fastq.gz"
+    return r1, r2
+
+
+@pytest.fixture()
+def uropod_reads_sample_mismatch(data_root):
+    r1 = data_root / "uropod_control_300k_S1_R1_001.fastq.gz"
+    r2 = data_root / "uropod_control_300k_S1_R2_001.fastq.gz"
+
+    with tempfile.TemporaryDirectory() as d:
+        r1_cpy = shutil.copy(r1, Path(d) / "uropod_control_R1.fastq.gz")
+        r2_cpy = shutil.copy(r2, Path(d) / "uropod_typo_R2.fastq.gz")
+
+        yield (r1_cpy, r2_cpy)
+
+
+def test_fastq_valid_inputs(mocker, uropod_reads):
+    runner = CliRunner()
+
+    mocker.patch("pixelator.cli.amplicon.amplicon_fastq")
+
+    with tempfile.TemporaryDirectory() as d:
+        cmd = runner.invoke(
+            cli.main_cli,
+            [
+                "single-cell",
+                "amplicon",
+                str(uropod_reads[0]),
+                str(uropod_reads[1]),
+                "--output",
+                str(d),
+                "--design",
+                "D21",
+            ],
+        )
+
+    assert cmd.exit_code == 0
+    assert pixelator.cli.amplicon.amplicon_fastq.called
+
+
+def test_fastq_swapped_read_input(mocker, uropod_reads):
+    runner = CliRunner()
+
+    mocker.patch("pixelator.cli.amplicon.amplicon_fastq")
+
+    with tempfile.TemporaryDirectory() as d:
+        cmd = runner.invoke(
+            cli.main_cli,
+            [
+                "single-cell",
+                "amplicon",
+                str(uropod_reads[1]),
+                str(uropod_reads[0]),
+                "--output",
+                str(d),
+                "--design",
+                "D21",
+            ],
+        )
+
+    assert cmd.exit_code == 0
+    assert (
+        "WARNING: Read 1 file does not contain a recognised read 1 suffix."
+        in cmd.output
+    )
+    assert (
+        "WARNING: Read 2 file does not contain a recognised read 2 suffix."
+        in cmd.output
+    )
+    assert pixelator.cli.amplicon.amplicon_fastq.called
+
+
+def test_fastq_sample_name_mismatch(mocker, uropod_reads_sample_mismatch):
+    runner = CliRunner()
+
+    mocker.patch("pixelator.cli.amplicon.amplicon_fastq")
+
+    with tempfile.TemporaryDirectory() as d:
+        cmd = runner.invoke(
+            cli.main_cli,
+            [
+                "single-cell",
+                "amplicon",
+                str(uropod_reads_sample_mismatch[0]),
+                str(uropod_reads_sample_mismatch[1]),
+                "--output",
+                str(d),
+                "--design",
+                "D21",
+            ],
+        )
+
+    assert cmd.exit_code == 0
+    assert "WARNING: The sample name for read1 and read2 is different" in cmd.output
+    assert pixelator.cli.amplicon.amplicon_fastq.called

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -167,3 +167,6 @@ def test_get_read_sample_name():
     assert get_read_sample_name("sample1.r2.fq.gz") == "sample1"
     assert get_read_sample_name("sample1.R1.fq.gz") == "sample1"
     assert get_read_sample_name("sample1.R2.fq.gz") == "sample1"
+
+    assert get_read_sample_name("sample1_R1_L001.fq.gz") == "sample1"
+    assert get_read_sample_name("sample1_R2_L001.fq.gz") == "sample1"

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -13,6 +13,7 @@ import pytest
 from pixelator import __version__
 from pixelator.cli.logging import LoggingSetup
 from pixelator.utils import (
+    get_read_sample_name,
     gz_size,
     log_step_start,
     sanity_check_inputs,
@@ -146,3 +147,23 @@ def test_multiprocess_logging(verbose):
         assert "This is a warning message" in log_content
         assert "This is an error message" in log_content
         assert "This is a critical message" in log_content
+
+
+def test_get_read_sample_name():
+    with pytest.raises(ValueError, match="Invalid file extension.*"):
+        get_read_sample_name("qwdwqwdqwd")
+
+    with pytest.raises(ValueError, match="Invalid R1/R2 suffix."):
+        get_read_sample_name("qwdwqwdqwd.fq.gz")
+
+    assert get_read_sample_name("sample1_1.fq.gz") == "sample1"
+    assert get_read_sample_name("sample1_2.fq.gz") == "sample1"
+
+    assert get_read_sample_name("sample1_R1.fq.gz") == "sample1"
+    assert get_read_sample_name("sample1_R2.fq.gz") == "sample1"
+    assert get_read_sample_name("sample1_r1.fq.gz") == "sample1"
+    assert get_read_sample_name("sample1_r2.fq.gz") == "sample1"
+    assert get_read_sample_name("sample1.r1.fq.gz") == "sample1"
+    assert get_read_sample_name("sample1.r2.fq.gz") == "sample1"
+    assert get_read_sample_name("sample1.R1.fq.gz") == "sample1"
+    assert get_read_sample_name("sample1.R2.fq.gz") == "sample1"

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -14,6 +14,7 @@ from pixelator import __version__
 from pixelator.cli.logging import LoggingSetup
 from pixelator.utils import (
     get_read_sample_name,
+    is_read_file,
     gz_size,
     log_step_start,
     sanity_check_inputs,
@@ -170,3 +171,33 @@ def test_get_read_sample_name():
 
     assert get_read_sample_name("sample1_R1_L001.fq.gz") == "sample1_L001"
     assert get_read_sample_name("sample1_R2_L001.fq.gz") == "sample1_L001"
+
+
+def test_is_read_file():
+    with pytest.raises(ValueError, match="Invalid file extension.*"):
+        is_read_file("qwdwqwdqwd", read_type="r1")
+
+    with pytest.raises(
+        AssertionError, match="Invalid read type: expected 'r1' or 'r2'"
+    ):
+        is_read_file("sample1.r1.fq.gz", read_type="qdqwdqw")
+
+    for r1_check in [
+        "sample1_1.fq.gz",
+        "sample1_R1.fq.gz",
+        "sample1_r1.fq.gz",
+        "sample1.r1.fq.gz",
+        "sample1.R1.fq.gz",
+    ]:
+        assert is_read_file(r1_check, read_type="r1")
+        assert not is_read_file(r1_check, read_type="r2")
+
+    for r2_check in [
+        "sample1_2.fq.gz",
+        "sample1_R2.fq.gz",
+        "sample1_r2.fq.gz",
+        "sample1.r2.fq.gz",
+        "sample1.R2.fq.gz",
+    ]:
+        assert is_read_file(r2_check, read_type="r2")
+        assert not is_read_file(r2_check, read_type="r1")

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -168,5 +168,5 @@ def test_get_read_sample_name():
     assert get_read_sample_name("sample1.R1.fq.gz") == "sample1"
     assert get_read_sample_name("sample1.R2.fq.gz") == "sample1"
 
-    assert get_read_sample_name("sample1_R1_L001.fq.gz") == "sample1"
-    assert get_read_sample_name("sample1_R2_L001.fq.gz") == "sample1"
+    assert get_read_sample_name("sample1_R1_L001.fq.gz") == "sample1_L001"
+    assert get_read_sample_name("sample1_R2_L001.fq.gz") == "sample1_L001"


### PR DESCRIPTION
## Description

Remove parallel processing of multiple samples in a single command. 
This feature is better handled by using the nextflow pipeline.

The only parallel handling remaining on the input file level is in collapse to deal with the demuxed fastq files.

The `amplicon` subcommand interface is changed: 
The also removes `--input1-pattern` and `--input2-pattern` since these have become redundant.
Add a --sample-name flag to use a custom output filename instead of extracting a sample name from the input fastq files.

Fixes: EXE-1341

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)