### PR TITLE
The edgelist will now be collected only once in the parent functions …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix deflated counts in the edgelist after collapse.
 * Improved console output in verbose mode.
 * Improved logging from multiprocessing jobs.
+* Improved runtime for graph synthesis.
 
 ## [0.16.1] - 2024-01-12
 


### PR DESCRIPTION
## Description

A small change in the implementation of the pixelator Graph that does not affect the usage of functions. The collect() function from polars that converts a LazyFrame to a DataFrame in the memory is the main speed bottleneck of Graph.from_edgelist method; the code is as a result modified to only call it once for each graph construction and pass on the DataFrame instead of the LazyFrame to the subsequent functions.


Fixes # EXE-1318

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Graph.from_edgelist method with all different combinations of simplify, use_full_bipartite, and add_marker_counts. Unit tests and the small workflow test are run. 

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] My code follows the style guidelines of this project
- [x] Make sure your code lints, is well-formatted and type checks
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
