### PR TITLE
Sample name matching should only match file name, not full path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Remove `--input1_pattern` and `--input2_pattern` from `single-cell amplicon` command.
 
+### Fixed
+
+* Fix bug where an `r1` or `r2` in the directory part of a read file would break file
+  name sanity checks.
+
 ## [0.16.1] - 2024-01-12
 
 ### Fixed

--- a/src/pixelator/utils.py
+++ b/src/pixelator/utils.py
@@ -415,11 +415,10 @@ def is_read_file(read: str, read_type: Literal["r1"] | Literal["r2"]) -> bool:
         raise ValueError("Invalid file extension: expected .fq.gz or .fastq.gz")
 
     matches = []
+    read_stem = Path(read.removesuffix(get_extension(read, 2)).rstrip(".")).name
     if read_type == "r1":
-        read_stem = read.removesuffix(get_extension(read, 2)).rstrip(".")
         matches = re.findall(R"(.[Rr]1|(_[Rr]?1))", read_stem)
     elif read_type == "r2":
-        read_stem = read.removesuffix(get_extension(read, 2)).rstrip(".")
         matches = re.findall(R"(.[Rr]2|(_[Rr]?2))", read_stem)
     else:
         raise AssertionError("Invalid read type: expected 'r1' or 'r2'")

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -201,3 +201,13 @@ def test_is_read_file():
     ]:
         assert is_read_file(r2_check, read_type="r2")
         assert not is_read_file(r2_check, read_type="r1")
+
+
+def test_is_read_file_should_be_ok_when_r1_or_r2_in_dir_name():
+    # not the r1 in the directory name
+    file_name = "/tmp/tmp5r1eg53r/uropod_control_R1.fastq.gz"
+    assert is_read_file(file_name, "r1")
+
+    # not the r2 in the directory name
+    file_name = "/tmp/tmp5r2eg53r/uropod_control_R1.fastq.gz"
+    assert is_read_file(file_name, "r1")


### PR DESCRIPTION
## Description

Sample name matching should only match file name, not full path.

Fixes: EXE-1390 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit tests.

## PR checklist:

- [ ] This comment contains a description of changes (with reason).
- [ ] My code follows the style guidelines of this project
- [ ] Make sure your code lints, is well-formatted and type checks
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If you've added a new stage - have you followed the pipeline CLI conventions in the [USAGE guide](../USAGE.md)
- [ ] [README.md](./README.md) is updated
- [ ] If a new tool or package is included, update poetry.lock, [the conda recipe](../conda-recipe/pixelator/meta.yaml) and [cited it properly](../CITATIONS.md)
- [ ] Include any new [authors/contributors](../AUTHORS.md)
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] Usage Documentation is updated
- [ ] If you are doing a [release](../RELEASING.md#Releasing), or a significant change to the code, update [CHANGELOG.md](../CHANGELOG.md)
