### PR TITLE
Add __repr__ method to graph

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,4 +9,4 @@ arg-type-hints-in-signature = True
 arg-type-hints-in-docstring = False
 # Ignore documentation linting in tests
 per-file-ignores =
-    tests/**: DOC
+    tests/**: DOC, D

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add `--sample_name` option to `single-cell amplicon` to overwrite the name derived from the input filename.
 * Add `--skip-input-checks` option to `single-cell amplicon` to make input filename checks warnings instead of errors.
 * Pixeldatasets are now written to disk without creating intermediate files on-disk.
+* A nice string representation for the `Graph` class, to let you know how many nodes and edges there are in the
+  current graph object instance.
 
 ### Removed
 

--- a/src/pixelator/graph/graph.py
+++ b/src/pixelator/graph/graph.py
@@ -271,3 +271,7 @@ class Graph:
                             of different length
         """
         self._backend.add_names_to_vertexes(vs_names=vs_names)
+
+    def __repr__(self) -> str:
+        """Return a string representation of the graph."""
+        return f"Graph with {self.vcount()} vertices and {self.ecount()} edges"

--- a/tests/graph/test_graph.py
+++ b/tests/graph/test_graph.py
@@ -2,6 +2,7 @@
 
 Copyright (c) 2023 Pixelgen Technologies AB.
 """
+
 import random
 from unittest.mock import MagicMock
 
@@ -603,3 +604,7 @@ def test_layout_coordinates_caches(pentagram_graph):
     # If caching works as intended the backend should only be
     # hit once.
     mock_layout_method.assert_called_once()
+
+
+def test__repr__(pentagram_graph):
+    assert repr(pentagram_graph) == "Graph with 5 vertices and 5 edges"


### PR DESCRIPTION
## Description

Adds a `__repr__` method to the `Graph` class to give some nice output in e.g. jupyter notebooks.

Fixes: EXE-915

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Unit tests and by trying it in ipython.
