### PR TITLE
Add step names to pxl file names

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,6 @@ repos:
     hooks:
       - id: black
 
-
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.
     rev: "v0.2.1"
@@ -27,7 +26,6 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
-          - flake8-docstrings
           - pydoclint
 
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add `--skip-input-checks` option to `single-cell amplicon` to make input filename checks warnings instead of errors.
 * Pixeldatasets are now written to disk without creating intermediate files on-disk.
 
+### Changed
+
+* The output name of the `.pxl` file from the `annotate` step is now `*.annotated.dataset.pxl`
+* The output name of the `.pxl` file from the `analysis` step is now `*.analysis.dataset.pxl`
+
+
 ### Removed
 
 * Remove `--input1_pattern` and `--input2_pattern` from `single-cell amplicon` command.

--- a/src/pixelator/analysis/__init__.py
+++ b/src/pixelator/analysis/__init__.py
@@ -2,6 +2,7 @@
 
 Copyright (c) 2022 Pixelgen Technologies AB.
 """
+
 import json
 import logging
 from dataclasses import asdict, dataclass
@@ -136,7 +137,7 @@ def analyse_pixels(
         )
     }
     # save dataset
-    dataset.save(str(Path(output) / f"{output_prefix}.dataset.pxl"))
+    dataset.save(str(Path(output) / f"{output_prefix}.analysis.dataset.pxl"))
 
     # save metrics (JSON)
     with open(metrics_file, "w") as outfile:

--- a/src/pixelator/annotate/__init__.py
+++ b/src/pixelator/annotate/__init__.py
@@ -225,7 +225,7 @@ def annotate_components(
     adata.uns["version"] = __version__
     metadata = {"version": __version__, "sample": output_prefix}
     dataset = PixelDataset.from_data(edgelist=edgelist, adata=adata, metadata=metadata)
-    dataset.save(str(Path(output) / f"{output_prefix}.dataset.pxl"))
+    dataset.save(str(Path(output) / f"{output_prefix}.annotate.dataset.pxl"))
 
     # save metrics (JSON)
     with open(metrics_file, "w") as outfile:

--- a/src/pixelator/report/__init__.py
+++ b/src/pixelator/report/__init__.py
@@ -502,7 +502,7 @@ def cell_calling_metrics(path: str) -> pd.DataFrame:
         raise AssertionError(f"annotate folder missing in {path}")
 
     # collect the dataset files (filtered)
-    files = list(source_path.glob("*.dataset.pxl"))
+    files = list(source_path.glob("*.annotate.dataset.pxl"))
     if files is None or len(files) == 0:
         raise AssertionError(
             f"No dataset files found in {source_path}. Did you run annotate?"

--- a/src/pixelator/report/qcreport/collect.py
+++ b/src/pixelator/report/qcreport/collect.py
@@ -2,6 +2,7 @@
 
 Copyright (c) 2022 Pixelgen Technologies AB.
 """
+
 import json
 import logging
 import typing
@@ -307,7 +308,7 @@ def collect_report_data(input_path: str, sample_id: str) -> QCReportData:
         raise NotADirectoryError(f"annotate folder missing in {source_path}")
 
     # parse filtered dataset
-    dataset_file = source_path / f"{sample_id}.dataset.pxl"
+    dataset_file = source_path / f"{sample_id}.annotate.dataset.pxl"
     if not dataset_file.is_file():
         raise FileExistsError(f"dataset file {dataset_file} not found")
 

--- a/src/pixelator/test_utils/analysis.py
+++ b/src/pixelator/test_utils/analysis.py
@@ -1,4 +1,5 @@
 """Copyright (c) 2023 Pixelgen Technologies AB."""
+
 import logging
 
 import pytest
@@ -25,7 +26,10 @@ class BaseAnalysisTestsMixin(BaseWorkflowTestMixin):
         params = self.__get_parameters()
         verbose = self.__get_options("common").get("verbose")
         input_files = list(
-            map(lambda f: str(f), (self.workdir / "annotate").glob("*.dataset.pxl"))
+            map(
+                lambda f: str(f),
+                (self.workdir / "annotate").glob("*.annotate.dataset.pxl"),
+            )
         )
 
         command = [
@@ -50,7 +54,7 @@ class BaseAnalysisTestsMixin(BaseWorkflowTestMixin):
 
     @pytest.mark.dependency(depends=["test_analysis_run"])
     def test_analysis_dataset_exists(self):
-        pxl_files = (self.workdir / "analysis").glob("*.dataset.pxl")
+        pxl_files = (self.workdir / "analysis").glob("*.analysis.dataset.pxl")
         for f in pxl_files:
             assert f.is_file()
 

--- a/src/pixelator/test_utils/annotate.py
+++ b/src/pixelator/test_utils/annotate.py
@@ -2,6 +2,7 @@
 
 Copyright (c) 2023 Pixelgen Technologies AB.
 """
+
 import logging
 from pathlib import Path
 
@@ -68,7 +69,7 @@ class BaseAnnotateTestsMixin(BaseWorkflowTestMixin):
     @pytest.mark.dependency(depends=["test_annotate_run"])
     def test_annotate_dataset_exists(self):
         """Check that the pixel file is created."""
-        dataset_files = (self.workdir / "annotate").glob("*.dataset.pxl")
+        dataset_files = (self.workdir / "annotate").glob("*.annotate.dataset.pxl")
         for f in dataset_files:
             assert f.is_file()
 

--- a/tests/annotate/test_annotate.py
+++ b/tests/annotate/test_annotate.py
@@ -133,5 +133,5 @@ def test_annotate_adata(edgelist: pd.DataFrame, tmp_path: Path, panel: AntibodyP
         aggregate_calling=True,
     )
     assert (tmp_path / f"{output_prefix}.raw_components_metrics.csv.gz").is_file()
-    assert (tmp_path / f"{output_prefix}.dataset.pxl").is_file()
+    assert (tmp_path / f"{output_prefix}.annotate.dataset.pxl").is_file()
     assert metrics_file.is_file()

--- a/tests/report/test_report.py
+++ b/tests/report/test_report.py
@@ -3,6 +3,7 @@ Tests for the report.py module
 
 Copyright (c) 2022 Pixelgen Technologies AB.
 """
+
 import json
 from pathlib import Path
 from unittest import mock
@@ -247,8 +248,8 @@ def test_cell_calling_metrics(adata: AnnData, edgelist: pd.DataFrame, tmp_path: 
 
     input_path = tmp_path / "annotate"
     input_path.mkdir(parents=True, exist_ok=True)
-    dataset.save(str(input_path / "Sample1_01.dataset.pxl"))
-    dataset.save(str(input_path / "Sample2_02.dataset.pxl"))
+    dataset.save(str(input_path / "Sample1_01.annotate.dataset.pxl"))
+    dataset.save(str(input_path / "Sample2_02.annotate.dataset.pxl"))
 
     res = cell_calling_metrics(str(tmp_path))
 


### PR DESCRIPTION
## Description

This adds the stage name, i.e. `annotate`/`analysis` the the names of pixel files when they are generated by their respective commands.

Fixes: EXE-1347

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Using the unit test suite.
