### PR TITLE
Speed up init time by making some imports dynamic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.pytest.ini_options]
 pythonpath = [ "src" ]
+testpaths = [ "tests" ]
 markers = [
     "integration_test: Marks a test as an integration test, which is often slow (deselect with '-m \"not integration_test\"')",
     "workflow_test: Marks a test as a complete pixelator workflow, which is extremely slow (deselect with '-m \"not workflow_test\"')"]

--- a/src/pixelator/annotate/__init__.py
+++ b/src/pixelator/annotate/__init__.py
@@ -13,9 +13,7 @@ import numba
 import numpy as np
 import pandas as pd
 import polars as pl
-import scanpy as sc
 from anndata import AnnData
-from graspologic.partition import leiden
 
 from pixelator import __version__
 from pixelator.annotate.aggregates import call_aggregates
@@ -236,6 +234,9 @@ def _cluster_components_using_leiden(
     adata: AnnData, resolution: float = 1.0, random_seed: Optional[int] = None
 ) -> None:
     """Carry out a leiden clustering on the components."""
+    # Import here since the import is very slow and expensive
+    from graspologic.partition import leiden
+
     g = nx.from_scipy_sparse_array(adata.obsp["connectivities"])
     partitions = leiden(g, resolution=resolution, random_seed=random_seed)
     partitions_df = pd.DataFrame.from_dict(partitions, orient="index").sort_index()
@@ -273,6 +274,9 @@ def cluster_components(
     :rtype: Optional[AnnData]
     :raises: AssertionError if `obsmkey` is missing
     """
+    # Import here as it is a slow import
+    import scanpy as sc
+
     if obsmkey not in adata.obsm:
         raise AssertionError(f"Input AnnData is missing '{obsmkey}'")
 

--- a/src/pixelator/graph/backends/implementations/_networkx.py
+++ b/src/pixelator/graph/backends/implementations/_networkx.py
@@ -27,12 +27,6 @@ import pandas as pd
 import polars as pl
 import scipy as sp
 
-with warnings.catch_warnings():
-    # Graspologic raises a numba related warning here, that we can
-    # safely ignore.
-    warnings.filterwarnings("ignore", module="graspologic.models.edge_swaps")
-    from graspologic.partition import leiden
-
 from networkx.algorithms import bipartite as nx_bipartite
 from scipy.sparse import csr_matrix
 
@@ -284,6 +278,13 @@ class NetworkXGraphBackend(GraphBackend):
         **kwargs,
     ) -> VertexClustering:
         """Run community detection using the Leiden algorithm."""
+        # Only importing leiden at runtime since it is very slow to import
+        with warnings.catch_warnings():
+            # Graspologic raises a numba related warning here, that we can
+            # safely ignore.
+            warnings.filterwarnings("ignore", module="graspologic.models.edge_swaps")
+            from graspologic.partition import leiden
+
         graph = self._raw
 
         # TODO This is probably not sufficient for

--- a/tests/graph/test_graph.py
+++ b/tests/graph/test_graph.py
@@ -9,9 +9,9 @@ from unittest.mock import MagicMock
 import numpy as np
 import pandas as pd
 import pytest
-from graspologic.match import graph_match
 from numpy.testing import assert_array_equal
 from pandas.testing import assert_frame_equal
+
 from pixelator.graph import Graph
 
 from tests.graph.networkx.test_tools import random_sequence
@@ -275,6 +275,9 @@ def test_get_adjacency_sparse(enable_backend, pentagram_graph):
     # for that and the expected adjacency matrix under which they are identical.
     #
     # Finally it tests for the equality of these rotated matrices.
+
+    # This import is very slow, so take it here
+    from graspologic.match import graph_match
 
     expected = np.array(
         [


### PR DESCRIPTION
## Description

Importing `graspologic` and `scanpy` is slow, so I have moved these to only be imported when needed at runtime. This speeds up pixelator start-up times and tests considerably. Cold startups going from ~9s -> 2s (your milage might very depending on what has been cached etc). And also shaving of up to ~1/3 of the startup time when running tests, which is why I started looking into this in the first place.
