### PR TITLE
Feature/exe 1328 add layouts to pixeldataset tidy

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,12 @@
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
     "editor.formatOnSave": true,
+    "notebook.formatOnSave.enabled": true,
     "[python]": {
-        "editor.defaultFormatter": "ms-python.black-formatter",
-    }
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "charliermarsh.ruff",
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": true
+        }
+    },
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Metric to collect molecules (edges) in cells with outlier distributions of antibodies (aggregates).
 * Provide typed interfaces for all per-stage report files using pydantic.
 * Centralize pixelator intermediate file lookup and access.
+* Add a `precomputed_layouts` property to `pixeldataset` to allow for loading precomputed layouts.
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,8 +113,7 @@ select = [
     # pycodestyle
     "E",
     # pydocstyle
-    "D",
-]
+    "D",]
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]
 unfixable = []

--- a/src/pixelator/exceptions.py
+++ b/src/pixelator/exceptions.py
@@ -1,0 +1,5 @@
+"""Copyright (c) 2022 Pixelgen Technologies AB."""
+
+
+class PixelatorBaseException(Exception):
+    """Base exception for Pixelator."""

--- a/src/pixelator/pixeldataset/__init__.py
+++ b/src/pixelator/pixeldataset/__init__.py
@@ -24,17 +24,21 @@ from pixelator.pixeldataset.utils import (
     _enforce_edgelist_types,
     update_metrics_anndata,
 )
+
 from pixelator.pixeldataset.backends import (
     PixelDatasetBackend,
     FileBasedPixelDatasetBackend,
     ObjectBasedPixelDatasetBackend,
 )
+from pixelator.pixeldataset.precomputed_layouts import PreComputedLayouts
+
 from pixelator.pixeldataset.datastores import (
     PixelDataStore,
     ZipBasedPixelFileWithParquet,
     ZipBasedPixelFileWithCSV,
 )
 from pixelator.types import PathType
+
 
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", module="libpysal")
@@ -76,6 +80,8 @@ class PixelDataset:
                   each component -> Optional
     colocalization: the colocalization scores (pd.DataFrame) for each
                     component -> Optional
+    precomputed_layouts: pre-computed layouts that can be used to visualize
+                         that component -> Optional
     """
 
     def __init__(self, backend: PixelDatasetBackend) -> None:
@@ -110,6 +116,7 @@ class PixelDataset:
         metadata: Optional[Dict[str, Any]] = None,
         polarization: Optional[pd.DataFrame] = None,
         colocalization: Optional[pd.DataFrame] = None,
+        precomputed_layouts: PreComputedLayouts | None = None,
         copy: bool = True,
         allow_empty_edgelist: bool = False,
     ) -> PixelDataset:
@@ -122,6 +129,7 @@ class PixelDataset:
                              defaults to None
         :param colocalization: a `pd.DataFrame` with colocalization information,
                                defaults to None
+        :param precomputed_layouts: a PreComputedLayouts object, defaults to None
         :param copy: specify if the input data should be copied or not.
                      Defaults to True.
         :param allow_empty_edgelist: allow the edgelist to be empty. Defaults to False.
@@ -135,6 +143,7 @@ class PixelDataset:
                 metadata=metadata,
                 polarization=polarization,
                 colocalization=colocalization,
+                precomputed_layouts=precomputed_layouts,
                 copy=copy,
                 allow_edgelist_to_be_empty=allow_empty_edgelist,
             )
@@ -205,6 +214,18 @@ class PixelDataset:
         """Set the metadata object."""
         self._backend.metadata = value
 
+    @property
+    def precomputed_layouts(
+        self,
+    ) -> PreComputedLayouts | None:
+        """Get the precomputed layouts."""
+        return self._backend.precomputed_layouts
+
+    @precomputed_layouts.setter
+    def precomputed_layouts(self, value: PreComputedLayouts | None) -> None:
+        """Set the precomputed layouts."""
+        self._backend.precomputed_layouts = value
+
     def graph(
         self,
         component_id: Optional[str] = None,
@@ -262,6 +283,12 @@ class PixelDataset:
                 f"{self.colocalization.shape[0]} elements"
             )
 
+        if (
+            self.precomputed_layouts is not None
+            and not self.precomputed_layouts.is_empty
+        ):
+            msg += "\n\tContains precomputed layouts"
+
         if self.metadata is not None:
             msg += "\n\tMetadata:\n"
             msg += "\n".join(
@@ -292,12 +319,19 @@ class PixelDataset:
                 self.colocalization.copy() if self.colocalization is not None else None
             ),
             metadata=self.metadata.copy() if self.metadata is not None else None,
+            precomputed_layouts=(
+                self.precomputed_layouts.copy()
+                if self.precomputed_layouts is not None
+                and not self.precomputed_layouts.is_empty
+                else None
+            ),
         )
 
     def save(
         self,
         path: PathType,
         file_format: Literal["csv", "parquet"] | PixelDataStore = "parquet",
+        force_overwrite: bool = False,
     ) -> None:
         """Save the PixelDataset to a .pxl file in the location provided in `path`.
 
@@ -305,6 +339,8 @@ class PixelDataset:
         :param file_format: should be 'csv' or 'parquet'. Default is 'parquet'.
                             This indicates what file-format is used to serialize
                             the data frames in the .pxl file.
+        :param force_overwrite: By default pixelator will not overwrite existing .pxl files, set this to true to
+                                force an overwrite of the existing file.
         :returns: None
         :rtype: None
         :raises: AssertionError if invalid file format specified
@@ -320,7 +356,7 @@ class PixelDataset:
         if file_format == "parquet":
             format_spec = ZipBasedPixelFileWithParquet(path)
 
-        format_spec.save(self)
+        format_spec.save(self, force_overwrite=force_overwrite)
 
     def filter(
         self,
@@ -332,6 +368,8 @@ class PixelDataset:
         Please note that markers will be filtered from the edgelist, even when provided,
         since it might cause different components to form, and hence invalidated the
         rest of the data.
+
+        Consequently precomputed layouts will also not be filtered by marker.
 
         :param components: The components you want to keep, defaults to None
         :param markers: The markers you want to keep, defaults to None
@@ -364,7 +402,6 @@ class PixelDataset:
                 if change_components
                 else self.edgelist_lazy
             )
-
             edgelist = _enforce_edgelist_types(edgelist_pred.collect().to_pandas())
 
         if self.polarization is not None:
@@ -392,10 +429,23 @@ class PixelDataset:
             )
             colocalization = self.colocalization[colocalization_mask]
 
+        if not (self.precomputed_layouts is None or self.precomputed_layouts.is_empty):
+            precomputed_layouts = self.precomputed_layouts.filter(
+                component_ids=components
+            )
+
         return PixelDataset.from_data(
             adata=adata,
             edgelist=edgelist,
             metadata=self.metadata,
             polarization=polarization if self.polarization is not None else None,
             colocalization=colocalization if self.colocalization is not None else None,
+            precomputed_layouts=(
+                precomputed_layouts
+                if not (
+                    self.precomputed_layouts is None
+                    or self.precomputed_layouts.is_empty
+                )
+                else None
+            ),
         )

--- a/src/pixelator/pixeldataset/aggregation.py
+++ b/src/pixelator/pixeldataset/aggregation.py
@@ -15,7 +15,9 @@ import polars as pl
 from anndata import AnnData, concat as concatenate_anndata
 
 from pixelator.pixeldataset import PixelDataset
-from pixelator.pixeldataset.utils import _enforce_edgelist_types, update_metrics_anndata
+from pixelator.pixeldataset.utils import update_metrics_anndata, _enforce_edgelist_types
+from pixelator.pixeldataset.precomputed_layouts import aggregate_precomputed_layouts
+
 
 logger = logging.getLogger(__name__)
 
@@ -145,12 +147,21 @@ def simple_aggregate(
         }
     }
 
+    precomputed_layouts = aggregate_precomputed_layouts(
+        [
+            (name, dataset.precomputed_layouts)
+            for name, dataset in zip(sample_names, datasets)
+        ],
+        all_markers=set(datasets[0].adata.var.index),
+    )
+
     return PixelDataset.from_data(
         adata=adata,
         edgelist=edgelists,
         polarization=polarizations,
         colocalization=colocalizations,
         metadata=metadata,
+        precomputed_layouts=precomputed_layouts,
         copy=False,
         allow_empty_edgelist=ignore_edgelists,
     )

--- a/src/pixelator/pixeldataset/precomputed_layouts.py
+++ b/src/pixelator/pixeldataset/precomputed_layouts.py
@@ -1,0 +1,350 @@
+"""Pre-computed layouts for components.
+
+This module contains the functionality to generate and work with pre-computed
+graph layouts. The primary purpose of this is to allow components to be
+visualized quickly in downstream analysis, since layout computation
+is a relatively computationally expensive operation.
+
+Copyright (c) 2023 Pixelgen Technologies AB.
+"""
+
+from __future__ import annotations
+
+from multiprocessing import get_context
+from typing import TYPE_CHECKING, Iterable, Optional
+
+import pandas as pd
+import polars as pl
+
+from pixelator.graph import Graph
+from pixelator.exceptions import PixelatorBaseException
+from pixelator.marks import experimental
+from pixelator.utils import batched
+
+if TYPE_CHECKING:
+    from pixelator.pixeldataset import PixelDataset
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class PreComputedLayoutsEmpty(PixelatorBaseException):
+    """Raised when trying to access an empty PreComputedLayouts instance."""
+
+
+class PreComputedLayouts:
+    """Pre-computed layouts for a set of graphs, typically per component."""
+
+    DEFAULT_PARTITIONING = [
+        "graph_projection",
+        "layout",
+        "component",
+    ]
+
+    def __init__(
+        self,
+        layouts_lazy: pl.LazyFrame | Iterable[pl.LazyFrame] | None,
+        partitioning: Optional[list[str]] = None,
+    ) -> None:
+        """Initialize the PreComputedLayouts instance."""
+        self._layouts_lazy = layouts_lazy
+        if not partitioning:
+            partitioning = PreComputedLayouts.DEFAULT_PARTITIONING
+        self._partitioning = partitioning
+
+    @staticmethod
+    def create_empty():
+        """Create an empty PreComputedLayouts instance."""
+        return PreComputedLayouts(None)
+
+    def __repr__(self) -> str:
+        """Return a string representation of the PreComputedLayouts instance."""
+        has_data = "empty" if self.is_empty else "with data"
+        return f"PreComputedLayouts({has_data})"
+
+    def __str__(self) -> str:
+        """Return a string representation of the PreComputedLayouts instance."""
+        return self.__repr__()
+
+    @property
+    def is_empty(self) -> bool:
+        """Return True if the layout is empty."""
+        try:
+            if self.lazy is None:
+                return True
+            return self.lazy.select(pl.col("component")).first().collect().is_empty()
+        except PreComputedLayoutsEmpty:
+            return True
+
+    @property
+    def partitioning(self) -> list[str]:
+        """Return the partitioning of the layouts.
+
+        This is used to determine how to partition the data when
+        serializing it to disk, for the cases when this is applicable.
+        For example when writing hive style parquet files.
+        """
+        return self._partitioning
+
+    @property
+    def df(self) -> pd.DataFrame:
+        """Return the layouts as a pandas DataFrame."""
+        return self.lazy.collect().to_pandas()
+
+    @property
+    def lazy(self) -> pl.LazyFrame:
+        """Return the layouts as a polars LazyFrame."""
+        if self._layouts_lazy is None:
+            raise PreComputedLayoutsEmpty("No layouts available")
+        if isinstance(self._layouts_lazy, Iterable):
+            return pl.concat(self._layouts_lazy, rechunk=False)
+        return self._layouts_lazy
+
+    @property
+    def raw_iterator(self) -> Iterable[pl.LazyFrame]:
+        """Return the raw iterator of the layouts.
+
+        Please note that the raw iterator does not necessarily return
+        one component per lazy frame. Instead if will return the lazy frames
+        as they were provided to the PreComputedLayouts instance.
+
+        This is useful e.g. to write the data lazily and efficiently to disk
+        but in many end-user scenarios it is probably better to work either
+        with `filter` or `component_iterator`.
+        """
+        if not isinstance(self._layouts_lazy, Iterable):
+            return [self._layouts_lazy]  # type: ignore
+        return self._layouts_lazy
+
+    def filter(
+        self,
+        component_ids: str | set[str] | None = None,
+        graph_projection: str | set[str] | None = None,
+        layout_method: str | set[str] | None = None,
+    ) -> PreComputedLayouts:
+        """Filter the layouts based on the provided criteria.
+
+        :param component_ids: the component ids to filter on
+        :param graph_projection: the graph projection to filter on
+        :param layout_method: the layout method to filter on
+        :return: A new PreComputedLayouts instance with the filtered layouts
+        :rtype: PreComputedLayouts
+        """
+        return PreComputedLayouts(
+            self._filter_layouts(
+                self.lazy, component_ids, graph_projection, layout_method
+            ),
+            partitioning=self.partitioning,
+        )
+
+    def component_iterator(
+        self,
+        component_ids: Optional[set[str] | str] = None,
+        graph_projections: Optional[set[str] | str] = None,
+        layout_methods: Optional[set[str] | str] = None,
+    ) -> Iterable[pd.DataFrame]:
+        """Get an iterator over the components provided.
+
+        If `component_ids` is not provided, all components will be returned.
+
+        Providing additional parameters will filter the layouts based on these
+        criteria.
+
+        :param component_ids: the component ids to filter on, if `None` all components
+                              will be returned.
+        :param graph_projections: the graph projections to filter on
+        :param layout_methods: the layout methods to filter on
+        :yields pd.DataFrame: A generator over the components where each dataframe contains the layout(s)
+                  for that component
+        """
+        if not component_ids:
+            unique_components = set(
+                self.lazy.select(pl.col("component").unique())
+                .collect()
+                .get_column("component")
+            )
+        else:
+            unique_components = self._convert_to_set(component_ids)  # type: ignore
+
+        for component in unique_components:
+            yield self._filter_layouts(
+                self.lazy, component, graph_projections, layout_methods
+            ).collect().to_pandas()
+
+    @staticmethod
+    def _convert_to_set(
+        value: Optional[str | set[str]] = None,
+    ) -> Optional[set[str]]:
+        if value is not None:
+            value = set([value]) if isinstance(value, str) else set(value)
+        return value
+
+    @staticmethod
+    def _filter_layouts(
+        layouts_lazy: pl.LazyFrame,
+        component_ids: str | set[str] | None = None,
+        graph_projections: str | set[str] | None = None,
+        layout_methods: str | set[str] | None = None,
+    ) -> pl.LazyFrame:
+        component_ids = PreComputedLayouts._convert_to_set(component_ids)
+        graph_projections = PreComputedLayouts._convert_to_set(graph_projections)
+        layout_methods = PreComputedLayouts._convert_to_set(layout_methods)
+
+        if component_ids:
+            layouts_lazy = layouts_lazy.filter(pl.col("component").is_in(component_ids))
+
+        if graph_projections:
+            layouts_lazy = layouts_lazy.filter(
+                pl.col("graph_projection").is_in(graph_projections)
+            )
+
+        if layout_methods:
+            layouts_lazy = layouts_lazy.filter(pl.col("layout").is_in(layout_methods))
+
+        return layouts_lazy
+
+    def copy(self) -> PreComputedLayouts:
+        """Copy the PreComputedLayouts instance."""
+        return PreComputedLayouts(
+            self.lazy.clone(), partitioning=self.partitioning.copy()
+        )
+
+
+def aggregate_precomputed_layouts(
+    precomputed_layouts: Iterable[tuple[str, PreComputedLayouts | None]],
+    all_markers: set[str],
+) -> PreComputedLayouts:
+    """Aggregate precomputed layouts into a single PreComputedLayouts instance."""
+
+    def zero_fill_missing_markers(
+        lazyframe: pl.LazyFrame, all_markers: set[str]
+    ) -> pl.LazyFrame:
+        missing_markers = all_markers - set(lazyframe.columns)
+        return lazyframe.with_columns(
+            **{marker: pl.lit(0) for marker in missing_markers}
+        )
+
+    def data():
+        for sample_name, layout in precomputed_layouts:
+            if layout is None:
+                continue
+            layout_with_name = layout.lazy.with_columns(
+                sample=pl.lit(sample_name)
+            ).pipe(zero_fill_missing_markers, all_markers=all_markers)
+            yield layout_with_name
+
+    return PreComputedLayouts(
+        pl.concat(data(), rechunk=False),
+        partitioning=["sample"] + PreComputedLayouts.DEFAULT_PARTITIONING,
+    )
+
+
+# TODO The code below this point is not yet tested, and should be considered
+# experimental. It is likely to change in the future. It will be exposed as
+# public to this method in the future.
+
+
+def _zero_fill_missing_markers(dataframe: pd.DataFrame, all_markers) -> pd.DataFrame:
+    missing_markers = all_markers - set(dataframe.columns.to_list())
+    for marker in missing_markers:
+        dataframe[marker] = 0
+    return dataframe
+
+
+def _get_layout(
+    edgelist: pl.DataFrame,
+    add_node_marker_counts,
+    layout_algorithm,
+    all_markers,
+):
+    def data():
+        for component, df in edgelist.group_by("component"):
+            logger.debug("Computing for component %s", component)
+            yield (
+                pl.DataFrame(
+                    Graph.from_edgelist(
+                        df.lazy(),
+                        add_marker_counts=add_node_marker_counts,
+                        simplify=True,
+                        use_full_bipartite=True,
+                    )
+                    .layout_coordinates(
+                        layout_algorithm=layout_algorithm,
+                        get_node_marker_matrix=add_node_marker_counts,
+                        cache=False,
+                    )
+                    .pipe(_zero_fill_missing_markers, all_markers=all_markers)
+                    .sort_index(axis=1)
+                ).with_columns(
+                    component=pl.lit(component),
+                    graph_projection=pl.lit("bipartite"),
+                    layout=pl.lit(layout_algorithm),
+                )
+            )
+
+    result = pl.concat(data())
+    return result
+
+
+def _fn(d):
+    (edgelist, add_node_marker_counts, layout_algorithm, all_markers) = d
+    return _get_layout(edgelist, add_node_marker_counts, layout_algorithm, all_markers)
+
+
+def _data(
+    pixel_dataset: PixelDataset,
+    components,
+    add_node_marker_counts,
+    layout_algorithm,
+    all_markers,
+):
+    processes = 10
+
+    # with ProcessPoolExecutor(max_workers=processes) as executor:
+    with get_context("spawn").Pool(processes=processes) as executor:
+        # Batch over the component groups to speed up the computation
+        # fine tune this later
+        component_group = map(set, batched(components, 10))
+        yield from executor.imap(
+            _fn,
+            (
+                (
+                    pixel_dataset.edgelist_lazy.filter(
+                        pl.col("component").is_in(components)
+                    ).collect(),
+                    add_node_marker_counts,
+                    layout_algorithm,
+                    all_markers,
+                )
+                for components in component_group
+            ),
+            chunksize=1,
+        )
+
+
+@experimental
+def _generate_precomputed_layouts_for_components(
+    pixel_dataset: PixelDataset,
+    components: set[str] | None = None,
+    add_node_marker_counts: bool = False,
+    layout_algorithm="pmds_3d",
+) -> PreComputedLayouts:
+    if components is None:
+        components = set(pixel_dataset.adata.obs.index)
+
+    # This is a bit of a hack to handle that different
+    # graphs might have different markers, but for the end result
+    # to be valid we need to have the same markers across all
+    # components
+    all_markers = set(pixel_dataset.adata.var.index.to_list())
+
+    return PreComputedLayouts(
+        _data(
+            pixel_dataset=pixel_dataset,
+            components=components,
+            add_node_marker_counts=add_node_marker_counts,
+            layout_algorithm=layout_algorithm,
+            all_markers=all_markers,
+        )
+    )

--- a/src/pixelator/pixeldataset/precomputed_layouts.py
+++ b/src/pixelator/pixeldataset/precomputed_layouts.py
@@ -87,8 +87,7 @@ class PreComputedLayouts:
         """
         return self._partitioning
 
-    @property
-    def df(self) -> pd.DataFrame:
+    def to_df(self) -> pd.DataFrame:
         """Return the layouts as a pandas DataFrame."""
         return self.lazy.collect().to_pandas()
 

--- a/src/pixelator/pixeldataset/precomputed_layouts.py
+++ b/src/pixelator/pixeldataset/precomputed_layouts.py
@@ -5,7 +5,7 @@ graph layouts. The primary purpose of this is to allow components to be
 visualized quickly in downstream analysis, since layout computation
 is a relatively computationally expensive operation.
 
-Copyright (c) 2023 Pixelgen Technologies AB.
+Copyright © 2023 Pixelgen Technologies AB.
 """
 
 from __future__ import annotations
@@ -16,8 +16,8 @@ from typing import TYPE_CHECKING, Iterable, Optional
 import pandas as pd
 import polars as pl
 
-from pixelator.graph import Graph
 from pixelator.exceptions import PixelatorBaseException
+from pixelator.graph import Graph
 from pixelator.marks import experimental
 from pixelator.utils import batched
 
@@ -167,9 +167,13 @@ class PreComputedLayouts:
             unique_components = self._convert_to_set(component_ids)  # type: ignore
 
         for component in unique_components:
-            yield self._filter_layouts(
-                self.lazy, component, graph_projections, layout_methods
-            ).collect().to_pandas()
+            yield (
+                self._filter_layouts(
+                    self.lazy, component, graph_projections, layout_methods
+                )
+                .collect()
+                .to_pandas()
+            )
 
     @staticmethod
     def _convert_to_set(

--- a/src/pixelator/utils.py
+++ b/src/pixelator/utils.py
@@ -110,6 +110,27 @@ def create_output_stage_dir(root: PathType, name: str) -> Path:
     return output
 
 
+def flatten(list_of_collections: List[Union[List, Set]]) -> List:
+    """Flattens a list of lists or list of sets.
+
+    :param list_of_collections: list of lists or list of sets
+    :returns List: list containing flattened items
+    """
+    return [item for sublist in list_of_collections for item in sublist]
+
+
+def batched(iterable, n):
+    """Batch data into tuples of length n. The last batch may be shorter.
+
+    Taken from python itertools recipes.
+    """
+    if n < 1:
+        raise ValueError("n must be at least one")
+    it = iter(iterable)
+    while batch := tuple(itertools.islice(it, n)):
+        yield batch
+
+
 def get_extension(filename: PathType, len_ext: int = 2) -> str:
     """Extract file extensions from a filename.
 

--- a/src/pixelator/utils.py
+++ b/src/pixelator/utils.py
@@ -110,15 +110,6 @@ def create_output_stage_dir(root: PathType, name: str) -> Path:
     return output
 
 
-def flatten(list_of_collections: List[Union[List, Set]]) -> List:
-    """Flattens a list of lists or list of sets.
-
-    :param list_of_collections: list of lists or list of sets
-    :returns List: list containing flattened items
-    """
-    return [item for sublist in list_of_collections for item in sublist]
-
-
 def batched(iterable, n):
     """Batch data into tuples of length n. The last batch may be shorter.
 

--- a/tests/pixeldataset/test_aggregation.py
+++ b/tests/pixeldataset/test_aggregation.py
@@ -186,8 +186,8 @@ def test_simple_aggregate(setup_basic_pixel_dataset):
     assert list(result.metadata.keys()) == ["samples"]
     assert result.metadata["samples"]["sample1"] == dataset_1.metadata
 
-    assert len(result.precomputed_layouts.df) == 2 * len(
-        dataset_1.precomputed_layouts.df
+    assert len(result.precomputed_layouts.to_df()) == 2 * len(
+        dataset_1.precomputed_layouts.to_df()
     )
 
 

--- a/tests/pixeldataset/test_aggregation.py
+++ b/tests/pixeldataset/test_aggregation.py
@@ -1,0 +1,302 @@
+"""Tests for pixeldataset.aggregation module.
+
+Copyright (c) 2022 Pixelgen Technologies AB.
+"""
+
+# pylint: disable=redefined-outer-name
+
+import random
+import re
+
+import numpy as np
+import pandas as pd
+import pytest
+from pandas.testing import assert_frame_equal
+from pixelator.pixeldataset import (
+    read,
+)
+from pixelator.pixeldataset.aggregation import simple_aggregate
+
+random.seed(42)
+np.random.seed(42)
+
+
+def test_simple_aggregate(setup_basic_pixel_dataset):
+    dataset_1, *_ = setup_basic_pixel_dataset
+    dataset_2 = dataset_1.copy()
+
+    result = simple_aggregate(
+        sample_names=["sample1", "sample2"], datasets=[dataset_1, dataset_2]
+    )
+
+    assert not (
+        set(result.adata.obs.index.unique()).difference(
+            result.edgelist["component"].unique()
+        )
+        and set(result.adata.obs.index.unique()).difference(
+            set(result.colocalization["component"].unique())
+        )
+        and set(result.adata.obs.index.unique()).difference(
+            set(result.polarization["component"].unique())
+        )
+    )
+
+    assert len(result.edgelist) == 2 * len(dataset_1.edgelist)
+    assert "sample" in result.edgelist.columns
+    row = result.edgelist.iloc[0]
+    assert re.match(r"PXLCMP(\d+)_sample\d", row["component"])
+    assert result.edgelist["sample"].dtype == pd.CategoricalDtype(
+        categories=["sample1", "sample2"], ordered=False
+    )
+    assert isinstance(result.edgelist["component"].dtype, pd.CategoricalDtype)
+
+    assert len(result.adata) == 2 * len(dataset_1.adata)
+    assert len(result.adata.var) == len(dataset_1.adata.var)
+    assert result.adata.var_keys() == dataset_1.adata.var_keys()
+    expected_var = pd.DataFrame.from_dict(
+        {
+            "antibody_count": {
+                "CD45": 18150,
+                "CD3": 9218,
+                "CD19": 0,
+                "IgG1ctrl": 0,
+                "CD20": 4816,
+                "CD69": 0,
+                "HLA-DR": 0,
+                "CD8": 0,
+                "CD14": 0,
+                "IsoT_ctrl": 13940,
+                "CD45RA": 4534,
+                "CD45RO": 0,
+                "CD62L": 0,
+                "CD82": 0,
+                "CD7": 0,
+                "CD70": 0,
+                "CD72": 4730,
+                "CD162": 0,
+                "CD26": 0,
+                "CD63": 0,
+                "CD4": 0,
+                "hashtag": 4612,
+            },
+            "components": {
+                "CD45": 10,
+                "CD3": 10,
+                "CD19": 0,
+                "IgG1ctrl": 0,
+                "CD20": 10,
+                "CD69": 0,
+                "HLA-DR": 0,
+                "CD8": 0,
+                "CD14": 0,
+                "IsoT_ctrl": 10,
+                "CD45RA": 10,
+                "CD45RO": 0,
+                "CD62L": 0,
+                "CD82": 0,
+                "CD7": 0,
+                "CD70": 0,
+                "CD72": 10,
+                "CD162": 0,
+                "CD26": 0,
+                "CD63": 0,
+                "CD4": 0,
+                "hashtag": 10,
+            },
+            "antibody_pct": {
+                "CD45": 0.3025,
+                "CD3": 0.15363333333333334,
+                "CD19": 0.0,
+                "IgG1ctrl": 0.0,
+                "CD20": 0.08026666666666667,
+                "CD69": 0.0,
+                "HLA-DR": 0.0,
+                "CD8": 0.0,
+                "CD14": 0.0,
+                "IsoT_ctrl": 0.23233333333333334,
+                "CD45RA": 0.07556666666666667,
+                "CD45RO": 0.0,
+                "CD62L": 0.0,
+                "CD82": 0.0,
+                "CD7": 0.0,
+                "CD70": 0.0,
+                "CD72": 0.07883333333333334,
+                "CD162": 0.0,
+                "CD26": 0.0,
+                "CD63": 0.0,
+                "CD4": 0.0,
+                "hashtag": 0.07686666666666667,
+            },
+            "nuclear": {
+                "CD45": False,
+                "CD3": False,
+                "CD19": False,
+                "IgG1ctrl": False,
+                "CD20": False,
+                "CD69": False,
+                "HLA-DR": False,
+                "CD8": False,
+                "CD14": False,
+                "IsoT_ctrl": False,
+                "CD45RA": False,
+                "CD45RO": False,
+                "CD62L": False,
+                "CD82": False,
+                "CD7": False,
+                "CD70": False,
+                "CD72": False,
+                "CD162": False,
+                "CD26": False,
+                "CD63": False,
+                "CD4": False,
+                "hashtag": False,
+            },
+            "control": {
+                "CD45": False,
+                "CD3": False,
+                "CD19": False,
+                "IgG1ctrl": True,
+                "CD20": False,
+                "CD69": False,
+                "HLA-DR": False,
+                "CD8": False,
+                "CD14": False,
+                "IsoT_ctrl": True,
+                "CD45RA": False,
+                "CD45RO": False,
+                "CD62L": False,
+                "CD82": False,
+                "CD7": False,
+                "CD70": False,
+                "CD72": False,
+                "CD162": False,
+                "CD26": False,
+                "CD63": False,
+                "CD4": False,
+                "hashtag": False,
+            },
+        }
+    )
+    expected_var.index.name = "marker"
+    assert_frame_equal(result.adata.var, expected_var)
+
+    assert len(result.polarization) == 2 * len(dataset_1.polarization)
+    assert len(result.colocalization) == 2 * len(dataset_1.colocalization)
+
+    assert list(result.metadata.keys()) == ["samples"]
+    assert result.metadata["samples"]["sample1"] == dataset_1.metadata
+
+    assert len(result.precomputed_layouts.df) == 2 * len(
+        dataset_1.precomputed_layouts.df
+    )
+
+
+def test_simple_aggregate_ignore_edgelist(setup_basic_pixel_dataset):
+    """test_simple_aggregate."""
+    dataset_1, *_ = setup_basic_pixel_dataset
+    dataset_2 = dataset_1.copy()
+
+    result = simple_aggregate(
+        sample_names=["sample1", "sample2"],
+        datasets=[dataset_1, dataset_2],
+        ignore_edgelists=True,
+    )
+
+    # We want an empty edgelist, but wit all the correct columns
+    assert result.edgelist.shape == (0, 7)
+
+
+def test_filter_should_return_proper_typed_edgelist_data(setup_basic_pixel_dataset):
+    # Test to check for bug EXE-1177
+    # This bug was caused by filtering returning an incorrectly typed
+    # edgelist, which in turn caused getting the graph to fail
+    dataset_1, *_ = setup_basic_pixel_dataset
+    dataset_2 = dataset_1.copy()
+
+    aggregated_data = simple_aggregate(
+        sample_names=["sample1", "sample2"], datasets=[dataset_1, dataset_2]
+    )
+
+    result = aggregated_data.filter(components=aggregated_data.adata.obs.index[:2])
+    assert isinstance(result.edgelist["component"].dtype, pd.CategoricalDtype)
+    # Running graph here to make sure it does not raise an exception
+    result.graph(result.adata.obs.index[0])
+
+
+def test_on_aggregation_not_passing_unique_sample_names_should_raise(
+    tmp_path,
+    setup_basic_pixel_dataset,
+):
+    dataset_1, *_ = setup_basic_pixel_dataset
+    dataset_2 = dataset_1.copy()
+
+    file_target_1 = tmp_path / "dataset_1.pxl"
+    dataset_1.save(str(file_target_1))
+    file_target_2 = tmp_path / "dataset_2.pxl"
+    dataset_2.save(str(file_target_2))
+
+    with pytest.raises(AssertionError):
+        simple_aggregate(
+            sample_names=["sample1", "sample1"],
+            datasets=[
+                read(file_target_1),
+                read(file_target_2),
+            ],
+        )
+
+
+def test_aggregation_all_samples_show_up(
+    tmp_path,
+    setup_basic_pixel_dataset,
+):
+    # There used to be a bug (EXE-1186) where only the first two samples
+    # were actually aggregated. This test is here to catch that potential
+    # problem in the future.
+
+    dataset_1, *_ = setup_basic_pixel_dataset
+    dataset_2 = dataset_1.copy()
+    dataset_3 = dataset_1.copy()
+    dataset_4 = dataset_1.copy()
+
+    file_target_1 = tmp_path / "dataset_1.pxl"
+    dataset_1.save(str(file_target_1))
+    file_target_2 = tmp_path / "dataset_2.pxl"
+    dataset_2.save(str(file_target_2))
+    file_target_3 = tmp_path / "dataset_3.pxl"
+    dataset_3.save(str(file_target_3))
+    file_target_4 = tmp_path / "dataset_4.pxl"
+    dataset_4.save(str(file_target_4))
+
+    result = simple_aggregate(
+        sample_names=["sample1", "sample2", "sample3", "sample4"],
+        datasets=[
+            read(file_target_1),
+            read(file_target_2),
+            read(file_target_3),
+            read(file_target_4),
+        ],
+    )
+    assert set(result.edgelist["sample"].unique()) == {
+        "sample1",
+        "sample2",
+        "sample3",
+        "sample4",
+    }
+    assert set(result.polarization["sample"].unique()) == {
+        "sample1",
+        "sample2",
+        "sample3",
+        "sample4",
+    }
+    assert set(result.colocalization["sample"].unique()) == {
+        "sample1",
+        "sample2",
+        "sample3",
+        "sample4",
+    }
+    assert set(result.adata.obs["sample"].unique()) == {
+        "sample1",
+        "sample2",
+        "sample3",
+        "sample4",
+    }

--- a/tests/pixeldataset/test_backends.py
+++ b/tests/pixeldataset/test_backends.py
@@ -31,6 +31,10 @@ def assert_backend_can_set_values(pixel_dataset_backend):
     pixel_dataset_backend.metadata = None
     assert not pixel_dataset_backend.metadata
 
+    assert pixel_dataset_backend.precomputed_layouts
+    pixel_dataset_backend.precomputed_layouts = None
+    assert not pixel_dataset_backend.precomputed_layouts
+
 
 def test_file_based_pixel_dataset_backend_set_attrs(pixel_dataset_file):
     """test_file_based_pixel_dataset_backend_set_attrs."""
@@ -47,6 +51,7 @@ def test_object_based_pixel_dataset_backend_set_attrs(setup_basic_pixel_dataset)
         metadata,
         polarization_scores,
         colocalization_scores,
+        precomputed_layouts,
     ) = setup_basic_pixel_dataset
     pixel_dataset_backend = ObjectBasedPixelDatasetBackend(
         adata=adata,
@@ -54,5 +59,6 @@ def test_object_based_pixel_dataset_backend_set_attrs(setup_basic_pixel_dataset)
         polarization=polarization_scores,
         colocalization=colocalization_scores,
         metadata=metadata,
+        precomputed_layouts=precomputed_layouts,
     )
     assert_backend_can_set_values(pixel_dataset_backend)

--- a/tests/pixeldataset/test_datastores.py
+++ b/tests/pixeldataset/test_datastores.py
@@ -3,22 +3,26 @@
 Copyright © 2024 Pixelgen Technologies AB.
 """
 
+from pathlib import Path
 from unittest.mock import patch
+from zipfile import ZipFile
+
+import pandas as pd
+import polars as pl
+import pytest
 from anndata import AnnData
 from pandas.core.frame import DataFrame
-from pathlib import Path
-
-import pytest
 from pandas.testing import assert_frame_equal
 from pixelator.pixeldataset import PixelDataset
-
 from pixelator.pixeldataset.datastores import (
     FileFormatNotRecognizedError,
     PixelDataStore,
     ZipBasedPixelFile,
     ZipBasedPixelFileWithCSV,
     ZipBasedPixelFileWithParquet,
+    CannotOverwriteError,
 )
+from pixelator.pixeldataset.precomputed_layouts import PreComputedLayouts
 
 
 class TestPixelDataStore:
@@ -77,12 +81,8 @@ class TestPixelDataStore:
         result = dataset.file_format_version()
         assert result == 1
 
-    @pytest.mark.parametrize(
-        "datastore", [ZipBasedPixelFileWithParquet, ZipBasedPixelFileWithCSV]
-    )
-    def test_pixelfile_datastore_can_switch_between_reading_and_writing(
+    def test_pixelfile_datastore_trying_to_write_with_same_name_raises_for_parquet(
         self,
-        datastore: type[ZipBasedPixelFileWithParquet] | type[ZipBasedPixelFileWithCSV],
         setup_basic_pixel_dataset: tuple[
             PixelDataset, DataFrame, AnnData, dict[str, int], DataFrame, DataFrame
         ],
@@ -92,34 +92,86 @@ class TestPixelDataStore:
         file_target = tmp_path / "dataset.pxl"
         dataset.save(
             str(file_target),
-            file_format=(
-                "csv" if datastore.EDGELIST_KEY.endswith(".csv.gz") else "parquet"
-            ),
+            file_format="parquet",
         )
 
-        datastore_inst = datastore(file_target)
+        datastore_inst = ZipBasedPixelFileWithParquet(file_target)
 
-        with pytest.warns(UserWarning, match="Duplicate name: "):
+        with pytest.raises(CannotOverwriteError):
             # Reading something / write something / read something
             adata = datastore_inst.read_anndata()
             datastore_inst.write_anndata(adata)
             _ = datastore_inst.read_anndata()
 
+        with pytest.raises(CannotOverwriteError):
             edgelists = datastore_inst.read_edgelist()
             datastore_inst.write_edgelist(edgelists)
             _ = datastore_inst.read_edgelist()
 
+        with pytest.raises(CannotOverwriteError):
             metadata = datastore_inst.read_metadata()
             datastore_inst.write_metadata(metadata)
             _ = datastore_inst.read_metadata()
 
+        with pytest.raises(CannotOverwriteError):
             polarization = datastore_inst.read_polarization()
             datastore_inst.write_polarization(polarization)
             _ = datastore_inst.read_polarization()
 
+        with pytest.raises(CannotOverwriteError):
             colocalization = datastore_inst.read_colocalization()
             datastore_inst.write_colocalization(colocalization)
             _ = datastore_inst.read_colocalization()
+
+        with pytest.raises(CannotOverwriteError):
+            layouts = datastore_inst.read_precomputed_layouts()
+            datastore_inst.write_precomputed_layouts(layouts)
+            _ = datastore_inst.read_precomputed_layouts()
+
+    def test_pixelfile_datastore_trying_to_write_with_same_name_raises_for_csv(
+        self,
+        setup_basic_pixel_dataset: tuple[
+            PixelDataset, DataFrame, AnnData, dict[str, int], DataFrame, DataFrame
+        ],
+        tmp_path: Path,
+    ):
+        dataset, *_ = setup_basic_pixel_dataset
+        file_target = tmp_path / "dataset.pxl"
+        dataset.save(
+            str(file_target),
+            file_format="csv",
+        )
+
+        datastore_inst = ZipBasedPixelFileWithCSV(file_target)
+
+        with pytest.raises(CannotOverwriteError):
+            # Reading something / write something / read something
+            adata = datastore_inst.read_anndata()
+            datastore_inst.write_anndata(adata)
+            _ = datastore_inst.read_anndata()
+
+        with pytest.raises(CannotOverwriteError):
+            edgelists = datastore_inst.read_edgelist()
+            datastore_inst.write_edgelist(edgelists)
+            _ = datastore_inst.read_edgelist()
+
+        with pytest.raises(CannotOverwriteError):
+            metadata = datastore_inst.read_metadata()
+            datastore_inst.write_metadata(metadata)
+            _ = datastore_inst.read_metadata()
+
+        with pytest.raises(CannotOverwriteError):
+            polarization = datastore_inst.read_polarization()
+            datastore_inst.write_polarization(polarization)
+            _ = datastore_inst.read_polarization()
+
+        with pytest.raises(CannotOverwriteError):
+            colocalization = datastore_inst.read_colocalization()
+            datastore_inst.write_colocalization(colocalization)
+            _ = datastore_inst.read_colocalization()
+
+        # csv files do not support reading/writing layouts
+        # since they require hive-style parquet files
 
     def test_read_metadata(self, pixel_dataset_file: Path):
         datastore = PixelDataStore.guess_datastore_from_path(pixel_dataset_file)
@@ -172,6 +224,52 @@ class TestZipBasedPixelFile:
             "component=PXLCMP0000002",
             "component=PXLCMP0000003",
             "component=PXLCMP0000004",
+        }
+
+    def test_pixelfile_datastore_can_read_layouts(
+        self, tmp_path: Path, layout_df: pd.DataFrame
+    ):
+        file_target = tmp_path / "dataset.pxl"
+
+        precomputed_layout = PreComputedLayouts(pl.DataFrame(layout_df).lazy())
+        with ZipBasedPixelFileWithParquet(file_target) as datastore:
+            datastore.write_precomputed_layouts(precomputed_layout)
+
+        with ZipBasedPixelFileWithParquet(file_target) as datastore:
+            result = datastore.read_precomputed_layouts()
+            assert not result.is_empty
+
+    def test_pixelfile_datastore_can_write_layouts(
+        self,
+        tmp_path: Path,
+        layout_df: pd.DataFrame,
+    ):
+        file_target = tmp_path / "dataset.pxl"
+        precomputed_layout = PreComputedLayouts(pl.DataFrame(layout_df).lazy())
+        with ZipBasedPixelFileWithParquet(file_target) as datastore:
+            datastore.write_precomputed_layouts(layouts=precomputed_layout)
+
+        assert set(ZipFile(file_target).namelist()) == {
+            "layouts.parquet/graph_projection=a-node/layout=fr/component=PXLCMP0000001/part-0.parquet",
+            "layouts.parquet/graph_projection=a-node/layout=fr/component=PXLCMP0000000/part-0.parquet",
+            "layouts.parquet/graph_projection=a-node/layout=fr/component=PXLCMP0000003/part-0.parquet",
+            "layouts.parquet/graph_projection=bipartite/layout=fr/component=PXLCMP0000002/part-0.parquet",
+            "layouts.parquet/graph_projection=a-node/layout=pmds/component=PXLCMP0000000/part-0.parquet",
+            "layouts.parquet/graph_projection=bipartite/layout=fr/component=PXLCMP0000000/part-0.parquet",
+            "layouts.parquet/graph_projection=a-node/layout=pmds/component=PXLCMP0000004/part-0.parquet",
+            "layouts.parquet/graph_projection=bipartite/layout=pmds/component=PXLCMP0000004/part-0.parquet",
+            "layouts.parquet/graph_projection=bipartite/layout=fr/component=PXLCMP0000001/part-0.parquet",
+            "layouts.parquet/graph_projection=a-node/layout=pmds/component=PXLCMP0000002/part-0.parquet",
+            "layouts.parquet/graph_projection=a-node/layout=pmds/component=PXLCMP0000001/part-0.parquet",
+            "layouts.parquet/graph_projection=bipartite/layout=pmds/component=PXLCMP0000002/part-0.parquet",
+            "layouts.parquet/graph_projection=bipartite/layout=fr/component=PXLCMP0000004/part-0.parquet",
+            "layouts.parquet/graph_projection=a-node/layout=fr/component=PXLCMP0000002/part-0.parquet",
+            "layouts.parquet/graph_projection=a-node/layout=fr/component=PXLCMP0000004/part-0.parquet",
+            "layouts.parquet/graph_projection=bipartite/layout=pmds/component=PXLCMP0000003/part-0.parquet",
+            "layouts.parquet/graph_projection=bipartite/layout=pmds/component=PXLCMP0000000/part-0.parquet",
+            "layouts.parquet/graph_projection=bipartite/layout=pmds/component=PXLCMP0000001/part-0.parquet",
+            "layouts.parquet/graph_projection=a-node/layout=pmds/component=PXLCMP0000003/part-0.parquet",
+            "layouts.parquet/graph_projection=bipartite/layout=fr/component=PXLCMP0000003/part-0.parquet",
         }
 
     def test_pixelfile_datastore_can_write_with_partitioning_with_multiple_partitions(

--- a/tests/pixeldataset/test_pixeldataset.py
+++ b/tests/pixeldataset/test_pixeldataset.py
@@ -65,7 +65,7 @@ def test_pixeldataset(setup_basic_pixel_dataset):
         dataset.colocalization,
     )
 
-    assert_array_equal(precomputed_layouts.df, dataset.precomputed_layouts.df)
+    assert_array_equal(precomputed_layouts.to_df(), dataset.precomputed_layouts.to_df())
 
 
 def test_pixeldataset_save(setup_basic_pixel_dataset, tmp_path):
@@ -122,11 +122,13 @@ def test_pixeldataset_from_file_parquet(setup_basic_pixel_dataset, tmp_path):
     assert_frame_equal(colocalization_scores, dataset_new.colocalization)
 
     assert_frame_equal(
-        precomputed_layouts.df.sort_index(axis=1)
-        .sort_values(by=precomputed_layouts.df.columns.to_list())
+        precomputed_layouts.to_df()
+        .sort_index(axis=1)
+        .sort_values(by=precomputed_layouts.to_df().columns.to_list())
         .reset_index(drop=True),
-        dataset_new.precomputed_layouts.df.sort_index(axis=1)
-        .sort_values(by=precomputed_layouts.df.columns.to_list())
+        dataset_new.precomputed_layouts.to_df()
+        .sort_index(axis=1)
+        .sort_values(by=precomputed_layouts.to_df().columns.to_list())
         .reset_index(drop=True),
     )
 
@@ -210,7 +212,9 @@ def test_pixeldataset_from_file_csv(setup_basic_pixel_dataset, tmp_path):
 
     # Layouts are not supported by csv backed files
     with pytest.raises(NotImplementedError):
-        assert_frame_equal(precomputed_layouts.df, dataset_new.precomputed_layouts.df)
+        assert_frame_equal(
+            precomputed_layouts.to_df(), dataset_new.precomputed_layouts.to_df()
+        )
 
 
 def test_pixeldataset_repr(setup_basic_pixel_dataset):
@@ -269,7 +273,7 @@ def _assert_has_components(dataset, comp_set):
     assert set(dataset.edgelist["component"]) == comp_set
     assert set(dataset.polarization["component"]) == comp_set
     assert set(dataset.colocalization["component"]) == comp_set
-    assert set(dataset.precomputed_layouts.df["component"]) == comp_set
+    assert set(dataset.precomputed_layouts.to_df()["component"]) == comp_set
 
 
 def test_filter_by_component(setup_basic_pixel_dataset):
@@ -325,7 +329,9 @@ def test_filter_by_marker(setup_basic_pixel_dataset):
     original_coloc_markers = set(dataset_1.colocalization["marker_1"]).union(
         set(dataset_1.colocalization["marker_2"])
     )
-    original_precomputed_layouts_columns = set(dataset_1.precomputed_layouts.df.columns)
+    original_precomputed_layouts_columns = set(
+        dataset_1.precomputed_layouts.to_df().columns
+    )
 
     # Try filtering
     result = dataset_1.filter(markers=["CD3", "CD45"])
@@ -354,7 +360,7 @@ def test_filter_by_marker(setup_basic_pixel_dataset):
     # The edgelist/precomputed layouts should contain all the original markers since it should
     # not be filtered
     assert set(result.edgelist["marker"]) == original_edgelist_markers
-    assert set(result.precomputed_layouts.df.columns).issuperset(
+    assert set(result.precomputed_layouts.to_df().columns).issuperset(
         original_precomputed_layouts_columns
     )
 
@@ -369,7 +375,9 @@ def test_filter_by_component_and_marker(setup_basic_pixel_dataset):
     original_coloc_markers = set(dataset_1.colocalization["marker_1"]).union(
         set(dataset_1.colocalization["marker_2"])
     )
-    original_precomputed_layouts_columns = set(dataset_1.precomputed_layouts.df.columns)
+    original_precomputed_layouts_columns = set(
+        dataset_1.precomputed_layouts.to_df().columns
+    )
 
     # Try filtering
     result = dataset_1.filter(components=["PXLCMP0000000"], markers=["CD3", "CD45"])
@@ -404,7 +412,7 @@ def test_filter_by_component_and_marker(setup_basic_pixel_dataset):
     # The edgelist/precomputed layouts should contain all the original markers since it should
     # not be filtered
     assert set(result.edgelist["marker"]) == original_edgelist_markers
-    assert set(result.precomputed_layouts.df.columns).issuperset(
+    assert set(result.precomputed_layouts.to_df().columns).issuperset(
         original_precomputed_layouts_columns
     )
 

--- a/tests/pixeldataset/test_pixeldataset.py
+++ b/tests/pixeldataset/test_pixeldataset.py
@@ -1,41 +1,25 @@
-"""Tests for pixeldataset.py module.
+"""Tests for pixeldataset module.
 
 Copyright © 2022 Pixelgen Technologies AB.
 """
 
 # pylint: disable=redefined-outer-name
 
-import logging
 import random
-import re
-from pathlib import Path
-from tempfile import TemporaryDirectory
 
 import numpy as np
 import pandas as pd
 import pytest
-from anndata import AnnData
 from numpy.testing import assert_array_equal
 from pandas.testing import assert_frame_equal
-
-from pixelator.config import AntibodyPanel
-from pixelator.graph import Graph, write_recovered_components
+from pixelator.graph import Graph
 from pixelator.pixeldataset import (
     PixelDataset,
     read,
 )
-from pixelator.pixeldataset.aggregation import simple_aggregate
+from pixelator.pixeldataset.precomputed_layouts import PreComputedLayouts
 from pixelator.pixeldataset.utils import (
     _enforce_edgelist_types,
-    antibody_metrics,
-    component_antibody_counts,
-    edgelist_to_anndata,
-    read_anndata,
-    write_anndata,
-)
-from pixelator.statistics import (
-    clr_transformation,
-    log1p_transformation,
 )
 
 random.seed(42)
@@ -51,6 +35,7 @@ def test_pixeldataset(setup_basic_pixel_dataset):
         metadata,
         polarization_scores,
         colocalization_scores,
+        precomputed_layouts,
     ) = setup_basic_pixel_dataset
 
     assert_frame_equal(
@@ -80,6 +65,8 @@ def test_pixeldataset(setup_basic_pixel_dataset):
         dataset.colocalization,
     )
 
+    assert_array_equal(precomputed_layouts.df, dataset.precomputed_layouts.df)
+
 
 def test_pixeldataset_save(setup_basic_pixel_dataset, tmp_path):
     """test_pixeldataset_save."""
@@ -107,6 +94,7 @@ def test_pixeldataset_from_file_parquet(setup_basic_pixel_dataset, tmp_path):
         metadata,
         polarization_scores,
         colocalization_scores,
+        precomputed_layouts,
     ) = setup_basic_pixel_dataset
     file_target = tmp_path / "dataset.pxl"
     dataset.save(str(file_target))
@@ -132,6 +120,15 @@ def test_pixeldataset_from_file_parquet(setup_basic_pixel_dataset, tmp_path):
     assert_frame_equal(polarization_scores, dataset_new.polarization)
 
     assert_frame_equal(colocalization_scores, dataset_new.colocalization)
+
+    assert_frame_equal(
+        precomputed_layouts.df.sort_index(axis=1)
+        .sort_values(by=precomputed_layouts.df.columns.to_list())
+        .reset_index(drop=True),
+        dataset_new.precomputed_layouts.df.sort_index(axis=1)
+        .sort_values(by=precomputed_layouts.df.columns.to_list())
+        .reset_index(drop=True),
+    )
 
 
 def test_pixeldataset_can_save_and_load_with_empty_edgelist(
@@ -174,6 +171,13 @@ def test_pixeldataset_graph_finds_component(setup_basic_pixel_dataset):
     assert len(component_graph.connected_components()) == 1
 
 
+def test_pixeldataset_precomputed_layouts(setup_basic_pixel_dataset):
+    dataset, *_ = setup_basic_pixel_dataset
+
+    precomputed_layouts = dataset.precomputed_layouts
+    assert isinstance(precomputed_layouts, PreComputedLayouts)
+
+
 def test_pixeldataset_from_file_csv(setup_basic_pixel_dataset, tmp_path):
     """test_pixeldataset_from_file_csv."""
     (
@@ -183,6 +187,7 @@ def test_pixeldataset_from_file_csv(setup_basic_pixel_dataset, tmp_path):
         metadata,
         polarization_scores,
         colocalization_scores,
+        precomputed_layouts,
     ) = setup_basic_pixel_dataset
     file_target = tmp_path / "dataset.pxl"
     dataset.save(str(file_target), file_format="csv")
@@ -203,6 +208,10 @@ def test_pixeldataset_from_file_csv(setup_basic_pixel_dataset, tmp_path):
 
     assert_frame_equal(colocalization_scores, dataset_new.colocalization)
 
+    # Layouts are not supported by csv backed files
+    with pytest.raises(NotImplementedError):
+        assert_frame_equal(precomputed_layouts.df, dataset_new.precomputed_layouts.df)
+
 
 def test_pixeldataset_repr(setup_basic_pixel_dataset):
     """test_pixeldataset_repr."""
@@ -214,436 +223,12 @@ def test_pixeldataset_repr(setup_basic_pixel_dataset):
         "  Edge list with 30000 edges",
         "  Polarization scores with 6 elements",
         "  Colocalization scores with 5 elements",
+        "  Contains precomputed layouts",
         "  Metadata:",
         "    A: 1",
         "    B: 2",
         "    file_format_version: 1",
     ]
-
-
-def test_write_recovered_components(tmp_path: Path):
-    """test_write_recovered_components."""
-    file_target = tmp_path / "components_recovered.csv"
-    write_recovered_components(
-        {"PXLCMP0000000": ["PXLCMP0000000", "PXLCMP0000001"]},
-        filename=file_target,
-    )
-
-    result = pd.read_csv(file_target)
-    assert list(result.columns) == ["cell_id", "recovered_from"]
-    assert_frame_equal(
-        result,
-        pd.DataFrame(
-            {
-                "cell_id": ["PXLCMP0000000", "PXLCMP0000001"],
-                "recovered_from": ["PXLCMP0000000", "PXLCMP0000000"],
-            }
-        ),
-    )
-
-
-def test_antibody_metrics(full_graph_edgelist: pd.DataFrame):
-    """test_antibody_metrics."""
-    assert_frame_equal(
-        antibody_metrics(edgelist=full_graph_edgelist),
-        pd.DataFrame(
-            data={
-                "antibody_count": [1250, 1250],
-                "components": [1, 1],
-                "antibody_pct": [0.5, 0.5],
-            },
-            index=pd.CategoricalIndex(
-                ["A", "B"],
-                name="marker",
-            ),
-        ),
-    )
-
-
-def test_antibody_counts(full_graph_edgelist: pd.DataFrame):
-    """test_antibody_counts."""
-    counts = component_antibody_counts(edgelist=full_graph_edgelist)
-    assert_array_equal(
-        counts.to_numpy(),
-        np.array([[1250, 1250]]),
-    )
-    assert sorted(counts.columns) == sorted(["A", "B"])
-
-
-def test_adata_creation(edgelist: pd.DataFrame, panel: AntibodyPanel):
-    """test_adata_creation."""
-    adata = edgelist_to_anndata(edgelist=edgelist, panel=panel)
-    assert adata.n_vars == panel.size
-    assert adata.n_obs == edgelist["component"].nunique()
-    assert sorted(adata.var) == sorted(
-        [
-            "antibody_count",
-            "components",
-            "antibody_pct",
-            "control",
-            "nuclear",
-        ]
-    )
-    assert sorted(adata.obs) == sorted(
-        [
-            "vertices",
-            "molecules",
-            "antibodies",
-            "upia",
-            "upib",
-            "reads",
-            "mean_reads_per_molecule",
-            "median_reads_per_molecule",
-            "mean_upia_degree",
-            "median_upia_degree",
-            "mean_umi_per_upia",
-            "median_umi_per_upia",
-            "upia_per_upib",
-        ]
-    )
-    assert "clr" in adata.obsm
-    assert "log1p" in adata.obsm
-
-
-def test_read_write_anndata(adata: AnnData):
-    """test_read_write_anndata."""
-    with TemporaryDirectory() as tmp_dir:
-        output_path = Path(tmp_dir) / "example.h5ad"
-        write_anndata(adata, output_path)
-        assert output_path.is_file()
-        adata2 = read_anndata(str(output_path))
-        assert_frame_equal(adata.to_df(), adata2.to_df())
-        assert_frame_equal(adata.obs, adata2.obs)
-        assert_frame_equal(adata.var, adata2.var)
-        assert_array_equal(
-            adata.obsm["clr"],
-            adata2.obsm["clr"],
-        )
-        assert_array_equal(
-            adata.obsm["log1p"],
-            adata2.obsm["log1p"],
-        )
-
-
-def test_edgelist_to_anndata_missing_markers(
-    panel: AntibodyPanel, edgelist: pd.DataFrame, caplog
-):
-    """test_edgelist_to_anndata_missing_markers."""
-    with caplog.at_level(logging.WARN):
-        edgelist_to_anndata(edgelist, panel)
-
-    assert "The given 'panel' is missing markers" in caplog.text
-
-
-def test_edgelist_to_anndata(
-    adata: AnnData, panel: AntibodyPanel, edgelist: pd.DataFrame
-):
-    """test_edgelist_to_anndata."""
-    antibodies = panel.markers
-    counts_df = component_antibody_counts(edgelist=edgelist)
-    counts_df = counts_df.reindex(columns=antibodies, fill_value=0)
-    assert_array_equal(adata.X, counts_df.to_numpy())
-
-    counts_df_clr = clr_transformation(counts_df, axis=1)
-    assert_array_equal(
-        adata.obsm["clr"],
-        counts_df_clr.to_numpy(),
-    )
-
-    counts_df_log1p = log1p_transformation(counts_df)
-    assert_array_equal(
-        adata.obsm["log1p"],
-        counts_df_log1p.to_numpy(),
-    )
-
-    assert set(adata.obs_names) == set(edgelist["component"].unique())
-
-
-def test_simple_aggregate(setup_basic_pixel_dataset):
-    """test_simple_aggregate."""
-    dataset_1, *_ = setup_basic_pixel_dataset
-    dataset_2 = dataset_1.copy()
-
-    result = simple_aggregate(
-        sample_names=["sample1", "sample2"], datasets=[dataset_1, dataset_2]
-    )
-
-    assert not (
-        set(result.adata.obs.index.unique()).difference(
-            result.edgelist["component"].unique()
-        )
-        and set(result.adata.obs.index.unique()).difference(
-            set(result.colocalization["component"].unique())
-        )
-        and set(result.adata.obs.index.unique()).difference(
-            set(result.polarization["component"].unique())
-        )
-    )
-
-    assert len(result.edgelist) == 2 * len(dataset_1.edgelist)
-    assert "sample" in result.edgelist.columns
-    row = result.edgelist.iloc[0]
-    assert re.match(r"PXLCMP(\d+)_sample\d", row["component"])
-    assert result.edgelist["sample"].dtype == pd.CategoricalDtype(
-        categories=["sample1", "sample2"], ordered=False
-    )
-    assert isinstance(result.edgelist["component"].dtype, pd.CategoricalDtype)
-
-    assert len(result.adata) == 2 * len(dataset_1.adata)
-    assert len(result.adata.var) == len(dataset_1.adata.var)
-    assert result.adata.var_keys() == dataset_1.adata.var_keys()
-    expected_var = pd.DataFrame.from_dict(
-        {
-            "antibody_count": {
-                "CD45": 18150,
-                "CD3": 9218,
-                "CD19": 0,
-                "IgG1ctrl": 0,
-                "CD20": 4816,
-                "CD69": 0,
-                "HLA-DR": 0,
-                "CD8": 0,
-                "CD14": 0,
-                "IsoT_ctrl": 13940,
-                "CD45RA": 4534,
-                "CD45RO": 0,
-                "CD62L": 0,
-                "CD82": 0,
-                "CD7": 0,
-                "CD70": 0,
-                "CD72": 4730,
-                "CD162": 0,
-                "CD26": 0,
-                "CD63": 0,
-                "CD4": 0,
-                "hashtag": 4612,
-            },
-            "components": {
-                "CD45": 10,
-                "CD3": 10,
-                "CD19": 0,
-                "IgG1ctrl": 0,
-                "CD20": 10,
-                "CD69": 0,
-                "HLA-DR": 0,
-                "CD8": 0,
-                "CD14": 0,
-                "IsoT_ctrl": 10,
-                "CD45RA": 10,
-                "CD45RO": 0,
-                "CD62L": 0,
-                "CD82": 0,
-                "CD7": 0,
-                "CD70": 0,
-                "CD72": 10,
-                "CD162": 0,
-                "CD26": 0,
-                "CD63": 0,
-                "CD4": 0,
-                "hashtag": 10,
-            },
-            "antibody_pct": {
-                "CD45": 0.3025,
-                "CD3": 0.15363333333333334,
-                "CD19": 0.0,
-                "IgG1ctrl": 0.0,
-                "CD20": 0.08026666666666667,
-                "CD69": 0.0,
-                "HLA-DR": 0.0,
-                "CD8": 0.0,
-                "CD14": 0.0,
-                "IsoT_ctrl": 0.23233333333333334,
-                "CD45RA": 0.07556666666666667,
-                "CD45RO": 0.0,
-                "CD62L": 0.0,
-                "CD82": 0.0,
-                "CD7": 0.0,
-                "CD70": 0.0,
-                "CD72": 0.07883333333333334,
-                "CD162": 0.0,
-                "CD26": 0.0,
-                "CD63": 0.0,
-                "CD4": 0.0,
-                "hashtag": 0.07686666666666667,
-            },
-            "nuclear": {
-                "CD45": False,
-                "CD3": False,
-                "CD19": False,
-                "IgG1ctrl": False,
-                "CD20": False,
-                "CD69": False,
-                "HLA-DR": False,
-                "CD8": False,
-                "CD14": False,
-                "IsoT_ctrl": False,
-                "CD45RA": False,
-                "CD45RO": False,
-                "CD62L": False,
-                "CD82": False,
-                "CD7": False,
-                "CD70": False,
-                "CD72": False,
-                "CD162": False,
-                "CD26": False,
-                "CD63": False,
-                "CD4": False,
-                "hashtag": False,
-            },
-            "control": {
-                "CD45": False,
-                "CD3": False,
-                "CD19": False,
-                "IgG1ctrl": True,
-                "CD20": False,
-                "CD69": False,
-                "HLA-DR": False,
-                "CD8": False,
-                "CD14": False,
-                "IsoT_ctrl": True,
-                "CD45RA": False,
-                "CD45RO": False,
-                "CD62L": False,
-                "CD82": False,
-                "CD7": False,
-                "CD70": False,
-                "CD72": False,
-                "CD162": False,
-                "CD26": False,
-                "CD63": False,
-                "CD4": False,
-                "hashtag": False,
-            },
-        }
-    )
-    expected_var.index.name = "marker"
-    assert_frame_equal(result.adata.var, expected_var)
-
-    assert len(result.polarization) == 2 * len(dataset_1.polarization)
-    assert len(result.colocalization) == 2 * len(dataset_1.colocalization)
-
-    assert list(result.metadata.keys()) == ["samples"]
-    assert result.metadata["samples"]["sample1"] == dataset_1.metadata
-
-
-def test_simple_aggregate_ignore_edgelist(setup_basic_pixel_dataset):
-    """test_simple_aggregate."""
-    dataset_1, *_ = setup_basic_pixel_dataset
-    dataset_2 = dataset_1.copy()
-
-    result = simple_aggregate(
-        sample_names=["sample1", "sample2"],
-        datasets=[dataset_1, dataset_2],
-        ignore_edgelists=True,
-    )
-
-    # We want an empty edgelist, but wit all the correct columns
-    assert result.edgelist.shape[0] == 0
-    assert set(result.edgelist.columns) == {
-        "sequence",
-        "upib",
-        "upia",
-        "umi",
-        "component",
-        "count",
-        "marker",
-    }
-
-
-def test_filter_should_return_proper_typed_edgelist_data(setup_basic_pixel_dataset):
-    # Test to check for bug EXE-1177
-    # This bug was caused by filtering returning an incorrectly typed
-    # edgelist, which in turn caused getting the graph to fail
-    dataset_1, *_ = setup_basic_pixel_dataset
-    dataset_2 = dataset_1.copy()
-
-    aggregated_data = simple_aggregate(
-        sample_names=["sample1", "sample2"], datasets=[dataset_1, dataset_2]
-    )
-
-    result = aggregated_data.filter(components=aggregated_data.adata.obs.index[:2])
-    assert isinstance(result.edgelist["component"].dtype, pd.CategoricalDtype)
-    # Running graph here to make sure it does not raise an exception
-    result.graph(result.adata.obs.index[0])
-
-
-def test_on_aggregation_not_passing_unique_sample_names_should_raise(
-    tmp_path,
-    setup_basic_pixel_dataset,
-):
-    dataset_1, *_ = setup_basic_pixel_dataset
-    dataset_2 = dataset_1.copy()
-
-    file_target_1 = tmp_path / "dataset_1.pxl"
-    dataset_1.save(str(file_target_1))
-    file_target_2 = tmp_path / "dataset_2.pxl"
-    dataset_2.save(str(file_target_2))
-
-    with pytest.raises(AssertionError):
-        simple_aggregate(
-            sample_names=["sample1", "sample1"],
-            datasets=[
-                read(file_target_1),
-                read(file_target_2),
-            ],
-        )
-
-
-def test_aggregation_all_samples_show_up(
-    tmp_path,
-    setup_basic_pixel_dataset,
-):
-    # There used to be a bug (EXE-1186) where only the first two samples
-    # were actually aggregated. This test is here to catch that potential
-    # problem in the future.
-
-    dataset_1, *_ = setup_basic_pixel_dataset
-    dataset_2 = dataset_1.copy()
-    dataset_3 = dataset_1.copy()
-    dataset_4 = dataset_1.copy()
-
-    file_target_1 = tmp_path / "dataset_1.pxl"
-    dataset_1.save(str(file_target_1))
-    file_target_2 = tmp_path / "dataset_2.pxl"
-    dataset_2.save(str(file_target_2))
-    file_target_3 = tmp_path / "dataset_3.pxl"
-    dataset_3.save(str(file_target_3))
-    file_target_4 = tmp_path / "dataset_4.pxl"
-    dataset_4.save(str(file_target_4))
-
-    result = simple_aggregate(
-        sample_names=["sample1", "sample2", "sample3", "sample4"],
-        datasets=[
-            read(file_target_1),
-            read(file_target_2),
-            read(file_target_3),
-            read(file_target_4),
-        ],
-    )
-    assert set(result.edgelist["sample"].unique()) == {
-        "sample1",
-        "sample2",
-        "sample3",
-        "sample4",
-    }
-    assert set(result.polarization["sample"].unique()) == {
-        "sample1",
-        "sample2",
-        "sample3",
-        "sample4",
-    }
-    assert set(result.colocalization["sample"].unique()) == {
-        "sample1",
-        "sample2",
-        "sample3",
-        "sample4",
-    }
-    assert set(result.adata.obs["sample"].unique()) == {
-        "sample1",
-        "sample2",
-        "sample3",
-        "sample4",
-    }
 
 
 def test_lazy_edgelist_should_warn_and_rm_on_index_column(setup_basic_pixel_dataset):
@@ -684,6 +269,7 @@ def _assert_has_components(dataset, comp_set):
     assert set(dataset.edgelist["component"]) == comp_set
     assert set(dataset.polarization["component"]) == comp_set
     assert set(dataset.colocalization["component"]) == comp_set
+    assert set(dataset.precomputed_layouts.df["component"]) == comp_set
 
 
 def test_filter_by_component(setup_basic_pixel_dataset):
@@ -739,6 +325,7 @@ def test_filter_by_marker(setup_basic_pixel_dataset):
     original_coloc_markers = set(dataset_1.colocalization["marker_1"]).union(
         set(dataset_1.colocalization["marker_2"])
     )
+    original_precomputed_layouts_columns = set(dataset_1.precomputed_layouts.df.columns)
 
     # Try filtering
     result = dataset_1.filter(markers=["CD3", "CD45"])
@@ -764,9 +351,12 @@ def test_filter_by_marker(setup_basic_pixel_dataset):
     assert_array_equal(
         result.adata.obs["antibodies"], np.repeat(2, len(result.adata.obs))
     )
-    # The edgelist should contain all the original markers since it should
+    # The edgelist/precomputed layouts should contain all the original markers since it should
     # not be filtered
     assert set(result.edgelist["marker"]) == original_edgelist_markers
+    assert set(result.precomputed_layouts.df.columns).issuperset(
+        original_precomputed_layouts_columns
+    )
 
 
 def test_filter_by_component_and_marker(setup_basic_pixel_dataset):
@@ -779,6 +369,7 @@ def test_filter_by_component_and_marker(setup_basic_pixel_dataset):
     original_coloc_markers = set(dataset_1.colocalization["marker_1"]).union(
         set(dataset_1.colocalization["marker_2"])
     )
+    original_precomputed_layouts_columns = set(dataset_1.precomputed_layouts.df.columns)
 
     # Try filtering
     result = dataset_1.filter(components=["PXLCMP0000000"], markers=["CD3", "CD45"])
@@ -810,9 +401,12 @@ def test_filter_by_component_and_marker(setup_basic_pixel_dataset):
     assert_array_equal(
         result.adata.obs["antibodies"], np.repeat(2, len(result.adata.obs))
     )
-    # The edgelist should contain all the original markers since it should
+    # The edgelist/precomputed layouts should contain all the original markers since it should
     # not be filtered
     assert set(result.edgelist["marker"]) == original_edgelist_markers
+    assert set(result.precomputed_layouts.df.columns).issuperset(
+        original_precomputed_layouts_columns
+    )
 
 
 def test__enforce_edgelist_types():

--- a/tests/pixeldataset/test_precomputed_layouts.py
+++ b/tests/pixeldataset/test_precomputed_layouts.py
@@ -66,8 +66,8 @@ class TestPreComputedLayouts:
             "component",
         ]
 
-    def test_df_returns_pandas_dataframe(self, precomputed_layouts):
-        df = precomputed_layouts.df
+    def test_to_df_returns_pandas_dataframe(self, precomputed_layouts):
+        df = precomputed_layouts.to_df()
         assert isinstance(df, pd.DataFrame)
         assert set(df["component"]) == {
             "PXLCMP0000000",
@@ -118,7 +118,7 @@ class TestPreComputedLayouts:
                 "layout": ["pmds"],
             }
         )
-        assert_frame_equal(filtered.df, expected_df)
+        assert_frame_equal(filtered.to_df(), expected_df)
 
     def test_iterator_returns_filtered_dataframes(self):
         layouts_lazy = pl.DataFrame(
@@ -211,4 +211,4 @@ class TestPreComputedLayouts:
                 ],
             }
         )
-        pd.testing.assert_frame_equal(aggregated_layouts.df, expected_df)
+        pd.testing.assert_frame_equal(aggregated_layouts.to_df(), expected_df)

--- a/tests/pixeldataset/test_precomputed_layouts.py
+++ b/tests/pixeldataset/test_precomputed_layouts.py
@@ -1,0 +1,214 @@
+"""Copyright (c) 2024 Pixelgen Technologies AB."""
+
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+import polars as pl
+import pytest
+from pandas.testing import assert_frame_equal
+from pixelator.pixeldataset.precomputed_layouts import (
+    PreComputedLayouts,
+    aggregate_precomputed_layouts,
+)
+
+
+@pytest.fixture(name="layout_df")
+def layout_df_fixture() -> pd.DataFrame:
+    nbr_of_rows = 300
+    components = [
+        "PXLCMP0000000",
+        "PXLCMP0000001",
+        "PXLCMP0000002",
+        "PXLCMP0000003",
+        "PXLCMP0000004",
+    ]
+    sample = ["sample_1", "sample_2"]
+    graph_projections = ["bipartite", "a-node"]
+    layout_methods = ["pmds", "fr"]
+    rgn = np.random.default_rng(1)
+    layout_df = pd.DataFrame(
+        {
+            "x": rgn.random(nbr_of_rows),
+            "y": rgn.random(nbr_of_rows),
+            "z": rgn.random(nbr_of_rows),
+            "graph_projection": rgn.choice(graph_projections, nbr_of_rows),
+            "layout": rgn.choice(layout_methods, nbr_of_rows),
+            "component": rgn.choice(components, nbr_of_rows),
+            "sample": rgn.choice(sample, nbr_of_rows),
+        }
+    )
+    yield layout_df
+
+
+@pytest.fixture(name="precomputed_layouts")
+def precomputed_layouts_fixture(layout_df) -> pd.DataFrame:
+    yield PreComputedLayouts(pl.DataFrame(layout_df).lazy())
+
+
+class TestPreComputedLayouts:
+    def test_is_empty_returns_true_for_empty_layout(self):
+        layouts_lazy = pl.DataFrame({"component": []}).lazy()
+        precomputed_layouts = PreComputedLayouts(layouts_lazy)
+        assert precomputed_layouts.is_empty
+
+    def test_is_empty_returns_false_for_non_empty_layout(self):
+        layouts_lazy = pl.DataFrame({"component": ["PXLCMP0000000"]}).lazy()
+        precomputed_layouts = PreComputedLayouts(layouts_lazy)
+        assert not precomputed_layouts.is_empty
+
+    def test_partitioning_returns_default_partitioning(self):
+        layouts_lazy = pl.DataFrame({"component": []}).lazy()
+        precomputed_layouts = PreComputedLayouts(layouts_lazy)
+        assert precomputed_layouts.partitioning == [
+            "graph_projection",
+            "layout",
+            "component",
+        ]
+
+    def test_df_returns_pandas_dataframe(self, precomputed_layouts):
+        df = precomputed_layouts.df
+        assert isinstance(df, pd.DataFrame)
+        assert set(df["component"]) == {
+            "PXLCMP0000000",
+            "PXLCMP0000001",
+            "PXLCMP0000002",
+            "PXLCMP0000003",
+            "PXLCMP0000004",
+        }
+        assert set(df.columns) == {
+            "x",
+            "y",
+            "z",
+            "graph_projection",
+            "layout",
+            "component",
+            "sample",
+        }
+
+    def test_lazy_returns_polars_lazy_frame(self):
+        layouts_lazy = pl.DataFrame({"component": ["PXLCMP0000000"]}).lazy()
+        precomputed_layouts = PreComputedLayouts(layouts_lazy)
+        lazy = precomputed_layouts.lazy
+        assert isinstance(lazy, pl.LazyFrame)
+        assert lazy.collect().shape == (1, 1)
+
+    def test_filter_returns_filtered_dataframe(self):
+        layouts_lazy = pl.DataFrame(
+            {
+                "component": ["PXLCMP0000000", "PXLCMP0000001"],
+                "graph_projection": ["a-node", "b-node"],
+                "layout": ["pmds", "fr"],
+            }
+        ).lazy()
+
+        precomputed_layouts = PreComputedLayouts(layouts_lazy)
+        filtered = precomputed_layouts.filter(
+            component_ids=["PXLCMP0000000"],
+            graph_projection="a-node",
+            layout_method="pmds",
+        )
+
+        assert isinstance(filtered, PreComputedLayouts)
+
+        expected_df = pd.DataFrame(
+            {
+                "component": ["PXLCMP0000000"],
+                "graph_projection": ["a-node"],
+                "layout": ["pmds"],
+            }
+        )
+        assert_frame_equal(filtered.df, expected_df)
+
+    def test_iterator_returns_filtered_dataframes(self):
+        layouts_lazy = pl.DataFrame(
+            {
+                "component": [
+                    "PXLCMP0000000",
+                    "PXLCMP0000000",
+                    "PXLCMP0000001",
+                    "PXLCMP0000001",
+                ],
+                "graph_projection": ["a-node", "a-node", "a-node", "a-node"],
+                "layout": ["pmds", "pmds", "fr", "pmds"],
+            }
+        ).lazy()
+        precomputed_layouts = PreComputedLayouts(layouts_lazy)
+
+        result = precomputed_layouts.component_iterator(
+            component_ids=["PXLCMP0000000", "PXLCMP0000001"],
+            graph_projections="a-node",
+            layout_methods="pmds",
+        )
+
+        expected_df1 = pd.DataFrame(
+            {
+                "component": ["PXLCMP0000000", "PXLCMP0000000"],
+                "graph_projection": ["a-node", "a-node"],
+                "layout": ["pmds", "pmds"],
+            }
+        )
+        expected_df2 = pd.DataFrame(
+            {
+                "component": ["PXLCMP0000001"],
+                "graph_projection": ["a-node"],
+                "layout": ["pmds"],
+            }
+        )
+        assert isinstance(result, Iterable)
+        result = list(result)
+        assert len(result) == 2
+        # There is no guarantee for the order of the results
+        try:
+            assert_frame_equal(result[0], expected_df1)
+            assert_frame_equal(result[1], expected_df2)
+        except AssertionError:
+            assert_frame_equal(result[1], expected_df1)
+            assert_frame_equal(result[0], expected_df2)
+
+    def test_aggregate_precomputed_layouts(self):
+        # Create some sample PreComputedLayouts
+        layout1 = PreComputedLayouts(
+            pl.DataFrame(
+                {
+                    "x": [1, 2, 3],
+                    "y": [4, 5, 6],
+                    "component": ["A", "B", "C"],
+                    "sample": ["sample1", "sample1", "sample1"],
+                }
+            ).lazy()
+        )
+        layout2 = PreComputedLayouts(
+            pl.DataFrame(
+                {
+                    "x": [7, 8, 9],
+                    "y": [10, 11, 12],
+                    "component": ["A", "B", "C"],
+                    "sample": ["sample2", "sample2", "sample2"],
+                }
+            ).lazy()
+        )
+
+        # Aggregate the layouts
+        aggregated_layouts = aggregate_precomputed_layouts(
+            [("sample1", layout1), ("sample2", layout2)],
+            all_markers={"x", "y", "component", "sample"},
+        )
+
+        # Check the aggregated layout DataFrame
+        expected_df = pd.DataFrame(
+            {
+                "x": [1, 2, 3, 7, 8, 9],
+                "y": [4, 5, 6, 10, 11, 12],
+                "component": ["A", "B", "C", "A", "B", "C"],
+                "sample": [
+                    "sample1",
+                    "sample1",
+                    "sample1",
+                    "sample2",
+                    "sample2",
+                    "sample2",
+                ],
+            }
+        )
+        pd.testing.assert_frame_equal(aggregated_layouts.df, expected_df)

--- a/tests/pixeldataset/test_utils.py
+++ b/tests/pixeldataset/test_utils.py
@@ -1,0 +1,172 @@
+"""Tests for pixeldataset.utils module.
+
+Copyright (c) 2022 Pixelgen Technologies AB.
+"""
+
+# pylint: disable=redefined-outer-name
+
+import logging
+import random
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import numpy as np
+import pandas as pd
+from anndata import AnnData
+from numpy.testing import assert_array_equal
+from pandas.testing import assert_frame_equal
+from pixelator.config import AntibodyPanel
+from pixelator.graph import write_recovered_components
+
+from pixelator.pixeldataset.utils import (
+    antibody_metrics,
+    component_antibody_counts,
+    edgelist_to_anndata,
+    read_anndata,
+    write_anndata,
+)
+from pixelator.statistics import (
+    clr_transformation,
+    log1p_transformation,
+)
+
+random.seed(42)
+np.random.seed(42)
+
+
+def test_write_recovered_components(tmp_path: Path):
+    """test_write_recovered_components."""
+    file_target = tmp_path / "components_recovered.csv"
+    write_recovered_components(
+        {"PXLCMP0000000": ["PXLCMP0000000", "PXLCMP0000001"]},
+        filename=file_target,
+    )
+
+    result = pd.read_csv(file_target)
+    assert list(result.columns) == ["cell_id", "recovered_from"]
+    assert_frame_equal(
+        result,
+        pd.DataFrame(
+            {
+                "cell_id": ["PXLCMP0000000", "PXLCMP0000001"],
+                "recovered_from": ["PXLCMP0000000", "PXLCMP0000000"],
+            }
+        ),
+    )
+
+
+def test_antibody_metrics(full_graph_edgelist: pd.DataFrame):
+    """test_antibody_metrics."""
+    assert_frame_equal(
+        antibody_metrics(edgelist=full_graph_edgelist),
+        pd.DataFrame(
+            data={
+                "antibody_count": [1250, 1250],
+                "components": [1, 1],
+                "antibody_pct": [0.5, 0.5],
+            },
+            index=pd.CategoricalIndex(
+                ["A", "B"],
+                name="marker",
+            ),
+        ),
+    )
+
+
+def test_antibody_counts(full_graph_edgelist: pd.DataFrame):
+    """test_antibody_counts."""
+    counts = component_antibody_counts(edgelist=full_graph_edgelist)
+    assert_array_equal(
+        counts.to_numpy(),
+        np.array([[1250, 1250]]),
+    )
+    assert sorted(counts.columns) == sorted(["A", "B"])
+
+
+def test_adata_creation(edgelist: pd.DataFrame, panel: AntibodyPanel):
+    """test_adata_creation."""
+    adata = edgelist_to_anndata(edgelist=edgelist, panel=panel)
+    assert adata.n_vars == panel.size
+    assert adata.n_obs == edgelist["component"].nunique()
+    assert sorted(adata.var) == sorted(
+        [
+            "antibody_count",
+            "components",
+            "antibody_pct",
+            "control",
+            "nuclear",
+        ]
+    )
+    assert sorted(adata.obs) == sorted(
+        [
+            "vertices",
+            "molecules",
+            "antibodies",
+            "upia",
+            "upib",
+            "reads",
+            "mean_reads_per_molecule",
+            "median_reads_per_molecule",
+            "mean_upia_degree",
+            "median_upia_degree",
+            "mean_umi_per_upia",
+            "median_umi_per_upia",
+            "upia_per_upib",
+        ]
+    )
+    assert "clr" in adata.obsm
+    assert "log1p" in adata.obsm
+
+
+def test_read_write_anndata(adata: AnnData):
+    """test_read_write_anndata."""
+    with TemporaryDirectory() as tmp_dir:
+        output_path = Path(tmp_dir) / "example.h5ad"
+        write_anndata(adata, output_path)
+        assert output_path.is_file()
+        adata2 = read_anndata(str(output_path))
+        assert_frame_equal(adata.to_df(), adata2.to_df())
+        assert_frame_equal(adata.obs, adata2.obs)
+        assert_frame_equal(adata.var, adata2.var)
+        assert_array_equal(
+            adata.obsm["clr"],
+            adata2.obsm["clr"],
+        )
+        assert_array_equal(
+            adata.obsm["log1p"],
+            adata2.obsm["log1p"],
+        )
+
+
+def test_edgelist_to_anndata_missing_markers(
+    panel: AntibodyPanel, edgelist: pd.DataFrame, caplog
+):
+    """test_edgelist_to_anndata_missing_markers."""
+    with caplog.at_level(logging.WARN):
+        edgelist_to_anndata(edgelist, panel)
+
+    assert "The given 'panel' is missing markers" in caplog.text
+
+
+def test_edgelist_to_anndata(
+    adata: AnnData, panel: AntibodyPanel, edgelist: pd.DataFrame
+):
+    """test_edgelist_to_anndata."""
+    antibodies = panel.markers
+    counts_df = component_antibody_counts(edgelist=edgelist)
+    counts_df = counts_df.reindex(columns=antibodies, fill_value=0)
+    assert_array_equal(adata.X, counts_df.to_numpy())
+
+    counts_df_clr = clr_transformation(counts_df, axis=1)
+    assert_array_equal(
+        adata.obsm["clr"],
+        counts_df_clr.to_numpy(),
+    )
+
+    counts_df_log1p = log1p_transformation(counts_df)
+    assert_array_equal(
+        adata.obsm["log1p"],
+        counts_df_log1p.to_numpy(),
+    )
+
+    assert set(adata.obs_names) == set(edgelist["component"].unique())

--- a/tests/pixeldataset/test_utils.py
+++ b/tests/pixeldataset/test_utils.py
@@ -17,7 +17,6 @@ from numpy.testing import assert_array_equal
 from pandas.testing import assert_frame_equal
 from pixelator.config import AntibodyPanel
 from pixelator.graph import write_recovered_components
-
 from pixelator.pixeldataset.utils import (
     antibody_metrics,
     component_antibody_counts,
@@ -29,6 +28,7 @@ from pixelator.statistics import (
     clr_transformation,
     log1p_transformation,
 )
+from pixelator.utils import batched
 
 random.seed(42)
 np.random.seed(42)
@@ -170,3 +170,47 @@ def test_edgelist_to_anndata(
     )
 
     assert set(adata.obs_names) == set(edgelist["component"].unique())
+
+
+def test_batched_empty_iterable():
+    """Test batched with an empty iterable."""
+    iterable = []
+    n = 3
+    batches = list(batched(iterable, n))
+    assert batches == []
+
+
+def test_batched_single_batch():
+    """Test batched with a single batch."""
+    iterable = [1, 2, 3]
+    n = 3
+    batches = list(batched(iterable, n))
+    assert batches == [(1, 2, 3)]
+
+
+def test_batched_multiple_batches():
+    """Test batched with multiple batches."""
+    iterable = [1, 2, 3, 4, 5, 6]
+    n = 2
+    batches = list(batched(iterable, n))
+    assert batches == [(1, 2), (3, 4), (5, 6)]
+
+
+def test_batched_last_batch_shorter():
+    """Test batched with the last batch being shorter."""
+    iterable = [1, 2, 3, 4, 5]
+    n = 3
+    batches = list(batched(iterable, n))
+    assert batches == [(1, 2, 3), (4, 5)]
+
+
+def test_batched_n_less_than_one():
+    """Test batched with n less than one."""
+    iterable = [1, 2, 3]
+    n = 0
+    try:
+        _ = list(batched(iterable, n))
+    except ValueError as e:
+        assert str(e) == "n must be at least one"
+    else:
+        assert False, "Expected ValueError"


### PR DESCRIPTION
## Description

This does a bunch of different things (sorry in advance about that).

### EXE-1328: make it possible to add pre-computed layouts to pxl files

This adds the capability for pixel files to hold pre-computed layouts. This is useful since it allows us to interactively visualize components in downstream analysis without having to do the relatively computationally expensive layout calculations on the fly.

### EXE-1414: a bug that caused the the same file to be written multiple time to the pxl file

When writing a file with the same file name multiple times to the pxl file, this would appear multiple times in the file. Since there is currently (as far as I understand) no way to delete files from a zip-archive in python pixelator will now require a completely fresh file to be written, unless the user explicitly overwrites the old file.

### EXE-1416: add a base exception for pixelator

Add a base exception that we should start using to build exception hierarchies in pixelator to allow us better error handling in the future.

### Makes PMDS use sparse matrices

An issue in the types of the sparse matrix indices meant that we were using dense matrix representation when computing pmds layouts. I found a work-around for this that I have implemented as part of this PR.

### Split `test_pixeldataset.py` into multiple files

This test file was testing multiple things and was getting large enough to be unwieldy. I split it up into multiple files.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

With the unit tests, and by running the prototype code included here (but not finished) that can generate layouts, and then trying those out in a notebook.

## PR checklist:

- [ ] This comment contains a description of changes (with reason).
- [ ] My code follows the style guidelines of this project
- [ ] Make sure your code lints, is well-formatted and type checks
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If you've added a new stage - have you followed the pipeline CLI conventions in the [USAGE guide](../USAGE.md)
- [ ] [README.md](./README.md) is updated
- [ ] If a new tool or package is included, update poetry.lock, [the conda recipe](../conda-recipe/pixelator/meta.yaml) and [cited it properly](../CITATIONS.md)
- [ ] Include any new [authors/contributors](../AUTHORS.md)
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] Usage Documentation is updated
- [ ] If you are doing a [release](../RELEASING.md#Releasing), or a significant change to the code, update [CHANGELOG.md](../CHANGELOG.md)
