### PR TITLE
Fails to write very large pxl files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
         "editor.formatOnSave": true,
         "editor.defaultFormatter": "charliermarsh.ruff",
         "editor.codeActionsOnSave": {
-            "source.organizeImports": true
+            "source.organizeImports": "never"
         }
     },
 }

--- a/src/pixelator/pixeldataset/datastores.py
+++ b/src/pixelator/pixeldataset/datastores.py
@@ -619,6 +619,11 @@ class ZipBasedPixelFileWithParquet(ZipBasedPixelFile):
             where=key,
             filesystem=self._file_system,
             compression=DEFAULT_COMPRESSION,
+            # We want all the data to go into one
+            # parquet row group to allow for maximum compression
+            # when we write the data here.
+            # the `or 1` ensures that it does not raise if
+            # the dataframe is empty.
             row_group_size=len(dataframe) or 1,
         )
 

--- a/src/pixelator/pixeldataset/datastores.py
+++ b/src/pixelator/pixeldataset/datastores.py
@@ -301,7 +301,9 @@ class ZipBasedPixelFile(PixelDataStore):
         files_system = ZipFileSystem(fo=self.path, mode=mode, allowZip64=True)
 
         # For now we are overwriting the zip open method to force it to
-        # always have force_zip=True, otherwise it won't work for large files
+        # always have force_zip=True, otherwise it won't work for large file
+        # This is related to this issue in fsspec:
+        # https://github.com/fsspec/filesystem_spec/issues/1474
         def custom_open(f):
             return partial(f, force_zip64=True)
 

--- a/src/pixelator/pixeldataset/datastores.py
+++ b/src/pixelator/pixeldataset/datastores.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import io
 import json
 import logging
+from functools import partial
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -30,10 +31,7 @@ import pyarrow.parquet as pq
 from anndata import AnnData
 from fsspec.implementations.zip import ZipFileSystem
 
-from functools import partial
-
 from pixelator.exceptions import PixelatorBaseException
-
 from pixelator.pixeldataset.precomputed_layouts import PreComputedLayouts
 
 if TYPE_CHECKING:

--- a/src/pixelator/pixeldataset/precomputed_layouts.py
+++ b/src/pixelator/pixeldataset/precomputed_layouts.py
@@ -239,10 +239,13 @@ def aggregate_precomputed_layouts(
             ).pipe(zero_fill_missing_markers, all_markers=all_markers)
             yield layout_with_name
 
-    return PreComputedLayouts(
-        pl.concat(data(), rechunk=False),
-        partitioning=["sample"] + PreComputedLayouts.DEFAULT_PARTITIONING,
-    )
+    try:
+        return PreComputedLayouts(
+            pl.concat(data(), rechunk=False),
+            partitioning=["sample"] + PreComputedLayouts.DEFAULT_PARTITIONING,
+        )
+    except ValueError:
+        return PreComputedLayouts.create_empty()
 
 
 # TODO The code below this point is not yet tested, and should be considered

--- a/src/pixelator/pixeldataset/precomputed_layouts.py
+++ b/src/pixelator/pixeldataset/precomputed_layouts.py
@@ -232,6 +232,8 @@ def aggregate_precomputed_layouts(
         for sample_name, layout in precomputed_layouts:
             if layout is None:
                 continue
+            if layout.is_empty:
+                continue
             layout_with_name = layout.lazy.with_columns(
                 sample=pl.lit(sample_name)
             ).pipe(zero_fill_missing_markers, all_markers=all_markers)

--- a/tests/pixeldataset/test_precomputed_layouts.py
+++ b/tests/pixeldataset/test_precomputed_layouts.py
@@ -1,4 +1,4 @@
-"""Copyright (c) 2024 Pixelgen Technologies AB."""
+"""Copyright © 2024 Pixelgen Technologies AB."""
 
 from typing import Iterable
 
@@ -7,6 +7,7 @@ import pandas as pd
 import polars as pl
 import pytest
 from pandas.testing import assert_frame_equal
+
 from pixelator.pixeldataset.precomputed_layouts import (
     PreComputedLayouts,
     aggregate_precomputed_layouts,
@@ -205,6 +206,41 @@ class TestPreComputedLayouts:
                     "sample1",
                     "sample1",
                     "sample1",
+                    "sample2",
+                    "sample2",
+                    "sample2",
+                ],
+            }
+        )
+        pd.testing.assert_frame_equal(aggregated_layouts.to_df(), expected_df)
+
+    def test_aggregate_precomputed_layouts_empty_data_frames(self):
+        # Create some sample PreComputedLayouts
+        layout1 = PreComputedLayouts(None)
+        layout2 = PreComputedLayouts(
+            pl.DataFrame(
+                {
+                    "x": [7, 8, 9],
+                    "y": [10, 11, 12],
+                    "component": ["A", "B", "C"],
+                    "sample": ["sample2", "sample2", "sample2"],
+                }
+            ).lazy()
+        )
+
+        # Aggregate the layouts
+        aggregated_layouts = aggregate_precomputed_layouts(
+            [("sample1", layout1), ("sample2", layout2)],
+            all_markers={"x", "y", "component", "sample"},
+        )
+
+        # Check the aggregated layout DataFrame
+        expected_df = pd.DataFrame(
+            {
+                "x": [7, 8, 9],
+                "y": [10, 11, 12],
+                "component": ["A", "B", "C"],
+                "sample": [
                     "sample2",
                     "sample2",
                     "sample2",

--- a/tests/pixeldataset/test_precomputed_layouts.py
+++ b/tests/pixeldataset/test_precomputed_layouts.py
@@ -214,7 +214,7 @@ class TestPreComputedLayouts:
         )
         pd.testing.assert_frame_equal(aggregated_layouts.to_df(), expected_df)
 
-    def test_aggregate_precomputed_layouts_empty_data_frames(self):
+    def test_aggregate_precomputed_layouts_one_empty_data_frame(self):
         # Create some sample PreComputedLayouts
         layout1 = PreComputedLayouts(None)
         layout2 = PreComputedLayouts(
@@ -248,3 +248,16 @@ class TestPreComputedLayouts:
             }
         )
         pd.testing.assert_frame_equal(aggregated_layouts.to_df(), expected_df)
+
+    def test_aggregate_precomputed_layouts_no_layouts_in_data(self):
+        # Create some sample PreComputedLayouts
+        layout1 = PreComputedLayouts(None)
+        layout2 = PreComputedLayouts(None)
+
+        # Aggregate the layouts
+        aggregated_layouts = aggregate_precomputed_layouts(
+            [("sample1", layout1), ("sample2", layout2)],
+            all_markers={"x", "y", "component", "sample"},
+        )
+
+        assert aggregated_layouts.is_empty


### PR DESCRIPTION
## Description

This PR fixes a problem we have with writing large pxl-files larger than 2Gb. This is related to this issue in https://github.com/fsspec/filesystem_spec/issues/1474

It also fixes some other issues I found:
 - Using pyarrow to write caused us to have smaller row groups in the parquet files which gave us much worse compression rations (files growing up to twice the size)
 - Make sure we use `zstd` compression instead of the default `snappy` for better compression rates
 - A bug that caused aggregation to fail when there are no precomputed layouts in the file

Fixes:
 - EXE-1450

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I have run aggregation of a bunch of very large pxl files (without precomputed layouts), and it write an output file larger than 2Gb.
