### PR TITLE
Enforce import sorting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,9 @@ select = [
     # pycodestyle
     "E",
     # pydocstyle
-    "D",]
+    "D",
+    # isort,
+    "I"]
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]
 unfixable = []

--- a/src/pixelator/analysis/colocalization/__init__.py
+++ b/src/pixelator/analysis/colocalization/__init__.py
@@ -6,8 +6,8 @@ Copyright © 2023 Pixelgen Technologies AB.
 import logging
 from functools import partial
 from typing import Optional, get_args
-import numpy as np
 
+import numpy as np
 import pandas as pd
 
 from pixelator.analysis.colocalization.estimate import (

--- a/src/pixelator/analysis/colocalization/permute.py
+++ b/src/pixelator/analysis/colocalization/permute.py
@@ -7,7 +7,8 @@ import time
 from typing import Generator, Optional
 
 import pandas as pd
-from numpy.random import Generator as RandomNumberGenerator, default_rng
+from numpy.random import Generator as RandomNumberGenerator
+from numpy.random import default_rng
 
 from pixelator.analysis.colocalization.types import (
     RegionByCountsDataFrame,

--- a/src/pixelator/annotate/__init__.py
+++ b/src/pixelator/annotate/__init__.py
@@ -23,10 +23,10 @@ from pixelator.annotate.constants import (
 )
 from pixelator.config import AntibodyPanel
 from pixelator.graph.utils import components_metrics, edgelist_metrics
-from pixelator.pixeldataset import PixelDataset, SIZE_DEFINITION
+from pixelator.pixeldataset import SIZE_DEFINITION, PixelDataset
 from pixelator.pixeldataset.utils import edgelist_to_anndata
-from pixelator.report.models.annotate import AnnotateSampleReport
 from pixelator.report.models import SummaryStatistics
+from pixelator.report.models.annotate import AnnotateSampleReport
 
 # TODO
 # Work around for issue with numba and multithreading

--- a/src/pixelator/cli/collapse.py
+++ b/src/pixelator/cli/collapse.py
@@ -13,8 +13,7 @@ import polars as pl
 from pixelator.cli.common import design_option, logger, output_option
 from pixelator.collapse import collapse_fastq
 from pixelator.config import config, get_position_in_parent, load_antibody_panel
-from pixelator.report.models import CollapseSampleReport
-from pixelator.report.models import SummaryStatistics
+from pixelator.report.models import CollapseSampleReport, SummaryStatistics
 from pixelator.utils import (
     create_output_stage_dir,
     get_process_pool_executor,

--- a/src/pixelator/cli/plugin.py
+++ b/src/pixelator/cli/plugin.py
@@ -12,8 +12,8 @@ except ImportError:
     # Python 3.8 and 3.9
     pass
 
-from importlib.metadata import EntryPoint
 import logging
+from importlib.metadata import EntryPoint
 from typing import Generator, List, Union
 
 from click import Group

--- a/src/pixelator/config/panel.py
+++ b/src/pixelator/config/panel.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import warnings
 from functools import cached_property
 from pathlib import Path
-from typing import List, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Optional
 
 import pandas as pd
 import pydantic

--- a/src/pixelator/config/plugin.py
+++ b/src/pixelator/config/plugin.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import importlib.metadata
 import logging
 from importlib.metadata import EntryPoint
-from typing import Generator, List, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Generator, List, Union
 
 try:
     from importlib.metadata import EntryPoints

--- a/src/pixelator/graph/backends/protocol.py
+++ b/src/pixelator/graph/backends/protocol.py
@@ -6,6 +6,7 @@ Copyright © 2023 Pixelgen Technologies AB.
 from __future__ import annotations
 
 from typing import (
+    TYPE_CHECKING,
     Any,
     Dict,
     Iterable,
@@ -15,7 +16,6 @@ from typing import (
     Optional,
     Protocol,
     Set,
-    TYPE_CHECKING,
     Tuple,
     Union,
 )

--- a/src/pixelator/graph/graph.py
+++ b/src/pixelator/graph/graph.py
@@ -19,8 +19,8 @@ from pixelator.graph.backends.implementations import (
 )
 from pixelator.graph.backends.protocol import (
     GraphBackend,
-    VertexClustering,
     SupportedLayoutAlgorithm,
+    VertexClustering,
 )
 
 logger = logging.getLogger(__name__)

--- a/src/pixelator/pixeldataset/__init__.py
+++ b/src/pixelator/pixeldataset/__init__.py
@@ -20,25 +20,22 @@ import polars as pl
 from anndata import AnnData
 
 from pixelator.graph import Graph
+from pixelator.pixeldataset.backends import (
+    FileBasedPixelDatasetBackend,
+    ObjectBasedPixelDatasetBackend,
+    PixelDatasetBackend,
+)
+from pixelator.pixeldataset.datastores import (
+    PixelDataStore,
+    ZipBasedPixelFileWithCSV,
+    ZipBasedPixelFileWithParquet,
+)
+from pixelator.pixeldataset.precomputed_layouts import PreComputedLayouts
 from pixelator.pixeldataset.utils import (
     _enforce_edgelist_types,
     update_metrics_anndata,
 )
-
-from pixelator.pixeldataset.backends import (
-    PixelDatasetBackend,
-    FileBasedPixelDatasetBackend,
-    ObjectBasedPixelDatasetBackend,
-)
-from pixelator.pixeldataset.precomputed_layouts import PreComputedLayouts
-
-from pixelator.pixeldataset.datastores import (
-    PixelDataStore,
-    ZipBasedPixelFileWithParquet,
-    ZipBasedPixelFileWithCSV,
-)
 from pixelator.types import PathType
-
 
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", module="libpysal")

--- a/src/pixelator/pixeldataset/aggregation.py
+++ b/src/pixelator/pixeldataset/aggregation.py
@@ -12,12 +12,12 @@ from typing import (
 
 import pandas as pd
 import polars as pl
-from anndata import AnnData, concat as concatenate_anndata
+from anndata import AnnData
+from anndata import concat as concatenate_anndata
 
 from pixelator.pixeldataset import PixelDataset
-from pixelator.pixeldataset.utils import update_metrics_anndata, _enforce_edgelist_types
 from pixelator.pixeldataset.precomputed_layouts import aggregate_precomputed_layouts
-
+from pixelator.pixeldataset.utils import _enforce_edgelist_types, update_metrics_anndata
 
 logger = logging.getLogger(__name__)
 

--- a/src/pixelator/pixeldataset/utils.py
+++ b/src/pixelator/pixeldataset/utils.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 import os
 import warnings
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 import pandas as pd

--- a/src/pixelator/plot/__init__.py
+++ b/src/pixelator/plot/__init__.py
@@ -3,6 +3,7 @@
 Copyright © 2023 Pixelgen Technologies AB.
 """
 
+import warnings
 from typing import Literal, Optional, Tuple, Union
 
 import matplotlib.pyplot as plt
@@ -15,10 +16,9 @@ import scipy
 import seaborn as sns
 from matplotlib import cm
 from matplotlib.colors import Normalize
-import warnings
 
-from pixelator.graph import Graph
 from pixelator.analysis.colocalization import get_differential_colocalization
+from pixelator.graph import Graph
 from pixelator.marks import experimental
 from pixelator.pixeldataset import PixelDataset
 from pixelator.plot.constants import Color

--- a/src/pixelator/report/common/reporting.py
+++ b/src/pixelator/report/common/reporting.py
@@ -7,16 +7,16 @@ from __future__ import annotations
 
 import logging
 import typing
-from typing import Iterable
 from pathlib import Path
+from typing import Iterable
 
 import pandas as pd
 
 from pixelator.report.common.cli_info import CLIInvocationInfo
 from pixelator.report.common.workdir import (
-    WorkdirOutputNotFound,
     PixelatorWorkdir,
     SingleCellStage,
+    WorkdirOutputNotFound,
 )
 from pixelator.report.models import (
     AdapterQCSampleReport,
@@ -27,9 +27,9 @@ from pixelator.report.models import (
     CommandInfo,
     DemuxSampleReport,
     GraphSampleReport,
+    MoleculesDataflowReport,
     PreQCSampleReport,
     ReadsDataflowReport,
-    MoleculesDataflowReport,
 )
 from pixelator.report.models.base import SampleReport
 from pixelator.report.models.layout import LayoutSampleReport

--- a/src/pixelator/report/models/__init__.py
+++ b/src/pixelator/report/models/__init__.py
@@ -8,9 +8,9 @@ from .collapse import CollapseSampleReport
 from .commands import CommandInfo, CommandOption
 from .demux import DemuxSampleReport
 from .graph import GraphSampleReport
+from .molecules_flow import MoleculesDataflowReport
 from .preqc import PreQCSampleReport
 from .reads_flow import ReadsDataflowReport
-from .molecules_flow import MoleculesDataflowReport
 from .summary_statistics import SummaryStatistics
 
 __all__ = [

--- a/src/pixelator/report/models/adapterqc.py
+++ b/src/pixelator/report/models/adapterqc.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+
 import pydantic
 
 from pixelator.report.models.base import SampleReport

--- a/src/pixelator/report/models/annotate.py
+++ b/src/pixelator/report/models/annotate.py
@@ -5,8 +5,9 @@ Copyright © 2023 Pixelgen Technologies AB.
 
 from __future__ import annotations
 
-from typing import Optional
 import textwrap
+from typing import Optional
+
 import pydantic
 
 from pixelator.report.models.base import SampleReport

--- a/src/pixelator/report/models/commands.py
+++ b/src/pixelator/report/models/commands.py
@@ -9,7 +9,7 @@ import json
 import logging
 import typing
 from pathlib import Path
-from typing import Any, Mapping, TypeVar, Optional
+from typing import Any, Mapping, Optional, TypeVar
 
 import click
 import pydantic

--- a/src/pixelator/report/models/layout.py
+++ b/src/pixelator/report/models/layout.py
@@ -5,7 +5,6 @@ Copyright © 2024 Pixelgen Technologies AB.
 
 from __future__ import annotations
 
-
 from pixelator.report.models.base import SampleReport
 
 

--- a/src/pixelator/report/models/summary_statistics.py
+++ b/src/pixelator/report/models/summary_statistics.py
@@ -4,6 +4,7 @@ Copyright © 2023 Pixelgen Technologies AB.
 """
 
 from __future__ import annotations
+
 from typing import TYPE_CHECKING, TypeVar
 
 import numpy as np

--- a/src/pixelator/report/qcreport/collect.py
+++ b/src/pixelator/report/qcreport/collect.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 import polars as pl
 
-from pixelator.pixeldataset import PixelDataset, SIZE_DEFINITION
+from pixelator.pixeldataset import SIZE_DEFINITION, PixelDataset
 from pixelator.report.qcreport.types import QCReportData
 
 logger = logging.getLogger(__name__)
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 if typing.TYPE_CHECKING:
     from anndata import AnnData
+
     from pixelator.report import PixelatorWorkdir
 
 

--- a/src/pixelator/report/qcreport/types.py
+++ b/src/pixelator/report/qcreport/types.py
@@ -4,7 +4,7 @@ Copyright © 2022 Pixelgen Technologies AB.
 """
 
 import dataclasses
-from typing import List, Optional, TypeVar, TypedDict
+from typing import List, Optional, TypedDict, TypeVar
 
 from pixelator.report.models.commands import CommandInfo
 

--- a/src/pixelator/test_utils/__init__.py
+++ b/src/pixelator/test_utils/__init__.py
@@ -14,8 +14,10 @@ from .report import BaseReportTestsMixin
 from .workflow import PixelatorWorkflowTest
 from .workflow_context import PixelatorWorkflowContext, use_workflow_context
 
+# isort: off
 # Unsorted import to avoid circular dependencies
 from .collector import YamlIntegrationTestsCollector
+# isort: on
 
 __all__ = [
     "BaseAmpliconTestsMixin",

--- a/src/pixelator/test_utils/collector.py
+++ b/src/pixelator/test_utils/collector.py
@@ -5,8 +5,8 @@ Copyright © 2023 Pixelgen Technologies AB.
 
 import pytest
 
-from .workflow import PixelatorWorkflowTest
 from .config import WorkflowConfig
+from .workflow import PixelatorWorkflowTest
 
 
 class NoModuleClass(pytest.Class):  # noqa

--- a/src/pixelator/test_utils/demux.py
+++ b/src/pixelator/test_utils/demux.py
@@ -7,6 +7,7 @@ import pytest
 
 from pixelator.config import config
 from pixelator.config.panel import load_antibody_panel
+
 from .base import BaseWorkflowTestMixin
 
 logger = logging.getLogger(__name__)

--- a/src/pixelator/test_utils/workflow.py
+++ b/src/pixelator/test_utils/workflow.py
@@ -1,6 +1,7 @@
 """Copyright © 2023 Pixelgen Technologies AB."""
 
 from __future__ import annotations
+
 import typing
 from pathlib import Path
 
@@ -9,10 +10,10 @@ from . import (
     BaseAmpliconTestsMixin,
     BaseAnalysisTestsMixin,
     BaseAnnotateTestsMixin,
-    BaseLayoutTestsMixin,
     BaseCollapseTestsMixin,
     BaseDemuxTestsMixin,
     BaseGraphTestsMixin,
+    BaseLayoutTestsMixin,
     BasePreQCTestsMixin,
     BaseReportTestsMixin,
 )

--- a/src/pixelator/test_utils/workflow_context.py
+++ b/src/pixelator/test_utils/workflow_context.py
@@ -6,7 +6,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import pytest
-from click.testing import CliRunner, Result as CliRunnerResult
+from click.testing import CliRunner
+from click.testing import Result as CliRunnerResult
 
 import pixelator.cli as pixelator_cli
 

--- a/tests/amplicon/test_amplicon.py
+++ b/tests/amplicon/test_amplicon.py
@@ -11,7 +11,6 @@ import itertools
 import numpy as np
 import pyfastx
 import pytest
-
 from pixelator.amplicon.process import generate_amplicon
 from pixelator.config import config, get_position_in_parent
 

--- a/tests/amplicon/test_cli.py
+++ b/tests/amplicon/test_cli.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
-
 from pixelator import cli
 
 

--- a/tests/amplicon/test_statistics.py
+++ b/tests/amplicon/test_statistics.py
@@ -4,7 +4,6 @@ Copyright © 2023 Pixelgen Technologies AB.
 """
 
 import numpy as np
-
 from pixelator.amplicon.statistics import (
     SequenceQualityStats,
     SequenceQualityStatsCollector,

--- a/tests/analysis/colocalization/test_colocalization.py
+++ b/tests/analysis/colocalization/test_colocalization.py
@@ -8,7 +8,6 @@ import numpy as np
 import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
-
 from pixelator.analysis.colocalization import (
     colocalization_from_component_edgelist,
     colocalization_scores,

--- a/tests/analysis/colocalization/test_estimate.py
+++ b/tests/analysis/colocalization/test_estimate.py
@@ -8,7 +8,6 @@ import numpy as np
 import pandas as pd
 from numpy.random import default_rng
 from pandas.testing import assert_frame_equal
-
 from pixelator.analysis.colocalization.estimate import (
     estimate_observation_statistics,
     permutation_analysis_results,

--- a/tests/analysis/colocalization/test_permute.py
+++ b/tests/analysis/colocalization/test_permute.py
@@ -7,7 +7,6 @@ Copyright © 2023 Pixelgen Technologies AB.
 import pandas as pd
 from numpy.random import default_rng
 from pandas.testing import assert_series_equal
-
 from pixelator.analysis.colocalization.permute import (
     permutations,
     permute,

--- a/tests/analysis/colocalization/test_prepare.py
+++ b/tests/analysis/colocalization/test_prepare.py
@@ -10,7 +10,6 @@ import pandas as pd
 import pytest
 from numpy.random import default_rng
 from pandas.testing import assert_frame_equal
-
 from pixelator.analysis.colocalization.prepare import (
     filter_by_marker_counts,
     filter_by_region_counts,

--- a/tests/analysis/colocalization/test_statistics.py
+++ b/tests/analysis/colocalization/test_statistics.py
@@ -3,10 +3,9 @@
 Copyright © 2023 Pixelgen Technologies AB.
 """
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 from pandas.testing import assert_frame_equal
-
 from pixelator.analysis.colocalization.statistics import (
     Jaccard,
     Pearson,

--- a/tests/analysis/polarization/test_polarization.py
+++ b/tests/analysis/polarization/test_polarization.py
@@ -10,11 +10,11 @@ import numpy as np
 import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
-
 from pixelator.analysis.polarization import (
     polarization_scores,
     polarization_scores_component,
 )
+
 from tests.graph.networkx.test_tools import create_randomly_connected_bipartite_graph
 
 

--- a/tests/annotate/test_aggregates.py
+++ b/tests/annotate/test_aggregates.py
@@ -8,7 +8,6 @@ import numpy as np
 import pandas as pd
 import pytest
 from anndata import AnnData
-
 from pixelator.annotate.aggregates import call_aggregates
 
 NBR_OF_MARKERS = 100

--- a/tests/annotate/test_annotate.py
+++ b/tests/annotate/test_annotate.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import pandas as pd
 import pytest
 from anndata import AnnData
-
 from pixelator.annotate import cluster_components, filter_components_sizes
 from pixelator.cli.annotate import annotate_components
 from pixelator.config import AntibodyPanel

--- a/tests/annotate/test_cell_calling.py
+++ b/tests/annotate/test_cell_calling.py
@@ -5,7 +5,6 @@ Copyright © 2023 Pixelgen Technologies AB.
 """
 
 import numpy as np
-
 from pixelator.annotate.cell_calling import (
     find_component_size_limits,
 )

--- a/tests/collapse/test_process.py
+++ b/tests/collapse/test_process.py
@@ -14,7 +14,6 @@ import pandas as pd
 import pytest
 from numpy.testing import assert_array_equal
 from pandas.testing import assert_frame_equal
-
 from pixelator.collapse.process import (
     CollapsedFragment,
     build_annoytree,

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -7,7 +7,6 @@ Copyright © 2023 Pixelgen Technologies AB.
 import copy
 
 import pytest
-
 from pixelator.config import (
     Config,
     RegionType,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,6 @@ import pandas as pd
 import polars as pl
 import pytest
 from anndata import AnnData
-
 from pixelator.config import AntibodyPanel
 from pixelator.graph import update_edgelist_membership
 from pixelator.graph.utils import union as graph_union
@@ -21,6 +20,7 @@ from pixelator.pixeldataset import (
 )
 from pixelator.pixeldataset.precomputed_layouts import PreComputedLayouts
 from pixelator.pixeldataset.utils import edgelist_to_anndata
+
 from tests.graph.networkx.test_tools import (
     create_fully_connected_bipartite_graph,
     create_random_graph,

--- a/tests/graph/backends/test_implementations.py
+++ b/tests/graph/backends/test_implementations.py
@@ -5,18 +5,17 @@ Copyright © 2023 Pixelgen Technologies AB.
 
 import networkx as nx
 import pytest
-
 from pixelator.graph.backends.implementations import (
     graph_backend,
     graph_backend_from_graph_type,
 )
 from pixelator.graph.backends.implementations._networkx import (
-    NetworkXGraphBackend,
     NetworkxBasedEdge,
     NetworkxBasedEdgeSequence,
     NetworkxBasedVertex,
     NetworkxBasedVertexClustering,
     NetworkxBasedVertexSequence,
+    NetworkXGraphBackend,
 )
 
 

--- a/tests/graph/conftest.py
+++ b/tests/graph/conftest.py
@@ -7,9 +7,9 @@ Copyright © 2023 Pixelgen Technologies AB.
 import networkx as nx
 import pandas as pd
 import pytest
-
 from pixelator.graph import Graph
 from pixelator.graph.backends.implementations import graph_backend
+
 from tests.graph.networkx.test_tools import add_random_names_to_vertexes
 
 

--- a/tests/graph/networkx/test_tools.py
+++ b/tests/graph/networkx/test_tools.py
@@ -10,7 +10,6 @@ from typing import Optional
 
 import networkx as nx
 import numpy as np
-
 from pixelator.graph.utils import Graph
 
 

--- a/tests/graph/test_community_detection.py
+++ b/tests/graph/test_community_detection.py
@@ -6,7 +6,6 @@ Copyright © 2022 Pixelgen Technologies AB.
 import pandas as pd
 import polars as pl
 import pytest
-
 from pixelator.graph.community_detection import (
     community_detection_crossing_edges,
     connect_components,

--- a/tests/graph/test_graph.py
+++ b/tests/graph/test_graph.py
@@ -11,8 +11,8 @@ import pandas as pd
 import pytest
 from numpy.testing import assert_array_equal
 from pandas.testing import assert_frame_equal
-
 from pixelator.graph import Graph
+
 from tests.graph.networkx.test_tools import random_sequence
 from tests.test_tools import enforce_edgelist_types_for_tests
 

--- a/tests/graph/test_graph_utils.py
+++ b/tests/graph/test_graph_utils.py
@@ -10,7 +10,6 @@ import pandas as pd
 import polars as pl
 import pytest
 from pandas.testing import assert_frame_equal
-
 from pixelator.graph import Graph
 from pixelator.graph.utils import (
     components_metrics,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,7 +10,6 @@ from types import TracebackType
 from typing import Optional, Type
 
 import pytest
-
 from pixelator.test_utils import (  # noqa: F401
     YamlIntegrationTestsCollector,
     use_workflow_context,

--- a/tests/pixeldataset/test_datastores.py
+++ b/tests/pixeldataset/test_datastores.py
@@ -15,12 +15,12 @@ from pandas.core.frame import DataFrame
 from pandas.testing import assert_frame_equal
 from pixelator.pixeldataset import PixelDataset
 from pixelator.pixeldataset.datastores import (
+    CannotOverwriteError,
     FileFormatNotRecognizedError,
     PixelDataStore,
     ZipBasedPixelFile,
     ZipBasedPixelFileWithCSV,
     ZipBasedPixelFileWithParquet,
-    CannotOverwriteError,
 )
 from pixelator.pixeldataset.precomputed_layouts import PreComputedLayouts
 

--- a/tests/plot/test_plot.py
+++ b/tests/plot/test_plot.py
@@ -5,25 +5,24 @@ Copyright © 2023 Pixelgen Technologies AB.
 
 import numpy as np
 import pandas as pd
-import pytest
 import plotly.graph_objects as go
-from pytest_snapshot.plugin import Snapshot
+import pytest
 from numpy.testing import assert_almost_equal
-
 from pixelator.graph import Graph
 from pixelator.plot import (
     _calculate_densities,
     _calculate_distance_to_unit_sphere_zones,
     _unit_sphere_surface,
-    plot_2d_graph,
-    plot_3d_graph,
-    plot_colocalization_heatmap,
-    plot_colocalization_diff_heatmap,
-    plot_3d_heatmap,
-    scatter_umi_per_upia_vs_tau,
     cell_count_plot,
     edge_rank_plot,
+    plot_2d_graph,
+    plot_3d_graph,
+    plot_3d_heatmap,
+    plot_colocalization_diff_heatmap,
+    plot_colocalization_heatmap,
+    scatter_umi_per_upia_vs_tau,
 )
+from pytest_snapshot.plugin import Snapshot
 
 
 @pytest.mark.parametrize(

--- a/tests/report/conftest.py
+++ b/tests/report/conftest.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
-
 from pixelator import PixelDataset
 from pixelator.report.common import PixelatorWorkdir
 

--- a/tests/report/test_adapterqc.py
+++ b/tests/report/test_adapterqc.py
@@ -4,7 +4,6 @@ Copyright © 2023 Pixelgen Technologies AB.
 """
 
 import pytest
-
 from pixelator.report import PixelatorReporting, PixelatorWorkdir
 
 

--- a/tests/report/test_amplicon.py
+++ b/tests/report/test_amplicon.py
@@ -6,7 +6,6 @@ Copyright © 2023 Pixelgen Technologies AB.
 import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
-
 from pixelator.report import PixelatorReporting, PixelatorWorkdir
 from pixelator.report.models.amplicon import AmpliconSampleReport
 

--- a/tests/report/test_analysis.py
+++ b/tests/report/test_analysis.py
@@ -4,7 +4,6 @@ Copyright © 2023 Pixelgen Technologies AB.
 """
 
 import pytest
-
 from pixelator.report import PixelatorReporting, PixelatorWorkdir
 from pixelator.report.models.analysis import (
     AnalysisSampleReport,

--- a/tests/report/test_annotate.py
+++ b/tests/report/test_annotate.py
@@ -4,7 +4,6 @@ Copyright © 2023 Pixelgen Technologies AB.
 """
 
 import pytest
-
 from pixelator.report import PixelatorReporting, PixelatorWorkdir
 from pixelator.report.models import SummaryStatistics
 from pixelator.report.models.annotate import AnnotateSampleReport

--- a/tests/report/test_cli_info.py
+++ b/tests/report/test_cli_info.py
@@ -6,7 +6,6 @@ Copyright © 2023 Pixelgen Technologies AB.
 import shutil
 
 import pytest
-
 from pixelator.report import PixelatorReporting, SingleCellStage
 from pixelator.report.common import WorkdirOutputNotFound
 from pixelator.report.models import CommandInfo

--- a/tests/report/test_collapse.py
+++ b/tests/report/test_collapse.py
@@ -4,7 +4,6 @@ Copyright © 2023 Pixelgen Technologies AB.
 """
 
 import pytest
-
 from pixelator.report import PixelatorReporting, PixelatorWorkdir
 
 

--- a/tests/report/test_data_collection.py
+++ b/tests/report/test_data_collection.py
@@ -4,8 +4,8 @@ Copyright © 2023 Pixelgen Technologies AB.
 """
 
 import json
-import pytest
 
+import pytest
 from pixelator.report.common.json_encoder import PixelatorJSONEncoder
 from pixelator.report.qcreport.collect import (
     collect_antibody_counts_data,

--- a/tests/report/test_demux.py
+++ b/tests/report/test_demux.py
@@ -4,7 +4,6 @@ Copyright © 2023 Pixelgen Technologies AB.
 """
 
 import pytest
-
 from pixelator.report import PixelatorReporting, PixelatorWorkdir
 
 

--- a/tests/report/test_graph.py
+++ b/tests/report/test_graph.py
@@ -4,7 +4,6 @@ Copyright © 2023 Pixelgen Technologies AB.
 """
 
 import pytest
-
 from pixelator.report import PixelatorReporting, PixelatorWorkdir
 
 

--- a/tests/report/test_layout.py
+++ b/tests/report/test_layout.py
@@ -4,7 +4,6 @@ Copyright © 2024 Pixelgen Technologies AB.
 """
 
 import pytest
-
 from pixelator.report import PixelatorReporting, PixelatorWorkdir
 from pixelator.report.models.layout import LayoutSampleReport
 

--- a/tests/report/test_preqc.py
+++ b/tests/report/test_preqc.py
@@ -6,7 +6,6 @@ Copyright © 2023 Pixelgen Technologies AB.
 import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
-
 from pixelator.report import PixelatorReporting, PixelatorWorkdir
 from pixelator.report.models.preqc import PreQCSampleReport
 

--- a/tests/report/test_qc_report.py
+++ b/tests/report/test_qc_report.py
@@ -14,8 +14,6 @@ from pathlib import Path
 import lxml
 import pytest
 from lxml.etree import _Element as LxmlElement
-from playwright.sync_api import Page, expect
-
 from pixelator import __version__
 from pixelator.report.qcreport import (
     QCReportBuilder,
@@ -31,6 +29,7 @@ from pixelator.report.qcreport.collect import (
     collect_components_umap_data,
     collect_reads_per_molecule_frequency,
 )
+from playwright.sync_api import Page, expect
 
 
 @pytest.fixture()

--- a/tests/report/test_report_sample_metadata.py
+++ b/tests/report/test_report_sample_metadata.py
@@ -5,7 +5,6 @@ Copyright © 2023 Pixelgen Technologies AB.
 
 import pandas as pd
 import pytest
-
 from pixelator.report.models.report_metadata import SampleMetadata, SampleMetadataRecord
 
 

--- a/tests/report/test_reporting.py
+++ b/tests/report/test_reporting.py
@@ -4,7 +4,6 @@ Copyright © 2023 Pixelgen Technologies AB.
 """
 
 import pytest
-
 from pixelator.report import PixelatorReporting, PixelatorWorkdir
 
 

--- a/tests/report/test_workdir.py
+++ b/tests/report/test_workdir.py
@@ -7,7 +7,6 @@ import os
 import shutil
 
 import pytest
-
 from pixelator.report import PixelatorWorkdir
 from pixelator.report.common import WorkdirOutputNotFound
 

--- a/tests/resources/test_panel.py
+++ b/tests/resources/test_panel.py
@@ -8,7 +8,6 @@ from tempfile import NamedTemporaryFile
 
 import pandas as pd
 import pytest
-
 from pixelator.config import AntibodyPanel
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,7 +7,6 @@ Copyright © 2022 Pixelgen Technologies AB.
 
 import pytest
 from click.testing import CliRunner
-
 from pixelator import cli
 
 pytestmark = pytest.mark.integration_test

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -6,9 +6,9 @@ Copyright © 2024 Pixelgen Technologies AB.
 import logging
 import tempfile
 import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
-from concurrent.futures import ThreadPoolExecutor
 import pytest
 from pixelator.logging import LoggingSetup
 from pixelator.utils import (

--- a/tests/test_marks.py
+++ b/tests/test_marks.py
@@ -4,7 +4,6 @@ Copyright © 2023 Pixelgen Technologies AB.
 """
 
 import pytest
-
 from pixelator.marks import experimental
 
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -8,7 +8,6 @@ from importlib.metadata import EntryPoint
 from unittest import mock
 
 import click
-
 from pixelator.cli.main import main_cli
 from pixelator.cli.plugin import add_cli_plugins, fetch_cli_plugins
 from pixelator.config import Config, config

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 from numpy.testing import assert_allclose, assert_array_almost_equal
 from pandas.testing import assert_frame_equal
-
 from pixelator.statistics import (
     clr_transformation,
     correct_pvalues,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,6 @@
 """Copyright © 2023 Pixelgen Technologies AB."""
 
 import pytest
-
 from pixelator.utils import flatten
 
 


### PR DESCRIPTION
## Description

This PR adds enforcing of import sort order according to the `ruff` `isort` rules. It also auto fixes this across all files. This should have no functional impact on the code.

Fixes: exe-1512