### PR TITLE
Feature/exe 1514 cache graph marker count

### DIFF
--- a/src/pixelator/analysis/colocalization/prepare.py
+++ b/src/pixelator/analysis/colocalization/prepare.py
@@ -23,38 +23,6 @@ def prepare_from_graph(graph: Graph, n_neighbours: int = 1) -> RegionByCountsDat
     return counts_df
 
 
-def prepare_from_edgelist(
-    edgelist: pd.DataFrame, group_by: Literal["upia", "upib"] = "upia"
-) -> RegionByCountsDataFrame:
-    """Prepare a RegionByCountsDataFrame from an edgelist.
-
-    Prepare a RegionByCountsDataFrame from an edgelist, using
-    either upia or upib as regions
-
-    :param edgelist: edgelist to prepare from
-    :param group_by: value to create regions from, defaults to "upia"
-    :return: a RegionByCountsDataFrame
-    :rtype: RegionByCountsDataFrame
-    """
-    markers_per_pixel = (
-        edgelist.astype({"upia": "string[pyarrow]", "upib": "string[pyarrow]"})
-        .groupby(by=group_by)["marker"]
-        .value_counts()
-        .reset_index()
-    ).pivot_table(
-        index=group_by, columns="marker", values="count", fill_value=0, observed=False
-    )
-    markers_per_pixel.columns.name = "markers"
-    markers_per_pixel.index.name = "node"
-    markers_per_pixel.index = markers_per_pixel.index.astype("string[pyarrow]")
-    markers_per_pixel = markers_per_pixel.reindex(
-        sorted(markers_per_pixel.columns), axis=1
-    )
-    markers_per_pixel.columns = markers_per_pixel.columns.astype("string[pyarrow]")
-    markers_per_pixel = markers_per_pixel.astype("int64", copy=False)
-    return markers_per_pixel
-
-
 def filter_by_region_counts(
     df: RegionByCountsDataFrame, min_region_counts: int = 5
 ) -> RegionByCountsDataFrame:

--- a/src/pixelator/graph/backends/implementations/_networkx.py
+++ b/src/pixelator/graph/backends/implementations/_networkx.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import logging
 import warnings
 from collections import defaultdict
-from functools import cached_property
 from timeit import default_timer as timer
 from typing import (
     TYPE_CHECKING,
@@ -367,7 +366,6 @@ class NetworkXGraphBackend(GraphBackend):
         )
         return coordinates
 
-    @cached_property
     def node_marker_counts(self) -> pd.DataFrame:
         """Get the marker counts of each node as a dataframe.
 
@@ -390,12 +388,7 @@ class NetworkXGraphBackend(GraphBackend):
         node_marker_counts.columns = node_marker_counts.columns.astype(
             "string[pyarrow]"
         )
-
-        node_marker_counts.index = pd.Index(
-            list(self.vs.get_attribute("name")),
-            dtype="string[pyarrow]",
-            name="node",
-        )
+        node_marker_counts.index.name = "node"
         return node_marker_counts
 
     def layout_coordinates(
@@ -447,7 +440,7 @@ class NetworkXGraphBackend(GraphBackend):
             coordinates = self._normalize_to_unit_sphere(coordinates)
 
         if get_node_marker_matrix:
-            node_marker_counts = self.node_marker_counts  # type: ignore
+            node_marker_counts = self.node_marker_counts()  # type: ignore
             df = pd.concat([coordinates, node_marker_counts], axis=1)
         else:
             df = coordinates

--- a/src/pixelator/graph/backends/protocol.py
+++ b/src/pixelator/graph/backends/protocol.py
@@ -5,7 +5,6 @@ Copyright © 2023 Pixelgen Technologies AB.
 
 from __future__ import annotations
 
-from functools import cached_property
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -137,7 +136,6 @@ class GraphBackend(Protocol):
         """
         ...
 
-    @cached_property
     def node_marker_counts(self) -> pd.DataFrame:
         """Get the marker counts of each node as a dataframe.
 

--- a/src/pixelator/graph/backends/protocol.py
+++ b/src/pixelator/graph/backends/protocol.py
@@ -5,6 +5,7 @@ Copyright © 2023 Pixelgen Technologies AB.
 
 from __future__ import annotations
 
+from functools import cached_property
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -133,6 +134,16 @@ class GraphBackend(Protocol):
                  the Leiden algorithm. Must be a positive, non-zero float.
         :param **kwargs: will be passed to the underlying Leiden implementation
         :rtype: VertexClustering
+        """
+        ...
+
+    @cached_property
+    def node_marker_counts(self) -> pd.DataFrame:
+        """Get the marker counts of each node as a dataframe.
+
+        :return: node markers as a dataframe
+        :rtype: pd.DataFrame
+        :raises: AssertionError if graph nodes don't include markers
         """
         ...
 

--- a/src/pixelator/graph/graph.py
+++ b/src/pixelator/graph/graph.py
@@ -120,7 +120,7 @@ class Graph:
     @cached_property
     def node_marker_counts(self):
         """Get the node marker counts as a dataframe."""
-        return self._backend.node_marker_counts
+        return self._backend.node_marker_counts()
 
     def vcount(self):
         """Get the total number of vertices in the Graph instance."""

--- a/src/pixelator/graph/graph.py
+++ b/src/pixelator/graph/graph.py
@@ -6,7 +6,7 @@ Copyright © 2023 Pixelgen Technologies AB.
 from __future__ import annotations
 
 import logging
-from functools import lru_cache
+from functools import cached_property, lru_cache
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import pandas as pd
@@ -116,6 +116,11 @@ class Graph:
     def es(self):
         """A sequence of the edges in the Graph instance."""
         return self._backend.es
+
+    @cached_property
+    def node_marker_counts(self):
+        """Get the node marker counts as a dataframe."""
+        return self._backend.node_marker_counts
 
     def vcount(self):
         """Get the total number of vertices in the Graph instance."""

--- a/src/pixelator/graph/utils.py
+++ b/src/pixelator/graph/utils.py
@@ -165,7 +165,6 @@ def create_node_markers_counts(
     graph: Graph,
     k: int = 0,
     normalization: Optional[Literal["mean"]] = None,
-    name_as_index: bool = True,
 ) -> pd.DataFrame:
     """Create a matrix of marker counts for each in the graph.
 
@@ -181,11 +180,9 @@ def create_node_markers_counts(
               1 first level, ...)
     :param normalization: selects a normalization method to apply when
                           building neighborhoods
-    :param name_as_index:  whether to set the name column as the dataframe index
 
     :returns: a pd.DataFrame with the antibody counts per node
     :rtype: pd.DataFrame
-    :raises AssertionError: if no 'markers' attribute is found on the vertices
     """
     if k == 0 and normalization:
         warnings.warn(
@@ -195,23 +192,8 @@ def create_node_markers_counts(
             )
         )
 
-    if "markers" not in graph.vs.attributes():
-        raise AssertionError("Could not find 'markers' in vertex attributes")
-    markers = list(sorted(next(iter(graph.vs))["markers"].keys()))
-    node_marker_counts = pd.DataFrame.from_records(
-        list(graph.vs.get_attribute("markers")),
-        columns=markers,
-        index=list(graph.raw.nodes),
-    )
-    node_marker_counts = node_marker_counts.reindex(
-        sorted(node_marker_counts.columns), axis=1
-    )
-    node_marker_counts.columns.name = "markers"
-    node_marker_counts.columns = node_marker_counts.columns.astype("string[pyarrow]")
-    if name_as_index:
-        node_marker_counts.index = pd.Index(
-            list(graph.vs.get_attribute("name")), dtype="string[pyarrow]", name="node"
-        )
+    node_marker_counts = graph.node_marker_counts
+
     if k == 0:
         return node_marker_counts
 

--- a/src/pixelator/graph/utils.py
+++ b/src/pixelator/graph/utils.py
@@ -223,11 +223,10 @@ def create_node_markers_counts(
     df = pd.DataFrame(
         data=neighbourhood_counts,
         columns=node_marker_counts.columns.copy(),
-        index=pd.Index(
-            list(graph.vs.get_attribute("name")), dtype="string[pyarrow]", name="node"
-        ),
+        index=node_marker_counts.index.copy(),
     )
     df.columns.name = "markers"
+    df.index.name = "node"
     return df
 
 

--- a/tests/analysis/colocalization/test_prepare.py
+++ b/tests/analysis/colocalization/test_prepare.py
@@ -14,18 +14,11 @@ from pixelator.analysis.colocalization.prepare import (
     filter_by_marker_counts,
     filter_by_region_counts,
     filter_by_unique_values,
-    prepare_from_edgelist,
     prepare_from_graph,
 )
 from pixelator.graph.utils import Graph
 
 random_number_generator = default_rng(seed=433)
-
-
-def test_prepare_from_edgelist(edgelist):
-    result = prepare_from_edgelist(edgelist=edgelist, group_by="upia")
-    assert len(result) == edgelist["upia"].nunique()
-    assert len(result.columns) == edgelist["marker"].nunique()
 
 
 @pytest.mark.parametrize("enable_backend", ["networkx"], indirect=True)
@@ -47,25 +40,6 @@ def test_prepare_from_graph(enable_backend, edgelist):
             ],
         )
         assert len(result.columns) == len(unique_markers_in_component)
-
-
-@pytest.mark.parametrize("enable_backend", ["networkx"], indirect=True)
-def test_prepare_from_graph_and_edgelist_eq_for_no_neigbours(enable_backend, edgelist):
-    for _, component_df in edgelist.groupby("component", observed=True):
-        graph = Graph.from_edgelist(
-            edgelist=component_df,
-            add_marker_counts=True,
-            simplify=True,
-            use_full_bipartite=False,
-        )
-        graph_result = prepare_from_graph(graph, n_neighbours=0)
-        edgelist_result = prepare_from_edgelist(edgelist=component_df, group_by="upia")
-        # We drop the indexes since whey will be named differently depending on the
-        # method.
-        assert_frame_equal(
-            graph_result.sort_index(),
-            edgelist_result.sort_index(),
-        )
 
 
 def test_filter_by_region_counts():

--- a/tests/graph/test_graph_utils.py
+++ b/tests/graph/test_graph_utils.py
@@ -56,7 +56,6 @@ def _create_df_with_expected_types(df):
     """Make sure that the dataframe gets the correct types and names."""
     df.columns.name = "markers"
     df.columns = df.columns.astype("string[pyarrow]")
-    df.index = df.index.astype("string[pyarrow]")
     df.index.name = "node"
     return df
 


### PR DESCRIPTION
Makes node_marker_count a cached_property of graph to avoid reconstructing the dataframe with every new call. The property will be a dataframe that is indexed with node ids rather than names. The main reason for this is to enable getting marker counts separately from neighborhood marker calculations. This in turn enables getting neighborhood markers after node and marker filtering and also speed up parameter sweeps for analysis.

prepare_from_edgelist is now removed from colocalization prepare.

Fixes: EXE-1514

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Several existing unit tests including layout calculations use this property.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and documentation and corrected any misspellings
