### PR TITLE
Release 0.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.2] - 2024-03-19
+
+### Fixed
+
+* Uninitialized value for `--polarization-n-permutations`
+
 ## [0.16.1] - 2024-01-12
 
 ### Fixed

--- a/src/pixelator/cli/analysis.py
+++ b/src/pixelator/cli/analysis.py
@@ -70,7 +70,7 @@ from pixelator.utils import (
 )
 @click.option(
     "--polarization-n-permutations",
-    default=None,
+    default=0,
     required=False,
     type=click.IntRange(min=0),
     show_default=True,


### PR DESCRIPTION
## Description

Cherry pick fix to `--polarization-n-permutations` from `dev` to make sure we can release 0.16.2 fixing the issue that this parameter was uninitialized.

Fixes: EXE-1362

## Type of change

Hotfix plus release notes.

## How Has This Been Tested?

We ran `pixelator single-cell analysis` and check that it was initialized to `0` rather than `None`.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If a new tool or package is included, I have updated poetry.lock, and [cited it properly](../CITATIONS.md)
- [x] I have checked my code and documentation and corrected any misspellings
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
