### PR TITLE
Feature/exe 1558 log1p transformation polarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add `pixelator single-cell layout` stage to pixelator, which allows users to compute layouts
   for a PXL file that can then be used to visualize the graph in 2D or 3D downstream.
 * Added minimum marker count `polarization_min_marker_count` parameter to calculate Polarity Score.
+* Added "log1p" as alternative for `PolarizationNormalizationTypes`.
 
 ### Changed
 

--- a/src/pixelator/analysis/__init__.py
+++ b/src/pixelator/analysis/__init__.py
@@ -70,7 +70,7 @@ def analyse_pixels(
     :param use_full_bipartite: use the bipartite graph instead of the
                                one-node-projection (UPIA)
     :param polarization_normalization: the method to use to normalize the
-                                       antibody counts (raw or clr)
+                                       antibody counts (raw, log1p, or clr)
     :param polarization_n_permutations: Select number of permutations used to
                                         calculate empirical p-values of the
                                         polarization scores

--- a/src/pixelator/analysis/polarization/__init__.py
+++ b/src/pixelator/analysis/polarization/__init__.py
@@ -122,19 +122,20 @@ def polarization_scores_component_graph(
         # Calculate normalization factor
         C = N / W.sum()
 
+        def pick_transformation():
+            if normalization == "log1p":
+                return np.log1p
+            if normalization == "clr":
+                return clr_transformation
+            # This is the same as no transformation
+            return lambda x: x
+
+        transformation = pick_transformation()
         X_perm = [
-            np.log1p(x)
-            if normalization == "log1p"
-            else clr_transformation(x)
-            if normalization == "clr"
-            else x
+            transformation(x)
             for x in permutations(X, n=n_permutations, random_seed=random_seed)
         ]
-
-        if normalization == "log1p":
-            X = np.log1p(X)
-        if normalization == "clr":
-            X = clr_transformation(X, non_negative=True, axis=0)
+        X = transformation(X)
 
         _compute_morans_i_per_marker = partial(
             _compute_morans_i,

--- a/src/pixelator/analysis/polarization/__init__.py
+++ b/src/pixelator/analysis/polarization/__init__.py
@@ -127,8 +127,6 @@ def polarization_scores_component_graph(
             if normalization == "log1p"
             else clr_transformation(x)
             if normalization == "clr"
-            else clr_transformation(x, non_negative=False)
-            if normalization == "clr_neg"
             else x
             for x in permutations(X, n=n_permutations, random_seed=random_seed)
         ]
@@ -137,8 +135,6 @@ def polarization_scores_component_graph(
             X = np.log1p(X)
         if normalization == "clr":
             X = clr_transformation(X, non_negative=True, axis=0)
-        if normalization == "clr_neg":
-            X = clr_transformation(X, non_negative=False, axis=0)
 
         _compute_morans_i_per_marker = partial(
             _compute_morans_i,

--- a/src/pixelator/analysis/polarization/__init__.py
+++ b/src/pixelator/analysis/polarization/__init__.py
@@ -84,7 +84,7 @@ def polarization_scores_component_graph(
 
     :param graph: a graph (it must be a single connected component)
     :param component_id: the id of the component
-    :param normalization: the normalization method to use (raw or clr)
+    :param normalization: the normalization method to use (raw, log1p, or clr)
     :param n_permutations: the number of permutations to use to estimate the
                            null-hypothesis for the Moran's I statistic
     :param min_marker_count: the minimum number of counts of a marker to calculate
@@ -190,7 +190,7 @@ def polarization_scores_component_df(
     :param component_id: the id of the component
     :param component_df: A data frame with an edgelist for a single connected component
     :param use_full_bipartite: use the bipartite graph instead of the projection (UPIA)
-    :param normalization: the normalization method to use (raw or clr)
+    :param normalization: the normalization method to use (raw, log1p, or clr)
     :param n_permutations: the number of permutations to use to estimate the
                            null-hypothesis for the Moran's I statistic
     :param min_marker_count: the minimum number of counts of a marker to calculate
@@ -240,7 +240,7 @@ def polarization_scores(
       (morans_p_value_sim and morans_z_sim if `permutations` > 0)
     :param edgelist: an edge list (pd.DataFrame) with a component column
     :param use_full_bipartite: use the bipartite graph instead of the projection (UPIA)
-    :param normalization: the normalization method to use (raw or clr)
+    :param normalization: the normalization method to use (raw, log1p, or clr)
     :param n_permutations: the number of permutations for simulated Z-score (z_sim)
                            estimation (if n_permutations>0)
     :param min_marker_count: the minimum number of counts of a marker to calculate

--- a/src/pixelator/analysis/polarization/__init__.py
+++ b/src/pixelator/analysis/polarization/__init__.py
@@ -123,12 +123,22 @@ def polarization_scores_component_graph(
         C = N / W.sum()
 
         X_perm = [
-            clr_transformation(x) if normalization == "clr" else x
+            np.log1p(x)
+            if normalization == "log1p"
+            else clr_transformation(x)
+            if normalization == "clr"
+            else clr_transformation(x, non_negative=False)
+            if normalization == "clr_neg"
+            else x
             for x in permutations(X, n=n_permutations, random_seed=random_seed)
         ]
 
+        if normalization == "log1p":
+            X = np.log1p(X)
         if normalization == "clr":
             X = clr_transformation(X, non_negative=True, axis=0)
+        if normalization == "clr_neg":
+            X = clr_transformation(X, non_negative=False, axis=0)
 
         _compute_morans_i_per_marker = partial(
             _compute_morans_i,

--- a/src/pixelator/analysis/polarization/types.py
+++ b/src/pixelator/analysis/polarization/types.py
@@ -5,4 +5,4 @@ Copyright © 2023 Pixelgen Technologies AB.
 
 from typing import Literal
 
-PolarizationNormalizationTypes = Literal["raw", "clr", "clr_neg", "log1p"]
+PolarizationNormalizationTypes = Literal["raw", "clr", "log1p"]

--- a/src/pixelator/analysis/polarization/types.py
+++ b/src/pixelator/analysis/polarization/types.py
@@ -5,4 +5,4 @@ Copyright © 2023 Pixelgen Technologies AB.
 
 from typing import Literal
 
-PolarizationNormalizationTypes = Literal["raw", "clr"]
+PolarizationNormalizationTypes = Literal["raw", "clr", "clr_neg", "log1p"]

--- a/src/pixelator/cli/analysis.py
+++ b/src/pixelator/cli/analysis.py
@@ -58,12 +58,13 @@ from pixelator.utils import (
     "--polarization-normalization",
     default="clr",
     required=False,
-    type=click.Choice(["raw", "clr"]),
+    type=click.Choice(["raw", "log1p", "clr"]),
     show_default=True,
     help=(
         "Which approach to use to normalize the antibody counts:"
-        " \n\traw will use the raw counts\n\tclr will use the"
-        " CLR transformed counts"
+        " \n\traw will use the raw counts"
+        " \n\tlog1p will use the log(x+1) transformed counts"
+        " \n\tclr will use the CLR transformed counts"
     ),
 )
 @click.option(

--- a/tests/analysis/polarization/test_polarization.py
+++ b/tests/analysis/polarization/test_polarization.py
@@ -93,18 +93,8 @@ def test_permuted_polarization(enable_backend, full_graph_edgelist: pd.DataFrame
 def test_polarization_log1p(enable_backend, full_graph_edgelist: pd.DataFrame):
     # TODO we should test more scenarios here (sparse and clustered patterns)
 
-    el = full_graph_edgelist
-
-    clr_scores = polarization_scores(
-        edgelist=el,
-        n_permutations=10,
-        normalization="clr_neg",
-        use_full_bipartite=True,
-        random_seed=1,
-    )
-
-    log1p_scores = polarization_scores(
-        edgelist=el,
+    scores = polarization_scores(
+        edgelist=full_graph_edgelist,
         n_permutations=10,
         normalization="log1p",
         use_full_bipartite=True,
@@ -112,7 +102,29 @@ def test_polarization_log1p(enable_backend, full_graph_edgelist: pd.DataFrame):
     )
 
     # test polarization scores
-    assert_frame_equal(clr_scores, log1p_scores)
+    expected = pd.DataFrame.from_dict(
+        {
+            0: {
+                "marker": "A",
+                "morans_i": -0.1776437812217308,
+                "morans_z": -25.810281029712225,
+                "morans_p_value": 3.3990578613561664e-147,
+                "morans_p_adjusted": 6.798115722712333e-147,
+                "component": "PXLCMP0000000",
+            },
+            1: {
+                "marker": "B",
+                "morans_i": -0.17764378122173088,
+                "morans_z": -25.399463214025243,
+                "morans_p_value": 1.2782689040520306e-142,
+                "morans_p_adjusted": 1.2782689040520306e-142,
+                "component": "PXLCMP0000000",
+            },
+        },
+        orient="index",
+    )
+    # test polarization scores
+    assert_frame_equal(scores, expected)
 
 
 def test_polarization_with_differentially_polarized_markers():

--- a/tests/analysis/polarization/test_polarization.py
+++ b/tests/analysis/polarization/test_polarization.py
@@ -89,6 +89,32 @@ def test_permuted_polarization(enable_backend, full_graph_edgelist: pd.DataFrame
     assert_frame_equal(scores, expected)
 
 
+@pytest.mark.parametrize("enable_backend", ["networkx"], indirect=True)
+def test_polarization_log1p(enable_backend, full_graph_edgelist: pd.DataFrame):
+    # TODO we should test more scenarios here (sparse and clustered patterns)
+
+    el = full_graph_edgelist
+
+    clr_scores = polarization_scores(
+        edgelist=el,
+        n_permutations=10,
+        normalization="clr_neg",
+        use_full_bipartite=True,
+        random_seed=1,
+    )
+
+    log1p_scores = polarization_scores(
+        edgelist=el,
+        n_permutations=10,
+        normalization="log1p",
+        use_full_bipartite=True,
+        random_seed=1,
+    )
+
+    # test polarization scores
+    assert_frame_equal(clr_scores, log1p_scores)
+
+
 def test_polarization_with_differentially_polarized_markers():
     # Set seed to get same graph every time
     graph = create_randomly_connected_bipartite_graph(


### PR DESCRIPTION
## Description

This adds "log1p" transformation (`log(x+1)`) as alternative to preprocessing for polarization score calculation.

Fixes: exe-1558

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

A new test has been added to verify functionality. It has also been tested and compared to CLR, which should generate the same polarization scores (it did). 

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated poetry.lock, and [cited it properly](../CITATIONS.md)
- [x] I have checked my code and documentation and corrected any misspellings
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
