### PR TITLE
fix: marker filtering after transformation in polar score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed name of TCRb to TCRVb5 antibody in human-immunology-panel file and bumped to version 0.5.0.
 * Renaming of component metrics in adata
 * Use MPX graph compatible permutation strategy when calculating Moran's I.
+* Marker filtering is now done after count transformation in polarization score calculation.
 
 ### Fixed
 

--- a/tests/analysis/polarization/test_polarization.py
+++ b/tests/analysis/polarization/test_polarization.py
@@ -161,15 +161,15 @@ def test_polarization_with_differentially_polarized_markers():
             0: {
                 "marker": "A",
                 "morans_i": 0.3009109262187527,
-                "morans_z": 3.6409882113983114,
-                "morans_p_value": 0.00013579678673041425,
+                "morans_z": 8.855302575253617,
+                "morans_p_value": 4.1728555387292095e-19,
                 "component": "PXLCMP0000000",
             },
             1: {
                 "marker": "C",
                 "morans_i": -0.001864280387770322,
-                "morans_z": -2.558088675046134,
-                "morans_p_value": 0.005262462500942811,
+                "morans_z": 0.33792334994637657,
+                "morans_p_value": 0.3677104754311888,
                 "component": "PXLCMP0000000",
             },
         },
@@ -223,15 +223,15 @@ def test_polarization_with_min_marker_count():
             0: {
                 "marker": "A",
                 "morans_i": 0.3009109262187527,
-                "morans_z": 3.6409882113983114,
-                "morans_p_value": 0.00013579678673041425,
+                "morans_z": 6.6115290465881955,
+                "morans_p_value": 1.9018523168814586e-11,
                 "component": "PXLCMP0000000",
             },
             1: {
                 "marker": "C",
                 "morans_i": -0.001864280387770322,
-                "morans_z": -2.558088675046134,
-                "morans_p_value": 0.005262462500942811,
+                "morans_z": -0.11473061339664403,
+                "morans_p_value": 0.4543293240814379,
                 "component": "PXLCMP0000000",
             },
         },
@@ -265,7 +265,11 @@ def test_permuted_polarization_with_differentially_polarized_markers():
     random_vertex["markers"]["C"] = 10
 
     scores = polarization_scores_component_graph(
-        graph, component_id="PXLCMP0000000", n_permutations=10, random_seed=1
+        graph,
+        component_id="PXLCMP0000000",
+        n_permutations=10,
+        random_seed=1,
+        min_marker_count=0,
     )
 
     # We don't expect to get a value for B, since it has only one value in it.
@@ -275,15 +279,15 @@ def test_permuted_polarization_with_differentially_polarized_markers():
             0: {
                 "marker": "A",
                 "morans_i": 0.3009109262187527,
-                "morans_z": 3.6409882113983114,
-                "morans_p_value": 0.00013579678673041425,
+                "morans_z": 8.855302575253617,
+                "morans_p_value": 4.1728555387292095e-19,
                 "component": "PXLCMP0000000",
             },
             1: {
                 "marker": "C",
                 "morans_i": -0.001864280387770322,
-                "morans_z": -2.558088675046134,
-                "morans_p_value": 0.005262462500942811,
+                "morans_z": 0.33792334994637657,
+                "morans_p_value": 0.3677104754311888,
                 "component": "PXLCMP0000000",
             },
         },
@@ -291,3 +295,107 @@ def test_permuted_polarization_with_differentially_polarized_markers():
     )
     # test polarization scores
     assert_frame_equal(scores, expected, check_exact=False, atol=1e-3)
+
+
+def test_polarization_transformation():
+    # Set seed to get same graph every time
+    graph = create_randomly_connected_bipartite_graph(
+        n1=50, n2=100, p=0.1, random_seed=2
+    )
+
+    rng = np.random.default_rng(1)
+
+    for v in graph.vs:
+        v["markers"] = {"A": 0, "B": 1, "C": 0, "D": 0}
+    random_vertex = graph.vs.get_vertex(
+        rng.integers(low=0, high=graph.vcount(), size=1)[0]
+    )
+    random_vertex["markers"]["A"] = 5
+    neighbors = random_vertex.neighbors()
+    for n in neighbors:
+        n["markers"]["A"] = 2
+
+    random_vertex = graph.vs.get_vertex(
+        rng.integers(low=0, high=graph.vcount(), size=1)[0]
+    )
+    random_vertex["markers"]["C"] = 10
+
+    random_vertex = graph.vs.get_vertex(
+        rng.integers(low=0, high=graph.vcount(), size=1)[0]
+    )
+    random_vertex["markers"]["D"] = 4
+
+    scores_1 = polarization_scores_component_graph(
+        graph,
+        component_id="PXLCMP0000000",
+        n_permutations=10,
+        random_seed=1,
+        min_marker_count=5,
+    )
+
+    scores_2 = polarization_scores_component_graph(
+        graph,
+        component_id="PXLCMP0000000",
+        n_permutations=10,
+        random_seed=1,
+        min_marker_count=0,
+    )
+
+    # We don't expect to get a value for B, since it has only one value in it.
+    # We don't expect to get a value for D, since the marker is filtered due to
+    # low counts
+    expected_1 = pd.DataFrame.from_dict(
+        {
+            0: {
+                "marker": "A",
+                "morans_i": 0.3009109262187527,
+                "morans_z": 6.6115290465881955,
+                "morans_p_value": 1.9018523168814586e-11,
+                "component": "PXLCMP0000000",
+            },
+            1: {
+                "marker": "C",
+                "morans_i": -0.001864280387770322,
+                "morans_z": -0.11473061339664403,
+                "morans_p_value": 0.4543293240814379,
+                "component": "PXLCMP0000000",
+            },
+        },
+        orient="index",
+    )
+
+    # We don't expect to get a value for B, since it has only one value in it.
+    # We DO expect to get a value for D, since it is not filtered this time
+    expected_2 = pd.DataFrame.from_dict(
+        {
+            0: {
+                "marker": "A",
+                "morans_i": 0.3009109262187527,
+                "morans_z": 6.6115290465881955,
+                "morans_p_value": 1.9018523168814586e-11,
+                "component": "PXLCMP0000000",
+            },
+            1: {
+                "marker": "C",
+                "morans_i": -0.001864280387770322,
+                "morans_z": -0.11473061339664403,
+                "morans_p_value": 0.4543293240814379,
+                "component": "PXLCMP0000000",
+            },
+            2: {
+                "marker": "D",
+                "morans_i": -0.0031455494542742875,
+                "morans_z": 0.8264801996063112,
+                "morans_p_value": 0.204265872789349,
+                "component": "PXLCMP0000000",
+            },
+        },
+        orient="index",
+    )
+
+    # test polarization scores
+    assert_frame_equal(scores_1, expected_1, check_exact=False, atol=1e-3)
+    assert_frame_equal(scores_2, expected_2, check_exact=False, atol=1e-3)
+
+    # we also expect the scores to be the same for A and B
+    assert_frame_equal(scores_1, scores_2.head(2), check_exact=False, atol=1e-3)


### PR DESCRIPTION
## Description

This moves marker filtering to be performed after count transformation and permutation in polarization score calculation in `polarization_scores_component_graph`. This removes bias of filtering parameters on the transformation and permutation.

This has become relevant since the introduction of the `polarization_min_marker_count` parameter, which affects which markers will be filtered prior to polarization score calculation. The bias was present before, but was predictable since there was no way for users to affect which markers were filtered. 

This is a breaking change, since the current transformation (non-negative CLR) takes all markers into account. 

Fixes: exe-1565

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

A new test has been added to verify that filtering parameters do not change the polarization score (which they would previously). 

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated poetry.lock, and [cited it properly](../CITATIONS.md)
- [x] I have checked my code and documentation and corrected any misspellings
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
