### PR TITLE
fix removal of wrong read 1/2 id when multiple matches are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix deflated counts in the edgelist after collapse.
 * Fix bug where an `r1` or `r2` in the directory part of a read file would break file
   name sanity checks.
+* Fix a bug where the wrong `r1` or `r2` in the filename would be removed when multiple
+  matches are present.
 * Logging would cause deadlocks in multiprocessing scenarios, this has been resolved
   by switching to a server/client-based logging system.
 * Fix a bug in the amplicon stage where read suffixes were not correctly recognised.

--- a/src/pixelator/utils/__init__.py
+++ b/src/pixelator/utils/__init__.py
@@ -465,8 +465,10 @@ def get_read_sample_name(read: str) -> str:
     # We need to cast away the optional here r1 or r2 will always
     # return a match object since we checked for both being None above
     match = typing.cast(re.Match[str], r1_match or r2_match)
-    pattern = match.group()
-    sample_name = read_stem.replace(pattern, "")
+
+    # Remove the R1 or R2 suffix by using the indices returned by the match
+    s, e = match.span()
+    sample_name = read_stem[0:s] + read_stem[e:-1]
 
     if match.groupdict().get("suffix"):
         sample_name += match.group("suffix")

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -123,6 +123,14 @@ def test_get_read_sample_name():
     assert get_read_sample_name("sample1_L001_R1_001.fq.gz") == "sample1_L001_001"
     assert get_read_sample_name("sample1_L001_R2_001.fq.gz") == "sample1_L001_001"
 
+    # Check that the right `_1` is removed when there are multiple matches
+    assert get_read_sample_name("sample_ABCD_12345_1.fastq.gz") == "sample_ABCD_12345"
+    # Check that the right `_2` is removed when there are multiple matches
+    assert (
+        get_read_sample_name("sample_ABCD_2234_2___2_66_2.fastq.gz")
+        == "sample_ABCD_2234_2___2_66"
+    )
+
 
 def test_is_read_file():
     with pytest.raises(ValueError, match="Invalid file extension.*"):


### PR DESCRIPTION
## Description

Fix a bug where the wrong read 1/2 suffix is stripped away causing the pipeline to file due to mismatches sample names 
between r1 and r2 read pairs.

Fixes: EXE-1633

