### PR TITLE
`convert_indices_to_integers` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add a `precomputed_layouts` property to `pixeldataset` to allow for loading precomputed layouts.
 * Add `pixelator single-cell layout` stage to pixelator, which allows users to compute layouts
   for a PXL file that can then be used to visualize the graph in 2D or 3D downstream.
-* Added minimum marker count `polarization_min_marker_count` parameter to calculate Polarity Score.
-* Added "log1p" as alternative for `PolarizationNormalizationTypes`.
+* Add minimum marker count `polarization_min_marker_count` parameter to calculate Polarity Score.
+* Add "log1p" as alternative for `PolarizationNormalizationTypes`.
+* Add `convert_indices_to_integers` option when creating graphs.
+
 
 ### Changed
 

--- a/src/pixelator/graph/backends/implementations/_networkx.py
+++ b/src/pixelator/graph/backends/implementations/_networkx.py
@@ -203,7 +203,7 @@ class NetworkXGraphBackend(GraphBackend):
         :param simplify: simplifies the graph (remove redundant edges)
         :param use_full_bipartite: use the bipartite graph instead of the projection
                                   (UPIA)
-        :param convert_indices_to_integers: convert the indices to integers (this in the default)
+        :param convert_indices_to_integers: convert the indices to integers (this is the default)
         :returns: a GraphBackend instance
         :rtype: NetworkXGraphBackend
         :raises: AssertionError when the input edge list is not valid

--- a/src/pixelator/graph/backends/protocol.py
+++ b/src/pixelator/graph/backends/protocol.py
@@ -46,6 +46,7 @@ class GraphBackend(Protocol):
         add_marker_counts: bool,
         simplify: bool,
         use_full_bipartite: bool,
+        convert_indices_to_integers: bool = True,
     ) -> GraphBackend:
         """Build a graph from an edgelist.
 
@@ -64,6 +65,7 @@ class GraphBackend(Protocol):
         :param simplify: simplifies the graph (remove redundant edges)
         :param use_full_bipartite: use the bipartite graph instead of the projection
                                   (UPIA)
+        :param convert_indices_to_integers: convert the indices to integers (this in the default)
         :returns: a Graph instance
         :rtype: GraphBackend
         :raises: AssertionError when the input edge list is not valid

--- a/src/pixelator/graph/backends/protocol.py
+++ b/src/pixelator/graph/backends/protocol.py
@@ -65,7 +65,7 @@ class GraphBackend(Protocol):
         :param simplify: simplifies the graph (remove redundant edges)
         :param use_full_bipartite: use the bipartite graph instead of the projection
                                   (UPIA)
-        :param convert_indices_to_integers: convert the indices to integers (this in the default)
+        :param convert_indices_to_integers: convert the indices to integers (this is the default)
         :returns: a Graph instance
         :rtype: GraphBackend
         :raises: AssertionError when the input edge list is not valid

--- a/src/pixelator/graph/graph.py
+++ b/src/pixelator/graph/graph.py
@@ -68,7 +68,7 @@ class Graph:
         :param simplify: simplifies the graph (remove redundant edges)
         :param use_full_bipartite: use the bipartite graph instead of the projection
                                   (UPIA)
-        :param convert_indices_to_integers: convert the indices to integers (this in the default)
+        :param convert_indices_to_integers: convert the indices to integers (this is the default)
         :returns: a Graph instance
         :rtype: Graph
         :raises: AssertionError when the input edge list is not valid

--- a/src/pixelator/graph/graph.py
+++ b/src/pixelator/graph/graph.py
@@ -47,6 +47,7 @@ class Graph:
         add_marker_counts: bool,
         simplify: bool,
         use_full_bipartite: bool,
+        convert_indices_to_integers: bool = True,
     ) -> Graph:
         """Build a graph from an edgelist.
 
@@ -67,6 +68,7 @@ class Graph:
         :param simplify: simplifies the graph (remove redundant edges)
         :param use_full_bipartite: use the bipartite graph instead of the projection
                                   (UPIA)
+        :param convert_indices_to_integers: convert the indices to integers (this in the default)
         :returns: a Graph instance
         :rtype: Graph
         :raises: AssertionError when the input edge list is not valid
@@ -76,6 +78,7 @@ class Graph:
             add_marker_counts=add_marker_counts,
             simplify=simplify,
             use_full_bipartite=use_full_bipartite,
+            convert_indices_to_integers=convert_indices_to_integers,
         )
 
         return Graph(backend=backend)

--- a/src/pixelator/pixeldataset/precomputed_layouts.py
+++ b/src/pixelator/pixeldataset/precomputed_layouts.py
@@ -394,6 +394,7 @@ def _compute_layouts(
                 add_marker_counts=add_node_marker_counts,
                 simplify=True,
                 use_full_bipartite=True,
+                convert_indices_to_integers=False,
             )
             for layout_algorithm in layout_algorithms:
                 yield (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,6 +162,7 @@ def layout_df_fixture() -> pd.DataFrame:
             "component": rgn.choice(components, nbr_of_rows),
             "name": "TTTT",
             "pixel_type": "A",
+            "index": range(0, nbr_of_rows),
         }
         | {
             marker: rgn.integers(0, 10, nbr_of_rows)

--- a/tests/graph/test_graph.py
+++ b/tests/graph/test_graph.py
@@ -74,6 +74,52 @@ def test_build_graph_full_bipartite(enable_backend, full_graph_edgelist: pd.Data
 
 
 @pytest.mark.parametrize("enable_backend", ["networkx"], indirect=True)
+def test_build_graph_convert_indices_to_integers(
+    enable_backend, edgelist: pd.DataFrame
+):
+    graph = Graph.from_edgelist(
+        edgelist=edgelist,
+        add_marker_counts=True,
+        simplify=True,
+        use_full_bipartite=True,
+        convert_indices_to_integers=True,
+    )
+    assert graph.vs.attributes() == {"name", "markers", "type", "pixel_type"}
+    # We want the indices to be converted to integers
+    # when convert_indices_to_integers=True
+    assert graph.vs.get_vertex(0)
+    with pytest.raises(KeyError):
+        graph.vs.get_vertex("ACCGTAGATGCATCATAGACT")
+
+    edge = list(graph.es)[0]
+    assert isinstance(edge[0], int)
+    assert isinstance(edge[1], int)
+
+
+@pytest.mark.parametrize("enable_backend", ["networkx"], indirect=True)
+def test_build_graph_do_not_convert_indices_to_integers(
+    enable_backend, edgelist: pd.DataFrame
+):
+    graph = Graph.from_edgelist(
+        edgelist=edgelist,
+        add_marker_counts=True,
+        simplify=True,
+        use_full_bipartite=True,
+        convert_indices_to_integers=False,
+    )
+    assert graph.vs.attributes() == {"name", "markers", "type", "pixel_type"}
+    # We want the indices to be kept as strings when
+    # convert_indices_to_integers=False
+    assert graph.vs.get_vertex("ACCGTAGATGCATCATAGACT")
+    with pytest.raises(KeyError):
+        graph.vs.get_vertex(0)
+
+    edge = list(graph.es)[0]
+    assert isinstance(edge[0], str)
+    assert isinstance(edge[1], str)
+
+
+@pytest.mark.parametrize("enable_backend", ["networkx"], indirect=True)
 def test_build_graph_full_bipartite_do_not_add_marker_counts(
     enable_backend,
     full_graph_edgelist: pd.DataFrame,
@@ -316,6 +362,7 @@ def test_layout_coordinates_2d_networkx(enable_backend, pentagram_graph):
         pd.DataFrame.from_dict(
             data={
                 0: {
+                    "index": 0,
                     "name": "AAAA",
                     "pixel_type": "A",
                     "x": -0.19130137780050335,
@@ -327,6 +374,7 @@ def test_layout_coordinates_2d_networkx(enable_backend, pentagram_graph):
                     "E": 0,
                 },
                 2: {
+                    "index": 2,
                     "name": "CCCC",
                     "pixel_type": "A",
                     "x": 0.8830198712248385,
@@ -338,6 +386,7 @@ def test_layout_coordinates_2d_networkx(enable_backend, pentagram_graph):
                     "E": 0,
                 },
                 3: {
+                    "index": 3,
                     "name": "GGGG",
                     "pixel_type": "B",
                     "x": -0.9999999999999999,
@@ -349,6 +398,7 @@ def test_layout_coordinates_2d_networkx(enable_backend, pentagram_graph):
                     "E": 0,
                 },
                 1: {
+                    "index": 1,
                     "name": "TTTT",
                     "pixel_type": "B",
                     "x": -0.42674182538070177,
@@ -360,6 +410,7 @@ def test_layout_coordinates_2d_networkx(enable_backend, pentagram_graph):
                     "E": 0,
                 },
                 4: {
+                    "index": 4,
                     "name": "AATT",
                     "pixel_type": "A",
                     "x": 0.7350233319563663,
@@ -389,6 +440,7 @@ def test_layout_coordinates_3d_pmds_networkx(enable_backend, pentagram_graph):
     expected = pd.DataFrame.from_dict(
         {
             0: {
+                "index": 0,
                 "name": "AAAA",
                 "pixel_type": "A",
                 "x": 2.176250899482823,
@@ -404,6 +456,7 @@ def test_layout_coordinates_3d_pmds_networkx(enable_backend, pentagram_graph):
                 "E": 0,
             },
             2: {
+                "index": 2,
                 "name": "CCCC",
                 "pixel_type": "A",
                 "x": -2.1762508994828202,
@@ -419,6 +472,7 @@ def test_layout_coordinates_3d_pmds_networkx(enable_backend, pentagram_graph):
                 "E": 0,
             },
             3: {
+                "index": 3,
                 "name": "GGGG",
                 "pixel_type": "B",
                 "x": 3.5212479234107357,
@@ -434,6 +488,7 @@ def test_layout_coordinates_3d_pmds_networkx(enable_backend, pentagram_graph):
                 "E": 0,
             },
             1: {
+                "index": 1,
                 "name": "TTTT",
                 "pixel_type": "B",
                 "x": -1.9984014443252818e-15,
@@ -449,6 +504,7 @@ def test_layout_coordinates_3d_pmds_networkx(enable_backend, pentagram_graph):
                 "E": 0,
             },
             4: {
+                "index": 4,
                 "name": "AATT",
                 "pixel_type": "A",
                 "x": -3.521247923410737,
@@ -537,6 +593,7 @@ def test_layout_coordinates_3d_networkx(enable_backend, pentagram_graph):
         pd.DataFrame.from_dict(
             {
                 0: {
+                    "index": 0,
                     "name": "AAAA",
                     "pixel_type": "A",
                     "x": -0.9648627593518555,
@@ -552,6 +609,7 @@ def test_layout_coordinates_3d_networkx(enable_backend, pentagram_graph):
                     "E": 0,
                 },
                 2: {
+                    "index": 2,
                     "name": "CCCC",
                     "pixel_type": "A",
                     "x": 0.06231005082947333,
@@ -567,6 +625,7 @@ def test_layout_coordinates_3d_networkx(enable_backend, pentagram_graph):
                     "E": 0,
                 },
                 3: {
+                    "index": 3,
                     "name": "GGGG",
                     "pixel_type": "B",
                     "x": -0.6574427161103169,
@@ -582,6 +641,7 @@ def test_layout_coordinates_3d_networkx(enable_backend, pentagram_graph):
                     "E": 0,
                 },
                 1: {
+                    "index": 1,
                     "name": "TTTT",
                     "pixel_type": "B",
                     "x": 0.5599954246326997,
@@ -597,6 +657,7 @@ def test_layout_coordinates_3d_networkx(enable_backend, pentagram_graph):
                     "E": 0,
                 },
                 4: {
+                    "index": 4,
                     "name": "AATT",
                     "pixel_type": "A",
                     "x": 0.9999999999999999,

--- a/tests/pixeldataset/test_precomputed_layouts.py
+++ b/tests/pixeldataset/test_precomputed_layouts.py
@@ -32,19 +32,23 @@ def layout_df() -> pl.DataFrame:
     pixel_type = ["A", "B"]
     sequences = dna_seqs(length=10, min_dist=0, n_sequences=1000)
     rgn = np.random.default_rng(1)
-    layout_df = pl.DataFrame(
-        {
-            "x": rgn.random(nbr_of_rows),
-            "y": rgn.random(nbr_of_rows),
-            "z": rgn.random(nbr_of_rows),
-            "graph_projection": rgn.choice(graph_projections, nbr_of_rows),
-            "layout": rgn.choice(layout_methods, nbr_of_rows),
-            "component": rgn.choice(components, nbr_of_rows),
-            "sample": rgn.choice(sample, nbr_of_rows),
-            "name": rgn.choice(sequences, nbr_of_rows),
-            "pixel_type": rgn.choice(pixel_type, nbr_of_rows),
-        }
-    ).lazy()
+    layout_df = (
+        pl.DataFrame(
+            {
+                "x": rgn.random(nbr_of_rows),
+                "y": rgn.random(nbr_of_rows),
+                "z": rgn.random(nbr_of_rows),
+                "graph_projection": rgn.choice(graph_projections, nbr_of_rows),
+                "layout": rgn.choice(layout_methods, nbr_of_rows),
+                "component": rgn.choice(components, nbr_of_rows),
+                "sample": rgn.choice(sample, nbr_of_rows),
+                "name": rgn.choice(sequences, nbr_of_rows),
+                "pixel_type": rgn.choice(pixel_type, nbr_of_rows),
+            }
+        )
+        .with_columns(index=pl.col("name"))
+        .lazy()
+    )
     return layout_df
 
 
@@ -63,19 +67,23 @@ def layout_df_generator() -> Iterable[pl.LazyFrame]:
         rgn = np.random.default_rng(1)
         pixel_type = ["A", "B"]
         sequences = dna_seqs(length=10, min_dist=0, n_sequences=1000)
-        layout_df = pl.DataFrame(
-            {
-                "x": rgn.random(nbr_of_rows),
-                "y": rgn.random(nbr_of_rows),
-                "z": rgn.random(nbr_of_rows),
-                "graph_projection": rgn.choice(graph_projections, nbr_of_rows),
-                "layout": rgn.choice(layout_methods, nbr_of_rows),
-                "component": component,
-                "sample": rgn.choice(sample, nbr_of_rows),
-                "name": rgn.choice(sequences, nbr_of_rows),
-                "pixel_type": rgn.choice(pixel_type, nbr_of_rows),
-            }
-        ).lazy()
+        layout_df = (
+            pl.DataFrame(
+                {
+                    "x": rgn.random(nbr_of_rows),
+                    "y": rgn.random(nbr_of_rows),
+                    "z": rgn.random(nbr_of_rows),
+                    "graph_projection": rgn.choice(graph_projections, nbr_of_rows),
+                    "layout": rgn.choice(layout_methods, nbr_of_rows),
+                    "component": component,
+                    "sample": rgn.choice(sample, nbr_of_rows),
+                    "name": rgn.choice(sequences, nbr_of_rows),
+                    "pixel_type": rgn.choice(pixel_type, nbr_of_rows),
+                }
+            )
+            .with_columns(index=pl.col("name"))
+            .lazy()
+        )
         yield layout_df
 
 
@@ -130,6 +138,7 @@ class TestPreComputedLayouts:
             "sample",
             "name",
             "pixel_type",
+            "index",
         }
 
     def test_to_df_filters_columns(self, precomputed_layouts):
@@ -423,6 +432,7 @@ class TestGeneratePrecomputedLayoutsForComponents:
             "component",
             "name",
             "pixel_type",
+            "index",
         } | set(pixel_dataset.adata.var.index)
 
         assert set(df["component"]) == set(pixel_dataset.adata.obs.index)
@@ -463,6 +473,7 @@ class TestGeneratePrecomputedLayoutsForComponents:
             "component",
             "name",
             "pixel_type",
+            "index",
         }
 
     def test_generate_precomputed_layouts_for_components_with_multiple_layout_algorithms(
@@ -532,6 +543,7 @@ class TestGeneratePrecomputedLayoutsForComponentsIntegrationTest:
             "component",
             "name",
             "pixel_type",
+            "index",
         } | set(pixel_dataset.adata.var.index)
 
         assert set(df["component"]) == set(pixel_dataset.adata.obs.index)


### PR DESCRIPTION
## Description

This adds an option on graph creation `convert_indices_to_integers` that allows us to bypass the conversion of node indices to integers. This defaults to `True` to keep the current behavior.

Being able to keep the node names as their original strings is important if you need to reattach edges to nodes at a later point in the analysis.


Fixes: exe-1662

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Manually, as well as with unit tests.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and documentation and corrected any misspellings
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
