### PR TITLE
Remove clr and use log1p as default polarity score transformation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of the total raw input reads.
 * Use common analysis engine to orchestrate running different "per component" analysis, like
   polarization and colocalization analysis (yielding a roughly 3x speed-up over previous approach).
+* The default transformation for the calculation of the polarity score is now `log1p` instead of `clr`.
 
 ### Fixed
 
@@ -76,6 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Remove `normalized_rel` and `denoised` from `obsm` in `anndata`.
 * Remove `denoise` function.
 * Remove cell type selector in QC report for UMAP colored by molecule count plots.
+* Remove `clr` as a transformation option in `pixalator analysis`
 
 ## [0.16.2] - 2024-03-19
 

--- a/src/pixelator/analysis/__init__.py
+++ b/src/pixelator/analysis/__init__.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from pixelator.analysis.analysis_engine import PerComponentAnalysis, run_analysis
 from pixelator.analysis.colocalization.types import TransformationTypes
-from pixelator.analysis.polarization.types import PolarizationNormalizationTypes
+from pixelator.analysis.polarization.types import PolarizationTransformationTypes
 from pixelator.pixeldataset import (
     PixelDataset,
 )
@@ -26,7 +26,7 @@ class AnalysisParameters:
     compute_polarization: bool
     compute_colocalization: bool
     use_full_bipartite: bool
-    polarization_normalization: PolarizationNormalizationTypes
+    polarization_normalization: PolarizationTransformationTypes
     polarization_n_permutations: int
     polarization_min_marker_count: int
     colocalization_transformation: TransformationTypes

--- a/src/pixelator/analysis/polarization/__init__.py
+++ b/src/pixelator/analysis/polarization/__init__.py
@@ -85,7 +85,7 @@ def polarization_scores_component_graph(
 
     :param graph: a graph (it must be a single connected component)
     :param component_id: the id of the component
-    :param transformation: the normalization method to use (raw, log1p)
+    :param transformation: the count transformation method to use (raw, log1p)
     :param n_permutations: the number of permutations to use to estimate the
                            null-hypothesis for the Moran's I statistic
     :param min_marker_count: the minimum number of counts of a marker to calculate
@@ -177,7 +177,7 @@ def polarization_scores_component_df(
     component_id: str,
     component_df: pd.DataFrame,
     use_full_bipartite: bool,
-    normalization: PolarizationTransformationTypes = "log1p",
+    transformation: PolarizationTransformationTypes = "log1p",
     n_permutations: int = 50,
     min_marker_count: int = 2,
     random_seed: int | None = None,
@@ -189,7 +189,7 @@ def polarization_scores_component_df(
     :param component_id: the id of the component
     :param component_df: A data frame with an edgelist for a single connected component
     :param use_full_bipartite: use the bipartite graph instead of the projection (UPIA)
-    :param normalization: the normalization method to use (raw, log1p)
+    :param transformation: the count transformation method to use (raw, log1p)
     :param n_permutations: the number of permutations to use to estimate the
                            null-hypothesis for the Moran's I statistic
     :param min_marker_count: the minimum number of counts of a marker to calculate
@@ -210,7 +210,7 @@ def polarization_scores_component_df(
     component_result = polarization_scores_component_graph(
         graph=graph,
         component_id=component_id,
-        transformation=normalization,
+        transformation=transformation,
         n_permutations=n_permutations,
         min_marker_count=min_marker_count,
         random_seed=random_seed,
@@ -239,7 +239,7 @@ def polarization_scores(
       (morans_p_value_sim and morans_z_sim if `permutations` > 0)
     :param edgelist: an edge list (pd.DataFrame) with a component column
     :param use_full_bipartite: use the bipartite graph instead of the projection (UPIA)
-    :param transformation: the normalization method to use (raw, log1p)
+    :param transformation: the count transformation method to use (raw, log1p)
     :param n_permutations: the number of permutations for simulated Z-score (z_sim)
                            estimation (if n_permutations>0)
     :param min_marker_count: the minimum number of counts of a marker to calculate
@@ -250,7 +250,7 @@ def polarization_scores(
     :raises: AssertionError when the input is not valid
     """
     if transformation not in get_args(PolarizationTransformationTypes):
-        raise AssertionError(f"incorrect value for normalization {transformation}")
+        raise AssertionError(f"incorrect value for count transformation {transformation}")
 
     if "component" not in edgelist.columns:
         raise AssertionError("Edge list is missing the component column")
@@ -270,7 +270,7 @@ def polarization_scores(
             polarization_function = partial(
                 polarization_scores_component_df,
                 use_full_bipartite=use_full_bipartite,
-                normalization=transformation,
+                transformation=transformation,
                 n_permutations=n_permutations,
                 min_marker_count=min_marker_count,
                 random_seed=random_seed,
@@ -317,7 +317,7 @@ class PolarizationAnalysis(PerComponentAnalysis):
     ):
         """Initialize polarization analysis.
 
-        :param transformation: the normalization method to use (raw, log1p)
+        :param transformation: the count transformation method to use (raw, log1p)
         :param n_permutations: the number of permutations to use to estimate the
                                null-hypothesis for the Moran's I statistic
         :param min_marker_count: the minimum number of counts of a marker to calculate
@@ -327,7 +327,7 @@ class PolarizationAnalysis(PerComponentAnalysis):
         """
         if transformation_type not in get_args(PolarizationTransformationTypes):
             raise AssertionError(
-                f"incorrect value for normalization {transformation_type}"
+                f"incorrect value for count transformation {transformation_type}"
             )
         self.transformation = transformation_type
         self.permutations = n_permutations

--- a/src/pixelator/analysis/polarization/__init__.py
+++ b/src/pixelator/analysis/polarization/__init__.py
@@ -250,7 +250,9 @@ def polarization_scores(
     :raises: AssertionError when the input is not valid
     """
     if transformation not in get_args(PolarizationTransformationTypes):
-        raise AssertionError(f"incorrect value for count transformation {transformation}")
+        raise AssertionError(
+            f"incorrect value for count transformation {transformation}"
+        )
 
     if "component" not in edgelist.columns:
         raise AssertionError("Edge list is missing the component column")

--- a/src/pixelator/analysis/polarization/__init__.py
+++ b/src/pixelator/analysis/polarization/__init__.py
@@ -12,10 +12,10 @@ from scipy.stats import norm
 
 from pixelator.analysis.analysis_engine import PerComponentAnalysis
 from pixelator.analysis.permute import permutations
-from pixelator.analysis.polarization.types import PolarizationNormalizationTypes
+from pixelator.analysis.polarization.types import PolarizationTransformationTypes
 from pixelator.graph.utils import Graph
 from pixelator.pixeldataset import MIN_VERTICES_REQUIRED, PixelDataset
-from pixelator.statistics import clr_transformation, correct_pvalues
+from pixelator.statistics import correct_pvalues
 from pixelator.utils import get_pool_executor
 
 logger = logging.getLogger(__name__)
@@ -64,7 +64,7 @@ def _compute_morans_i(
 def polarization_scores_component_graph(
     graph: Graph,
     component_id: str,
-    normalization: PolarizationNormalizationTypes = "clr",
+    transformation: PolarizationTransformationTypes = "log1p",
     n_permutations: int = 50,
     min_marker_count: int = 2,
     random_seed: int | None = None,
@@ -85,7 +85,7 @@ def polarization_scores_component_graph(
 
     :param graph: a graph (it must be a single connected component)
     :param component_id: the id of the component
-    :param normalization: the normalization method to use (raw, log1p, or clr)
+    :param transformation: the normalization method to use (raw, log1p)
     :param n_permutations: the number of permutations to use to estimate the
                            null-hypothesis for the Moran's I statistic
     :param min_marker_count: the minimum number of counts of a marker to calculate
@@ -118,26 +118,18 @@ def polarization_scores_component_graph(
         # Calculate normalization factor
         C = N / W.sum()
 
-        def pick_transformation():
-            if normalization == "log1p":
-                return np.log1p
-            if normalization == "clr":
-                return clr_transformation
-            # This is the same as no transformation
-            return lambda x: x
-
         # Record markers to keep
         # Remove markers with zero variance and markers below minimum marker count
         markers_to_keep = X.columns[
             (X != 0).any(axis=0) & (X.nunique() > 1) & (X.sum() >= min_marker_count)
         ]
 
-        transformation = pick_transformation()
+        transform_func = np.log1p if transformation == "log1p" else lambda x: x
         X_perm = [
-            transformation(x)
+            transform_func(x)
             for x in permutations(X, n=n_permutations, random_seed=random_seed)
         ]
-        X = transformation(X)
+        X = transform_func(X)
 
         # Apply marker filter after transformation
         X = X.loc[:, markers_to_keep]
@@ -185,7 +177,7 @@ def polarization_scores_component_df(
     component_id: str,
     component_df: pd.DataFrame,
     use_full_bipartite: bool,
-    normalization: PolarizationNormalizationTypes = "clr",
+    normalization: PolarizationTransformationTypes = "log1p",
     n_permutations: int = 50,
     min_marker_count: int = 2,
     random_seed: int | None = None,
@@ -197,7 +189,7 @@ def polarization_scores_component_df(
     :param component_id: the id of the component
     :param component_df: A data frame with an edgelist for a single connected component
     :param use_full_bipartite: use the bipartite graph instead of the projection (UPIA)
-    :param normalization: the normalization method to use (raw, log1p, or clr)
+    :param normalization: the normalization method to use (raw, log1p)
     :param n_permutations: the number of permutations to use to estimate the
                            null-hypothesis for the Moran's I statistic
     :param min_marker_count: the minimum number of counts of a marker to calculate
@@ -218,7 +210,7 @@ def polarization_scores_component_df(
     component_result = polarization_scores_component_graph(
         graph=graph,
         component_id=component_id,
-        normalization=normalization,
+        transformation=normalization,
         n_permutations=n_permutations,
         min_marker_count=min_marker_count,
         random_seed=random_seed,
@@ -229,7 +221,7 @@ def polarization_scores_component_df(
 def polarization_scores(
     edgelist: pd.DataFrame,
     use_full_bipartite: bool = False,
-    normalization: PolarizationNormalizationTypes = "clr",
+    transformation: PolarizationTransformationTypes = "log1p",
     n_permutations: int = 0,
     min_marker_count: int = 2,
     random_seed: int | None = None,
@@ -247,7 +239,7 @@ def polarization_scores(
       (morans_p_value_sim and morans_z_sim if `permutations` > 0)
     :param edgelist: an edge list (pd.DataFrame) with a component column
     :param use_full_bipartite: use the bipartite graph instead of the projection (UPIA)
-    :param normalization: the normalization method to use (raw, log1p, or clr)
+    :param transformation: the normalization method to use (raw, log1p)
     :param n_permutations: the number of permutations for simulated Z-score (z_sim)
                            estimation (if n_permutations>0)
     :param min_marker_count: the minimum number of counts of a marker to calculate
@@ -257,8 +249,8 @@ def polarization_scores(
     :rtype: pd.DataFrame
     :raises: AssertionError when the input is not valid
     """
-    if normalization not in get_args(PolarizationNormalizationTypes):
-        raise AssertionError(f"incorrect value for normalization {normalization}")
+    if transformation not in get_args(PolarizationTransformationTypes):
+        raise AssertionError(f"incorrect value for normalization {transformation}")
 
     if "component" not in edgelist.columns:
         raise AssertionError("Edge list is missing the component column")
@@ -278,7 +270,7 @@ def polarization_scores(
             polarization_function = partial(
                 polarization_scores_component_df,
                 use_full_bipartite=use_full_bipartite,
-                normalization=normalization,
+                normalization=transformation,
                 n_permutations=n_permutations,
                 min_marker_count=min_marker_count,
                 random_seed=random_seed,
@@ -318,14 +310,14 @@ class PolarizationAnalysis(PerComponentAnalysis):
 
     def __init__(
         self,
-        normalization: PolarizationNormalizationTypes,
+        transformation_type: PolarizationTransformationTypes,
         n_permutations: int,
         min_marker_count: int,
         random_seed: int | None = None,
     ):
         """Initialize polarization analysis.
 
-        :param normalization: the normalization method to use (raw, log1p, or clr)
+        :param transformation: the normalization method to use (raw, log1p)
         :param n_permutations: the number of permutations to use to estimate the
                                null-hypothesis for the Moran's I statistic
         :param min_marker_count: the minimum number of counts of a marker to calculate
@@ -333,7 +325,11 @@ class PolarizationAnalysis(PerComponentAnalysis):
         :param random_seed: set a random seed to ensure reproducibility when calculating z-scores
                             and p-values.
         """
-        self.normalization = normalization
+        if transformation_type not in get_args(PolarizationTransformationTypes):
+            raise AssertionError(
+                f"incorrect value for normalization {transformation_type}"
+            )
+        self.transformation = transformation_type
         self.permutations = n_permutations
         self.min_marker_count = min_marker_count
         self.random_seed = random_seed
@@ -344,7 +340,7 @@ class PolarizationAnalysis(PerComponentAnalysis):
         return polarization_scores_component_graph(
             graph=component,
             component_id=component_id,
-            normalization=self.normalization,
+            transformation=self.transformation,
             n_permutations=self.permutations,
             min_marker_count=self.min_marker_count,
             random_seed=self.random_seed,

--- a/src/pixelator/analysis/polarization/types.py
+++ b/src/pixelator/analysis/polarization/types.py
@@ -5,4 +5,4 @@ Copyright © 2023 Pixelgen Technologies AB.
 
 from typing import Literal
 
-PolarizationNormalizationTypes = Literal["raw", "clr", "log1p"]
+PolarizationTransformationTypes = Literal["raw", "log1p"]

--- a/src/pixelator/cli/analysis.py
+++ b/src/pixelator/cli/analysis.py
@@ -57,16 +57,15 @@ from pixelator.utils import (
     ),
 )
 @click.option(
-    "--polarization-normalization",
-    default="clr",
+    "--polarization-transformation",
+    default="log1p",
     required=False,
-    type=click.Choice(["raw", "log1p", "clr"]),
+    type=click.Choice(["raw", "log1p"]),
     show_default=True,
     help=(
         "Which approach to use to normalize the antibody counts:"
         " \n\traw will use the raw counts"
         " \n\tlog1p will use the log(x+1) transformed counts"
-        " \n\tclr will use the CLR transformed counts"
     ),
 )
 @click.option(
@@ -144,7 +143,7 @@ def analysis(
     compute_polarization,
     compute_colocalization,
     use_full_bipartite,
-    polarization_normalization,
+    polarization_transformation,
     polarization_n_permutations,
     polarization_min_marker_count,
     colocalization_transformation,
@@ -165,7 +164,7 @@ def analysis(
         output=output,
         compute_polarization=compute_polarization,
         compute_colocalization=compute_colocalization,
-        normalization=polarization_normalization,
+        polarization_transformation=polarization_transformation,
         polarization_n_permutations=polarization_n_permutations,
         polarization_min_marker_count=polarization_min_marker_count,
         colocalization_transformation=colocalization_transformation,
@@ -201,7 +200,7 @@ def analysis(
         logger.info("Polarization score computation is activated")
         analysis_to_run.append(
             PolarizationAnalysis(
-                normalization=polarization_normalization,
+                transformation_type=polarization_transformation,
                 n_permutations=polarization_n_permutations,
                 min_marker_count=polarization_min_marker_count,
             )

--- a/tests/analysis/polarization/test_polarization.py
+++ b/tests/analysis/polarization/test_polarization.py
@@ -36,18 +36,18 @@ def test_polarization(enable_backend, full_graph_edgelist: pd.DataFrame):
         {
             0: {
                 "marker": "A",
-                "morans_i": -0.058418204066991254,
-                "morans_z": -7.844216486178604,
-                "morans_p_value": 2.1783248596911517e-15,
-                "morans_p_adjusted": 4.356649719382303e-15,
+                "morans_i": -0.17764378122173094,
+                "morans_z": -25.810281029712247,
+                "morans_p_value": 3.399057861353845e-147,
+                "morans_p_adjusted": 6.79811572270769e-147,
                 "component": "PXLCMP0000000",
             },
             1: {
                 "marker": "B",
-                "morans_i": -0.05841820406699129,
-                "morans_z": -7.747319374160002,
-                "morans_p_value": 4.692634773999269e-15,
-                "morans_p_adjusted": 4.692634773999269e-15,
+                "morans_i": -0.17764378122173102,
+                "morans_z": -25.39946321402526,
+                "morans_p_value": 1.2782689040515938e-142,
+                "morans_p_adjusted": 1.2782689040515938e-142,
                 "component": "PXLCMP0000000",
             },
         },
@@ -72,18 +72,18 @@ def test_permuted_polarization(enable_backend, full_graph_edgelist: pd.DataFrame
         {
             0: {
                 "marker": "A",
-                "morans_i": -0.058418204066991254,
-                "morans_z": -7.844216486178604,
-                "morans_p_value": 2.1783248596911517e-15,
-                "morans_p_adjusted": 4.356649719382303e-15,
+                "morans_i": -0.17764378122173094,
+                "morans_z": -25.810281029712247,
+                "morans_p_value": 3.399057861353845e-147,
+                "morans_p_adjusted": 6.79811572270769e-147,
                 "component": "PXLCMP0000000",
             },
             1: {
                 "marker": "B",
-                "morans_i": -0.05841820406699129,
-                "morans_z": -7.747319374160002,
-                "morans_p_value": 4.692634773999269e-15,
-                "morans_p_adjusted": 4.692634773999269e-15,
+                "morans_i": -0.17764378122173102,
+                "morans_z": -25.39946321402526,
+                "morans_p_value": 1.2782689040515938e-142,
+                "morans_p_adjusted": 1.2782689040515938e-142,
                 "component": "PXLCMP0000000",
             },
         },
@@ -100,7 +100,7 @@ def test_polarization_log1p(enable_backend, full_graph_edgelist: pd.DataFrame):
     scores = polarization_scores(
         edgelist=full_graph_edgelist,
         n_permutations=10,
-        normalization="log1p",
+        transformation="log1p",
         use_full_bipartite=True,
         random_seed=1,
     )
@@ -180,7 +180,7 @@ def test_polarization_with_differentially_polarized_markers():
         orient="index",
     )
     # test polarization scores
-    assert_frame_equal(scores, expected, check_exact=False, atol=1e-3)
+    assert_frame_equal(scores, expected, check_exact=False, atol=1e-1)
 
 
 def test_polarization_with_min_marker_count():
@@ -242,7 +242,7 @@ def test_polarization_with_min_marker_count():
         orient="index",
     )
     # test polarization scores
-    assert_frame_equal(scores, expected, check_exact=False, atol=1e-3)
+    assert_frame_equal(scores, expected, check_exact=False, atol=1e-1)
 
 
 def test_permuted_polarization_with_differentially_polarized_markers():
@@ -298,7 +298,7 @@ def test_permuted_polarization_with_differentially_polarized_markers():
         orient="index",
     )
     # test polarization scores
-    assert_frame_equal(scores, expected, check_exact=False, atol=1e-3)
+    assert_frame_equal(scores, expected, check_exact=False, atol=1e-1)
 
 
 def test_polarization_transformation():
@@ -398,16 +398,16 @@ def test_polarization_transformation():
     )
 
     # test polarization scores
-    assert_frame_equal(scores_1, expected_1, check_exact=False, atol=1e-3)
-    assert_frame_equal(scores_2, expected_2, check_exact=False, atol=1e-3)
+    assert_frame_equal(scores_1, expected_1, check_exact=False, atol=1e-1)
+    assert_frame_equal(scores_2, expected_2, check_exact=False, atol=1e-1)
 
     # we also expect the scores to be the same for A and B
-    assert_frame_equal(scores_1, scores_2.head(2), check_exact=False, atol=1e-3)
+    assert_frame_equal(scores_1, scores_2.head(2), check_exact=False, atol=1e-1)
 
 
 def test_polarization_backward_compatibility():
     # This tests that we get the same polarity score as the original
-    # polarization score where markers were filtered prior to CLR
+    # polarization score where markers were filtered prior to transformation
     # transformation.
 
     # Set seed to get same graph every time
@@ -454,12 +454,15 @@ def test_polarization_backward_compatibility():
         orient="index",
     )
     # test polarization scores
-    assert_frame_equal(scores, expected, check_exact=False, atol=1e-3)
+    assert_frame_equal(scores, expected, check_exact=False, atol=1e-1)
 
 
 class TestPolarizationAnalysis:
     analysis = PolarizationAnalysis(
-        normalization="clr", n_permutations=10, min_marker_count=2, random_seed=1
+        transformation_type="log1p",
+        n_permutations=10,
+        min_marker_count=2,
+        random_seed=1,
     )
 
     def test_run_on_component(self, full_graph_edgelist):
@@ -477,23 +480,23 @@ class TestPolarizationAnalysis:
             {
                 0: {
                     "marker": "A",
-                    "morans_i": -0.058418204066991254,
-                    "morans_z": -7.844216486178604,
-                    "morans_p_value": 2.1783248596911517e-15,
+                    "morans_i": -0.17764378122173094,
+                    "morans_z": -25.810281029712247,
+                    "morans_p_value": 3.399057861353845e-147,
                     "component": "PXLCMP0000000",
                 },
                 1: {
                     "marker": "B",
-                    "morans_i": -0.05841820406699129,
-                    "morans_z": -7.747319374160002,
-                    "morans_p_value": 4.692634773999269e-15,
+                    "morans_i": -0.17764378122173102,
+                    "morans_z": -25.39946321402526,
+                    "morans_p_value": 1.2782689040515938e-142,
                     "component": "PXLCMP0000000",
                 },
             },
             orient="index",
         )
 
-        assert_frame_equal(result, expected)
+        assert_frame_equal(result, expected, check_exact=False, atol=1e-3)
 
     def test_post_process_data(self):
         data = pd.DataFrame.from_dict(


### PR DESCRIPTION
## Description

Remove `clr` and use instead use `log1p` as default polarity score transformation.

Fixes: EXE-1542

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

By unit tests. @maxkarlsson has done analysis to verify the change itself.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and documentation and corrected any misspellings
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
