### PR TITLE
fix: missed transformation

### DIFF
--- a/src/pixelator/analysis/__init__.py
+++ b/src/pixelator/analysis/__init__.py
@@ -26,7 +26,7 @@ class AnalysisParameters:
     compute_polarization: bool
     compute_colocalization: bool
     use_full_bipartite: bool
-    polarization_normalization: PolarizationTransformationTypes
+    polarization_transformation: PolarizationTransformationTypes
     polarization_n_permutations: int
     polarization_min_marker_count: int
     colocalization_transformation: TransformationTypes


### PR DESCRIPTION

## Description

One comment was missed in feature/exe-1542-switch-from-clr-to-log1p-as-default-polarity-transformation. This resolves that comment. 

Fixes: exe-1542

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Test suite

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated poetry.lock, and [cited it properly](../CITATIONS.md)
- [x] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
