### PR TITLE
Added local_g

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Add `local_g` function to compute spatial autocorrelation of marker counts per node.
+* Add `compute_transition_probabilities` function to compute transition probabilities for k-step random walks for node pairs in a graph.
 * Add QC plot showing UMIs per UPIA vs Tau.
 * Add plot functions showing edge rank and cell counts.
 * Add 2D and 3D graph plot functions.

--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -21,3 +21,7 @@
 - [graspologic](https://microsoft.github.io/graspologic/latest/index.html)
 
   > Chung, J., Pedigo, B. D., Bridgeford, E. W., Varjavand, B. K., Helm, H. S., & Vogelstein, J. T. (2019). GraSPy: Graph Statistics in Python. Journal of Machine Learning Research, 20(158), 1-7.
+
+- [local G](https://doi.org/10.1007/s11749-018-0599-x)
+
+  > Bivand, R.S., Wong, D.W.S. Comparing implementations of global and local indicators of spatial association. TEST 27, 716–748 (2018). https://doi.org/10.1007/s11749-018-0599-x

--- a/src/pixelator/graph/graph.py
+++ b/src/pixelator/graph/graph.py
@@ -299,7 +299,7 @@ class Graph:
     ) -> pd.DataFrame:
         """Compute the local G metric for each node in the graph.
 
-                The local G metric is a measure of the local clustering of a node in the graph.
+        The local G metric is a measure of the local clustering of a node in the graph.
 
         :param k: The number of steps in the k-step random walk. Default is 1.
         :param use_weights: Whether to use weights in the computation. When turned off, all

--- a/src/pixelator/graph/graph.py
+++ b/src/pixelator/graph/graph.py
@@ -211,7 +211,7 @@ class Graph:
         :param only_keep_a_pixels: If true, only keep the a-pixels
         :param get_node_marker_matrix: Add a matrix of marker counts to each
                                        node if True.
-        :param cache: set to `True` in k to cache one call of this this method.
+        :param cache: set to `True` in order to cache one call of this this method.
                       It will make subsequent calls to the layout method
                       with the same settings much faster, at the cost of additional
                       memory usage. This can speed things up a lot when plotting
@@ -299,7 +299,22 @@ class Graph:
     ) -> pd.DataFrame:
         """Compute the local G metric for each node in the graph.
 
-        The local G metric is a measure of the local clustering of a node in the graph.
+                The local G metric is a measure of the local clustering of a node in the graph.
+
+        :param k: The number of steps in the k-step random walk. Default is 1.
+        :param use_weights: Whether to use weights in the computation. When turned off, all
+        edge weights will be equal to 1. Default is True.
+        :param normalize_counts: Whether to normalize counts to proportions. Default is True.
+        :param W: A sparse matrix of custom edge weights. This will override the automated
+        computation of edge weights. `W` must have the same dimensions as A. Note that weights can
+        be defined for any pair of nodes, not only the pairs represented by edges in `A`. Default is None.
+        :param method: The method to use for computing local G. Must be one of 'gi' or 'gistar'.
+        'gi' is the original local G metric, which does not consider self-loops, meaning that the
+        local marker expression for a node is computed by aggregating the weighted expression of
+        its neighbors. 'gistar' is a simplified version of local G that does consider self-loops.
+        In other words, the local marker expression of a node also includes the weighted marker
+        expression of the node itself. Default is 'gi'.
+        :return: A DataFrame of local G-scores for each node and marker.
         """
         return local_g(
             A=self.get_adjacency_sparse(),

--- a/src/pixelator/graph/node_metrics.py
+++ b/src/pixelator/graph/node_metrics.py
@@ -1,0 +1,214 @@
+"""Functions related to computing node metrics on graphs.
+
+Copyright © 2024 Pixelgen Technologies AB.
+"""
+
+from typing import Literal
+
+import numpy as np
+import pandas as pd
+import scipy as sp
+
+from pixelator.marks import experimental
+
+
+def compute_transition_probabilities(
+    A: sp.sparse.csr_array,
+    k: int = 1,
+    remove_self_loops: bool = False,
+) -> sp.sparse.csr_array:
+    """Compute transition probabilities of a graph.
+
+    This function computes the transition probabilities for node pairs in a graph.
+    Transition probabilities can for example be useful for weighting marker counts
+    when computing local spatial node metrics such as local G. The transition
+    probability is the probability of going from one node to another in a k-step walk,
+    where `k` is the number of steps in the walk. When `k=1`, the transition probabilities
+    are defined for the edges in the graph. With `k>1`, the transition probabilities can
+    be positive for node pairs that are not directly connected by an edge, including
+    transitions from a node to itself. In some situations, it may be desirable to ignore
+    these transitions (self-loops), which can be achieved by setting `remove_self_loops=True`.
+    In this case, the diagonal of the transition probability matrix is set to 0 and the
+    probabilities are renormalized (row-wise) to sum to 1.
+
+    :param A: A sparse adjacency matrix representing the graph.
+    :param k: The number of steps in the random walk. Default is 1.
+    :param remove_self_loops: Whether to remove self-loops from the transition probability
+    matrix. Default is False.
+    :return: A sparse matrix with transition probabilities.
+    :rtype: sp.sparse.csr_matrix
+    """
+    # Check that k is a positive integer
+    if not isinstance(k, int) or k < 1:
+        raise ValueError("k must be a positive integer")
+
+    W_out = A / A.sum(axis=0)[:, None]
+
+    # Multiply W by itself k times
+    if k > 1:
+        W_out = sp.sparse.linalg.matrix_power(W_out, k)
+
+    if remove_self_loops and k > 1:
+        # Set diagonal of W to 0 if k > 1 for gi to avoid self-loops
+        W_out.setdiag(values=0)
+        # Renormalize transition probabilities to sum to 1
+        W_out = W_out / W_out.sum(axis=0)[:, None]
+
+    return W_out
+
+
+@experimental
+def local_g(
+    A: sp.sparse.csr_array,
+    counts: pd.DataFrame,
+    k: int = 1,
+    use_weights: bool = True,
+    normalize_counts: bool = True,
+    W: sp.sparse.csr_array | None = None,
+    method: Literal["gi", "gistar"] = "gi",
+) -> pd.DataFrame:
+    """Compute local G-scores for each node and marker.
+
+    Local G([1]_) is a spatial node metric that measures the spatial association.
+    The metric can for instance be used to detect hot spots for marker counts in a graph, where nodes
+    that are close to each other have similar values. The metric is a Z-score that
+    measures the deviation of the observed local marker expression from the expected marker
+    expression under the null hypothesis of no spatial association. The sign of the score
+    indicates whether the observed marker counts are higher or lower than expected
+    and can therefore be used to identify hot and/or cold spots.
+
+    The observed local marker expression for a node is computed by aggregating the weighted marker
+    expression within its local neighborhood. The local G metric is largely influenced by the choice
+    of edge weights and the size of the local neighborhood (`k`). The method implemented here uses
+    incoming transition probabilities for a k-step random walk as edge weights. By increasing `k`,
+    the local neighborhood of a node is expanded, increasing the "smoothing effect" of the metric,
+    which can be useful to increase the scale of spatial association.
+
+    Local G can also be useful for more interpretable visualization of polarized marker expression
+    as it enhances spatial trends across neighborhoods in the graph, even if the marker counts within
+    individual nodes are sparse.
+
+    .. [1] Bivand, R.S., Wong, D.W.S. Comparing implementations of global and
+    local indicators of spatial association. TEST 27, 716–748 (2018).
+    https://doi.org/10.1007/s11749-018-0599-x
+
+    :param A: A sparse adjacency matrix representing the graph.
+    :param counts: A DataFrame of marker counts for each node.
+    :param k: The number of steps in the k-step random walk. Default is 1.
+    :param use_weights: Whether to use weights in the computation. When turned off, all
+    edge weights will be qeual to 1. Default is True.
+    :param normalize_counts: Whether to normalize counts to proportions. Default is True.
+    :param W: A sparse matrix of custom edge weights. This will override the automated
+    computation of edge weights. `W` must have the same dimensions as A. Note that weights can
+    be defined for any pair of nodes, not only the pairs represented by edges in `A`. Default is None.
+    :param method: The method to use for computing local G. Must be one of 'gi' or 'gistar'.
+    'gi' is the original local G metric, which does not consider self-loops, meaning that the
+    local marker expression for a node is computed by aggregating the weighted expression of
+    its neighbors. 'gistar' is a simplified version of local G that does consider self-loops.
+    In other words, the local marker expression of a node also includes the weighted marker
+    expression of the node itself. Default is 'gi'.
+    :return: A DataFrame of local G-scores for each node and marker.
+    :rtype: pd.DataFrame
+    """
+    # Check that type is one of 'gi' or 'gstari'
+    if method not in ["gi", "gstari"]:
+        raise ValueError("type must be one of 'gi' or 'gstari'")
+
+    n_nodes = A.shape[0]
+
+    marker_columns = counts.columns
+    node_indices = counts.index
+    counts = sp.sparse.csr_array(counts.values, dtype=np.float64)
+
+    # Number of nodes in G must match the number of rows in counts
+    if n_nodes != counts.shape[0]:
+        raise ValueError(
+            "The number of nodes in G must match the number of rows in counts"
+        )
+
+    # Check that k is a positive integer
+    if not isinstance(k, int) or k < 1:
+        raise ValueError("k must be a positive integer")
+
+    # Convert marker counts to proportions if normalize_counts is True
+    if normalize_counts:
+        row_sums = counts.sum(axis=1)
+        row_sums[np.abs(row_sums) < np.finfo(counts.dtype).eps] = 1
+        counts = counts.multiply(1 / row_sums[:, None]).tocsr()
+
+    if W is not None:
+        # Raise ValueError if W is not a sparse matrix
+        if not sp.sparse.issparse(W):
+            raise ValueError("W must be a sparse matrix")
+        # Raise ValueError if the dimensions of W differ from the number of nodes in G
+        if W.shape[0] != n_nodes or W.shape[1] != n_nodes:
+            raise ValueError("The dimensions of W must match the number of nodes in G")
+    if not W:
+        if use_weights:
+            if method == "gstari":
+                # Set diagonal of A to 1 for gstari which expects self-loops
+                A = A + sp.sparse.eye(n_nodes)
+            W = compute_transition_probabilities(
+                A, k=k, remove_self_loops=(method == "gi")
+            ).tocsr()
+            # Transpose W to get incoming transition probabilities
+            # This eliminates the correlation between local G and node degree
+            W = W.T
+        else:
+            W = A
+
+    # Compute lag matrix
+    lag_mat = W @ counts
+
+    if method == "gstari":
+        # Compute xibar for each node and marker
+        xibar_mat = np.tile(counts.mean(axis=0), n_nodes).reshape(counts.shape)
+        # Compute si for each node and marker
+        s_mat = np.tile(
+            ((counts**2).sum(axis=0) / n_nodes) - (counts.sum(axis=0) / n_nodes) ** 2,
+            n_nodes,
+        ).reshape(counts.shape)
+
+    if method == "gi":
+        # Compute xibar for each node and marker, excluding i
+        xibar_mat = (
+            np.tile(counts.sum(axis=0), n_nodes).reshape(counts.shape) - counts
+        ) / (n_nodes - 1)
+
+        # Compute si for each node and marker, excluding i
+        s_mat = (
+            (
+                np.tile((counts**2).sum(axis=0), n_nodes).reshape(counts.shape)
+                - (counts**2)
+            )
+            / (n_nodes - 1)
+        ) - (xibar_mat**2)
+
+    # Calculate weights for each node. If k = 1 and use_weights=False,
+    # the weights should be equal to the node degree
+    weights_i = W.sum(axis=1)[:, None]
+    square_weights_i = (W**2).sum(axis=1)[:, None]
+
+    # Calculate expected value
+    E_G = xibar_mat * weights_i
+
+    # Calculate numerator G - E(G)
+    numerator_mat = lag_mat - E_G
+
+    # Calculate denomenator Var(G)
+    if method == "gstari":
+        var_weights = ((n_nodes * square_weights_i) - weights_i**2) / (n_nodes - 1)
+        denominator_mat = np.sqrt(s_mat * var_weights)
+
+    if method == "gi":
+        var_weights = (((n_nodes - 1) * square_weights_i) - weights_i**2) / (
+            n_nodes - 2
+        )
+        denominator_mat = np.sqrt(s_mat * var_weights)
+
+    # Calculate Z-score
+    gi_mat = numerator_mat / denominator_mat
+
+    gi_mat[~np.isfinite(gi_mat)] = 0
+
+    return pd.DataFrame(gi_mat, index=node_indices, columns=marker_columns)

--- a/tests/graph/test_graph.py
+++ b/tests/graph/test_graph.py
@@ -311,7 +311,7 @@ def test_connected_components_benchmark(benchmark, enable_backend, edgelist):
 def test_get_adjacency_sparse(enable_backend, pentagram_graph):
     # This is a little bit involved. Since different network backends might
     # use different internal indexing schemes, they are not guaranteed to generate
-    # the same k of nodes in the adjacency matrix
+    # the same order of nodes in the adjacency matrix
     #
     # What this test does is to generate the sparse adjacency matrix
     # and then try to find a rotation (i.e. an ordering of the nodes)

--- a/tests/graph/test_graph.py
+++ b/tests/graph/test_graph.py
@@ -311,7 +311,7 @@ def test_connected_components_benchmark(benchmark, enable_backend, edgelist):
 def test_get_adjacency_sparse(enable_backend, pentagram_graph):
     # This is a little bit involved. Since different network backends might
     # use different internal indexing schemes, they are not guaranteed to generate
-    # the same order of nodes in the adjacency matrix
+    # the same k of nodes in the adjacency matrix
     #
     # What this test does is to generate the sparse adjacency matrix
     # and then try to find a rotation (i.e. an ordering of the nodes)
@@ -728,3 +728,30 @@ def test_layout_coordinates_caches(pentagram_graph):
 
 def test__repr__(pentagram_graph):
     assert repr(pentagram_graph) == "Graph with 5 vertices and 5 edges"
+
+
+def test_local_g(pentagram_graph):
+    # Compute local g-scores
+    gi_scores = pentagram_graph.local_g(
+        k=1, use_weights=True, normalize_counts=True, method="gi"
+    )
+
+    # Expected local g-scores
+    expected_gi_scores = pd.DataFrame.from_dict(
+        {
+            0: {"A": 0.0, "B": -1.0, "C": 1.0, "D": 1.0, "E": -1.0},
+            2: {"A": 1.0, "B": -1.0, "C": 0.0, "D": -1.0, "E": 1.0},
+            3: {"A": 1.0, "B": 1.0, "C": -1.0, "D": 0.0, "E": -1.0},
+            1: {"A": -1.0, "B": 0.0, "C": -1.0, "D": 1.0, "E": 1.0},
+            4: {"A": -1.0, "B": 1.0, "C": 1.0, "D": -1.0, "E": 0.0},
+        },
+        orient="index",
+    )
+    expected_gi_scores.index.name = "node"
+    expected_gi_scores.columns.name = "markers"
+
+    # Compare the computed and expected local g-scores
+    assert isinstance(gi_scores, pd.DataFrame)
+    assert_frame_equal(
+        gi_scores.sort_index(), expected_gi_scores.sort_index(), check_column_type=False
+    )

--- a/tests/graph/test_node_metrics.py
+++ b/tests/graph/test_node_metrics.py
@@ -1,0 +1,312 @@
+"""Test transition probability and local G functions.
+
+Copyright © 2024 Pixelgen Technologies AB.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+import scipy.sparse as sp
+from pandas.testing import assert_frame_equal
+from pixelator.graph.node_metrics import compute_transition_probabilities, local_g
+
+
+def test_compute_transition_probabilities(pentagram_graph):
+    # Create a sparse adjacency matrix
+    A = pentagram_graph.get_adjacency_sparse()
+
+    # Compute transition probabilities
+    W = compute_transition_probabilities(A, k=1, remove_self_loops=False)
+
+    # Expected transition probabilities
+    expected_W = np.array(
+        [
+            [0.0, 0.5, 0.5, 0.0, 0.0],
+            [0.5, 0.0, 0.0, 0.0, 0.5],
+            [0.5, 0.0, 0.0, 0.5, 0.0],
+            [0.0, 0.0, 0.5, 0.0, 0.5],
+            [0.0, 0.5, 0.0, 0.5, 0.0],
+        ]
+    )
+
+    # Compare the computed and expected transition probabilities
+    assert sp.issparse(W)
+    assert np.allclose(W.toarray(), expected_W)
+
+
+def test_compute_transition_probabilities_remove_self_loops_true(pentagram_graph):
+    # Create a sparse adjacency matrix
+    A = pentagram_graph.get_adjacency_sparse()
+
+    # Compute transition probabilities
+    W = compute_transition_probabilities(A, k=2, remove_self_loops=True)
+
+    # Expected transition probabilities
+    expected_W = np.array(
+        [
+            [0, 0, 0, 0.5, 0.5],
+            [0, 0, 0.5, 0.5, 0],
+            [0, 0.5, 0, 0, 0.5],
+            [0.5, 0.5, 0, 0, 0],
+            [0.5, 0, 0.5, 0, 0],
+        ]
+    )
+
+    # Compare the computed and expected transition probabilities
+    assert sp.issparse(W)
+    assert np.allclose(W.toarray(), expected_W)
+
+
+def test_local_g(pentagram_graph):
+    # Create a sparse adjacency matrix
+    A = pentagram_graph.get_adjacency_sparse()
+    counts = pentagram_graph.node_marker_counts
+
+    # Compute local g-scores
+    gi_scores = local_g(
+        A, counts, k=1, use_weights=True, normalize_counts=True, method="gi"
+    )
+
+    # Expected local g-scores
+    expected_gi_scores = pd.DataFrame.from_dict(
+        {
+            0: {"A": 0.0, "B": -1.0, "C": 1.0, "D": 1.0, "E": -1.0},
+            2: {"A": 1.0, "B": -1.0, "C": 0.0, "D": -1.0, "E": 1.0},
+            3: {"A": 1.0, "B": 1.0, "C": -1.0, "D": 0.0, "E": -1.0},
+            1: {"A": -1.0, "B": 0.0, "C": -1.0, "D": 1.0, "E": 1.0},
+            4: {"A": -1.0, "B": 1.0, "C": 1.0, "D": -1.0, "E": 0.0},
+        },
+        orient="index",
+    )
+    expected_gi_scores.index.name = "node"
+    expected_gi_scores.columns.name = "markers"
+
+    # Compare the computed and expected local g-scores
+    assert isinstance(gi_scores, pd.DataFrame)
+    assert_frame_equal(
+        gi_scores.sort_index(), expected_gi_scores.sort_index(), check_column_type=False
+    )
+
+
+def test_local_g_use_weights_false(pentagram_graph):
+    # Create a sparse adjacency matrix
+    A = pentagram_graph.get_adjacency_sparse()
+    # Create a 5x5 DataFrame of marker counts
+    counts = pd.DataFrame(
+        [
+            [1, 2, 3, 4, 5],
+            [6, 7, 8, 9, 10],
+            [11, 12, 13, 14, 15],
+            [16, 17, 18, 19, 20],
+            [21, 22, 23, 24, 25],
+        ],
+        columns=["A", "B", "C", "D", "E"],
+    )
+    counts.index.name = "node"
+    counts.columns.name = "markers"
+
+    # Compute local g-scores
+    gi_scores = local_g(
+        A, counts, k=1, use_weights=False, normalize_counts=True, method="gi"
+    )
+
+    # Expected local g-scores
+    expected_gi_scores = pd.DataFrame.from_dict(
+        {
+            0: {
+                "A": -1.4313800979143823,
+                "B": -1.4313800979143463,
+                "C": 0.0,
+                "D": 1.4313800979143463,
+                "E": 1.4313800979144704,
+            },
+            1: {
+                "A": -0.8850404109843606,
+                "B": -0.8850404109843573,
+                "C": 0.0,
+                "D": 0.8850404109843546,
+                "E": 0.8850404109843633,
+            },
+            2: {
+                "A": -0.8210543814390132,
+                "B": -0.8210543814390153,
+                "C": 0.0,
+                "D": 0.8210543814390054,
+                "E": 0.8210543814390159,
+            },
+            3: {
+                "A": 1.2983285241175744,
+                "B": 1.298328524117571,
+                "C": 0.0,
+                "D": -1.2983285241175513,
+                "E": -1.2983285241175755,
+            },
+            4: {
+                "A": 0.9035128891381983,
+                "B": 0.9035128891381959,
+                "C": 0.0,
+                "D": -0.9035128891381841,
+                "E": -0.9035128891382024,
+            },
+        },
+        orient="index",
+    )
+    expected_gi_scores.index.name = "node"
+    expected_gi_scores.columns.name = "markers"
+
+    # Compare the computed and expected local g-scores
+    assert isinstance(gi_scores, pd.DataFrame)
+    assert_frame_equal(
+        gi_scores.sort_index(), expected_gi_scores.sort_index(), check_column_type=False
+    )
+
+
+def test_local_g_normalize_counts_false(pentagram_graph):
+    # Create a sparse adjacency matrix
+    A = pentagram_graph.get_adjacency_sparse()
+    # Create a 5x5 DataFrame of marker counts
+    counts = pd.DataFrame(
+        [
+            [1, 2, 3, 4, 5],
+            [6, 7, 8, 9, 10],
+            [11, 12, 13, 14, 15],
+            [16, 17, 18, 19, 20],
+            [21, 22, 23, 24, 25],
+        ],
+        columns=["A", "B", "C", "D", "E"],
+    )
+    counts.index.name = "node"
+    counts.columns.name = "markers"
+
+    # Compute local g-scores
+    gi_scores = local_g(
+        A, counts, k=1, use_weights=False, normalize_counts=False, method="gi"
+    )
+
+    # Expected local g-scores
+    expected_gi_scores = pd.DataFrame.from_dict(
+        {
+            0: {
+                "A": -1.5491933384829668,
+                "B": -1.5491933384829668,
+                "C": -1.5491933384829668,
+                "D": -1.5491933384829668,
+                "E": -1.5491933384829668,
+            },
+            1: {
+                "A": -0.29277002188455997,
+                "B": -0.29277002188455997,
+                "C": -0.29277002188455997,
+                "D": -0.29277002188455997,
+                "E": -0.29277002188455997,
+            },
+            2: {
+                "A": -0.5477225575051661,
+                "B": -0.5477225575051661,
+                "C": -0.5477225575051661,
+                "D": -0.5477225575051661,
+                "E": -0.5477225575051661,
+            },
+            3: {
+                "A": 1.4638501094228,
+                "B": 1.4638501094228,
+                "C": 1.4638501094228,
+                "D": 1.4638501094228,
+                "E": 1.4638501094228,
+            },
+            4: {
+                "A": 0.7745966692414834,
+                "B": 0.7745966692414834,
+                "C": 0.7745966692414834,
+                "D": 0.7745966692414834,
+                "E": 0.7745966692414834,
+            },
+        },
+        orient="index",
+    )
+    expected_gi_scores.index.name = "node"
+    expected_gi_scores.columns.name = "markers"
+
+    # Compare the computed and expected local g-scores
+    assert isinstance(gi_scores, pd.DataFrame)
+    assert_frame_equal(
+        gi_scores.sort_index(), expected_gi_scores.sort_index(), check_column_type=False
+    )
+
+
+def test_local_g_normalize_method_gstari(pentagram_graph):
+    # Create a sparse adjacency matrix
+    A = pentagram_graph.get_adjacency_sparse()
+    # Create a 5x5 DataFrame of marker counts
+    counts = pd.DataFrame(
+        [
+            [1, 2, 3, 4, 5],
+            [6, 7, 8, 9, 10],
+            [11, 12, 13, 14, 15],
+            [16, 17, 18, 19, 20],
+            [21, 22, 23, 24, 25],
+        ],
+        columns=["A", "B", "C", "D", "E"],
+    )
+    counts.index.name = "node"
+    counts.columns.name = "markers"
+
+    # Compute local g-scores
+    gi_scores = local_g(
+        A, counts, k=1, use_weights=True, normalize_counts=True, method="gstari"
+    )
+
+    # Expected local g-scores
+    expected_gi_scores = pd.DataFrame.from_dict(
+        {
+            0: {
+                "A": -1.181174161915827,
+                "B": -1.1811741619158245,
+                "C": 0.0,
+                "D": 1.1811741619158003,
+                "E": 1.1811741619158258,
+            },
+            1: {
+                "A": -0.9257851539340258,
+                "B": -0.925785153934024,
+                "C": 0.0,
+                "D": 0.9257851539340036,
+                "E": 0.9257851539340244,
+            },
+            2: {
+                "A": -0.6508872633980606,
+                "B": -0.6508872633980609,
+                "C": 0.0,
+                "D": 0.6508872633980447,
+                "E": 0.6508872633980601,
+            },
+            3: {
+                "A": 1.5624841391108724,
+                "B": 1.5624841391108693,
+                "C": 0.0,
+                "D": -1.5624841391108488,
+                "E": -1.5624841391108784,
+            },
+            4: {
+                "A": 1.1953624401370362,
+                "B": 1.1953624401370306,
+                "C": 0.0,
+                "D": -1.1953624401370189,
+                "E": -1.1953624401370413,
+            },
+        },
+        orient="index",
+    )
+    expected_gi_scores.index.name = "node"
+    expected_gi_scores.columns.name = "markers"
+
+    # Compare the computed and expected local g-scores
+    assert isinstance(gi_scores, pd.DataFrame)
+    assert_frame_equal(
+        gi_scores.sort_index(), expected_gi_scores.sort_index(), check_column_type=False
+    )
+
+
+# Run the tests
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
## Description

Adding `compute_transition_probabilities` and `local_g` functions. `compute_transition_probabilities` takes an adjacency matrix as input and returns a matrix with transition probabilities between node pairs for a k-step random walk. `local_g` takes an adjacency matrix and a marker count matrix as input and returns a DataFrame with local G scores per marker and node. By default, `local_g` uses transition probabilities for a k-step random walk (`compute_transition_probabilities`) to construct a weighting scheme for the metric computation. 

The main expected use case of local G scores is for visualizing spatial trends of marker expression on 2D/3D layouts.

`local_g` is provided as a separate function within the new `node_metrics` module and can also be called as a method on Graph objects.

Fixes: EXE-1677

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce it when relevant.
- Added two tests for `compute_transition_probabilities` with the parameter `remove_self_loops` set to `True` or `False` (test_node_metric.py)
- Added four tests for `local_g` (test_node_metric.py)
   1. Default parameter settings
   2. `use_weights=False`
   3. `normalize_counts=False`
   4. `method='gstari'`
- Added one test for `Graph` method `local_g`  with default settings. (test_graph.py)

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and documentation and corrected any misspellings
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
