### PR TITLE
Fix write performance for many small layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED] - 2024-??-??
+
+### Added
+
+
+### Changed
+
+
+### Fixed
+
+* Poor performance when writing many small layouts to pxl file (~45x speed-up). This should almost only
+  impact test scenarios, since most real components should be large enough for this not to be an issue.
+
+
+### Removed
+
+
+
 ## [0.17.0] - 2024-05-23
 
 ### Added


### PR DESCRIPTION
## Description

Write performance degraded when writing layouts for many small components, taking 1.5h+ for ~3000 components of 2-5 vertices in size (like we currently have in the nf-core/pixelator test data). This brings that back into a total runtime of ~2 min which is more manageable.

Fixes: EXE-1751

## Type of change

Performance fix.

## How Has This Been Tested?

Unit tests and by manually running layouts on files locally.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If a new tool or package is included, I have updated poetry.lock, and [cited it properly](../CITATIONS.md)
- [x] I have checked my code and documentation and corrected any misspellings
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
