### PR TITLE
Implement low-count marker removal in pixelator colocalizaiton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Add minimum marker count `colocalization_min_marker_count` parameter to calculate colocalization score.
 * Add `wpmds` option in `pmds_layout` to compute edge weighted layouts. This is now set as the default layout algorithm.
 * Add `dsb_normalization` function for normalization of marker abundance.
 

--- a/src/pixelator/analysis/__init__.py
+++ b/src/pixelator/analysis/__init__.py
@@ -33,6 +33,7 @@ class AnalysisParameters:
     colocalization_neighbourhood_size: int
     colocalization_n_permutations: int
     colocalization_min_region_count: int
+    colocalization_min_marker_count: int
 
 
 def analyse_pixels(

--- a/src/pixelator/cli/analysis.py
+++ b/src/pixelator/cli/analysis.py
@@ -150,6 +150,7 @@ def analysis(
     colocalization_neighbourhood_size,
     colocalization_n_permutations,
     colocalization_min_region_count,
+    colocalization_min_marker_count,
     output,
 ):
     """
@@ -171,6 +172,7 @@ def analysis(
         colocalization_neighbourhood_size=colocalization_neighbourhood_size,
         colocalization_n_permutations=colocalization_n_permutations,
         colocalization_min_region_count=colocalization_min_region_count,
+        colocalization_min_marker_count=colocalization_min_marker_count,
     )
 
     # some basic sanity check on the input files
@@ -214,7 +216,7 @@ def analysis(
                 neighbourhood_size=colocalization_neighbourhood_size,
                 n_permutations=colocalization_n_permutations,
                 min_region_count=colocalization_min_region_count,
-                min_marker_count=polarization_min_marker_count,
+                min_marker_count=colocalization_min_marker_count,
             )
         )
 

--- a/src/pixelator/cli/analysis.py
+++ b/src/pixelator/cli/analysis.py
@@ -214,6 +214,7 @@ def analysis(
                 neighbourhood_size=colocalization_neighbourhood_size,
                 n_permutations=colocalization_n_permutations,
                 min_region_count=colocalization_min_region_count,
+                min_marker_count=polarization_min_marker_count,
             )
         )
 

--- a/src/pixelator/cli/analysis.py
+++ b/src/pixelator/cli/analysis.py
@@ -134,6 +134,14 @@ from pixelator.utils import (
         "valid for computing colocalization"
     ),
 )
+@click.option(
+    "--colocalization-min-marker-count",
+    default=5,
+    required=False,
+    type=click.IntRange(min=0),
+    show_default=True,
+    help=("The minimum number of marker counts in component for colocalization"),
+)
 @output_option
 @click.pass_context
 @timer

--- a/tests/Taskfile.yml
+++ b/tests/Taskfile.yml
@@ -188,6 +188,8 @@ tasks:
         0
         --colocalization-min-region-count
         0
+        --colocalization-min-marker-count
+        0
         --colocalization-n-permutations
         10
         --colocalization-neighbourhood-size

--- a/tests/analysis/colocalization/test_colocalization.py
+++ b/tests/analysis/colocalization/test_colocalization.py
@@ -213,7 +213,7 @@ def test_colocalization_scores_low_marker_removed(
     ]
     marker_counts = component_edges.groupby("marker").count()["count"]
     second_highest_marker_count = marker_counts.sort_values()[-2]
-    result = colocalization_scores(
+    result2 = colocalization_scores(
         edgelist=component_edges,
         use_full_bipartite=True,
         transformation="rate-diff",
@@ -224,30 +224,21 @@ def test_colocalization_scores_low_marker_removed(
         random_seed=1477,
     )
 
-    expected = pd.DataFrame.from_dict(
-        {
-            0: {
-                "marker_1": "A",
-                "marker_2": "C",
-                "pearson": -1.0,
-                "pearson_mean": -1.0,
-                "pearson_stdev": 0.0,
-                "pearson_z": 0.0,
-                "pearson_p_value": 0.5,
-                "pearson_p_value_adjusted": 0.5,
-                "jaccard": 0.0,
-                "jaccard_mean": 0.0,
-                "jaccard_stdev": 0.0,
-                "jaccard_z": np.nan,
-                "jaccard_p_value": np.nan,
-                "jaccard_p_value_adjusted": np.nan,
-                "component": "PXLCMP0000000",
-            }
-        },
-        orient="index",
+    assert result2.shape[0] == 1
+
+    third_highest_marker_count = marker_counts.sort_values()[-3]
+    result3 = colocalization_scores(
+        edgelist=component_edges,
+        use_full_bipartite=True,
+        transformation="rate-diff",
+        neighbourhood_size=0,
+        n_permutations=50,
+        min_region_count=0,
+        min_marker_count=2 * third_highest_marker_count - 1,
+        random_seed=1477,
     )
 
-    assert_frame_equal(result, expected)
+    assert result3.shape[0] == 3
 
 
 @pytest.mark.parametrize("enable_backend", ["networkx"], indirect=True)

--- a/tests/analysis/colocalization/test_colocalization.py
+++ b/tests/analysis/colocalization/test_colocalization.py
@@ -205,6 +205,52 @@ def test_colocalization_scores_ratediff(
 
 
 @pytest.mark.parametrize("enable_backend", ["networkx"], indirect=True)
+def test_colocalization_scores_low_marker_removed(
+    enable_backend, full_random_graph_edgelist: pd.DataFrame
+):
+    component_edges = full_random_graph_edgelist.loc[
+        full_random_graph_edgelist["component"] == "PXLCMP0000000", :
+    ]
+    marker_counts = component_edges.groupby("marker").count()["count"]
+    second_highest_marker_count = marker_counts.sort_values()[-2]
+    result = colocalization_scores(
+        edgelist=component_edges,
+        use_full_bipartite=True,
+        transformation="rate-diff",
+        neighbourhood_size=0,
+        n_permutations=50,
+        min_region_count=0,
+        min_marker_count=2 * second_highest_marker_count - 1,
+        random_seed=1477,
+    )
+
+    expected = pd.DataFrame.from_dict(
+        {
+            0: {
+                "marker_1": "A",
+                "marker_2": "C",
+                "pearson": -1.0,
+                "pearson_mean": -1.0,
+                "pearson_stdev": 0.0,
+                "pearson_z": 0.0,
+                "pearson_p_value": 0.5,
+                "pearson_p_value_adjusted": 0.5,
+                "jaccard": 0.0,
+                "jaccard_mean": 0.0,
+                "jaccard_stdev": 0.0,
+                "jaccard_z": np.nan,
+                "jaccard_p_value": np.nan,
+                "jaccard_p_value_adjusted": np.nan,
+                "component": "PXLCMP0000000",
+            }
+        },
+        orient="index",
+    )
+
+    assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("enable_backend", ["networkx"], indirect=True)
 def test_colocalization_scores_should_not_fail_when_one_component_has_single_node(
     enable_backend,
     full_graph_edgelist,

--- a/tests/analysis/colocalization/test_colocalization.py
+++ b/tests/analysis/colocalization/test_colocalization.py
@@ -58,6 +58,7 @@ def test_colocalization_from_component_edgelist(
         neighbourhood_size=1,
         n_permutations=50,
         min_region_count=0,
+        min_marker_count=0,
     )
 
     expected = pd.DataFrame.from_dict(
@@ -94,6 +95,7 @@ def test_colocalization_scores(enable_backend, full_graph_edgelist: pd.DataFrame
         neighbourhood_size=1,
         n_permutations=50,
         min_region_count=0,
+        min_marker_count=0,
     )
 
     expected = pd.DataFrame.from_dict(
@@ -131,6 +133,7 @@ def test_colocalization_scores_log1p(enable_backend, full_graph_edgelist: pd.Dat
         neighbourhood_size=1,
         n_permutations=50,
         min_region_count=0,
+        min_marker_count=0,
         random_seed=1477,
     )
 
@@ -171,6 +174,7 @@ def test_colocalization_scores_ratediff(
         neighbourhood_size=1,
         n_permutations=50,
         min_region_count=0,
+        min_marker_count=0,
         random_seed=1477,
     )
 
@@ -216,6 +220,7 @@ def test_colocalization_scores_should_not_fail_when_one_component_has_single_nod
         neighbourhood_size=1,
         n_permutations=50,
         min_region_count=0,
+        min_marker_count=0,
         random_seed=1477,
     )
 
@@ -234,6 +239,7 @@ def test_colocalization_scores_should_warn_when_no_data(
             neighbourhood_size=1,
             n_permutations=50,
             min_region_count=0,
+            min_marker_count=0,
             random_seed=1477,
         )
     assert (
@@ -247,6 +253,7 @@ class TestColocalizationAnalysis:
         transformation_type="raw",
         n_permutations=50,
         min_region_count=0,
+        min_marker_count=0,
         neighbourhood_size=1,
     )
 

--- a/tests/analysis/test_analysis_engine.py
+++ b/tests/analysis/test_analysis_engine.py
@@ -124,9 +124,13 @@ def test_run_analysis(setup_basic_pixel_dataset):
     dataset.colocalization = None
 
     analysis_functions = [
-        PolarizationAnalysis("raw", n_permutations=5, min_marker_count=1),
+        PolarizationAnalysis("log1p", n_permutations=5, min_marker_count=1),
         ColocalizationAnalysis(
-            "log1p", neighbourhood_size=3, n_permutations=5, min_region_count=3
+            "rate-diff",
+            neighbourhood_size=3,
+            n_permutations=5,
+            min_region_count=3,
+            min_marker_count=1,
         ),
     ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,6 +138,16 @@ def random_graph_edgelist_fixture():
     return edgelist
 
 
+@pytest.fixture(name="full_random_graph_edgelist", scope="module")
+def full_random_graph_edgelist_fixture():
+    """Create an edgelist based on a random graph."""
+    g = create_random_graph(n_nodes=500, prob=0.005)
+    edgelist = create_simple_edge_list_from_graph(g, random_markers=True)
+    edgelist = update_edgelist_membership(edgelist, prefix="PXLCMP")
+    edgelist = enforce_edgelist_types_for_tests(edgelist)
+    return edgelist
+
+
 @pytest.fixture(name="layout_df")
 def layout_df_fixture() -> pd.DataFrame:
     nbr_of_rows = 300

--- a/tests/graph/networkx/test_tools.py
+++ b/tests/graph/networkx/test_tools.py
@@ -19,6 +19,7 @@ def create_random_graph(n_nodes: int, prob: float) -> Graph:
     and a probability prob of connecting two
     nodes with an edge
     """
+    random.seed(0)
     rng = np.random.default_rng(2)
     edge_list = []
     for i in range(0, n_nodes):

--- a/tests/integration/test_small_D21.yaml
+++ b/tests/integration/test_small_D21.yaml
@@ -30,6 +30,8 @@ small-D21:
           "5",
           "--colocalization-min-region-count",
           "0",
+          "--colocalization-min-marker-count",
+          "0",
           "--colocalization-n-permutations",
           "10",
           "--colocalization-neighbourhood-size",


### PR DESCRIPTION
Exclude low-count markers in a component from colocalization calculation.

Fixes: EXE-1826
## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

The existing tests pass. A new test is added to remove markers with low counts from a component and check how many marker-pairs are included in colocalization output.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and documentation and corrected any misspellings
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
