### PR TITLE
ci: fix pixelator container version on tag push

### DIFF
--- a/.github/actions/build-dev-image/action.yml
+++ b/.github/actions/build-dev-image/action.yml
@@ -1,9 +1,6 @@
 name: "build-dev-image"
 description: "Build a dev image and push it to the Pixelgen container registries"
 inputs:
-  tag:
-    description: "The tag to use for the image"
-    required: true
   cache-from:
     description: "The cache to use for the build"
     default: ""
@@ -60,6 +57,11 @@ runs:
           bakeSetCommands.push(...cacheFromArray)
           bakeSetCommands.push(...cacheToArray)
           bakeSetCommands.push(...platformArray)
+
+          # Override the version in the container if we are run in a version tag push event
+          if ( context.eventName === "push" && github.ref.startsWith('refs/tags/v) ) {
+            bakeSetCommands.push("*.args.VERSION_OVERRIDE=" + "${{ steps.meta.outputs.version }}" )
+          }
 
           bakeSetCommandsText = bakeSetCommands.join('\n')
           core.setOutput('set', bakeSetCommandsText)


### PR DESCRIPTION
## Description

Make sure containers created on tag events override the dynamic pixelator version.
Remove unused input argument

Fixes: EXE-1880

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
