### PR TITLE
Fix  layout aggregation memory usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [x.x.x] - 2024-xx-xx
+
+
+### Fixed
+
+ - Improved memory usage when aggregating pixel files with precomputed layouts.
+
 ## [0.18.2] - 2024-07-16
 
 ### Changed

--- a/src/pixelator/pixeldataset/__init__.py
+++ b/src/pixelator/pixeldataset/__init__.py
@@ -210,14 +210,18 @@ class PixelDataset:
     @property
     def precomputed_layouts(
         self,
-    ) -> PreComputedLayouts | None:
+    ) -> PreComputedLayouts:
         """Get the precomputed layouts."""
         return self._backend.precomputed_layouts
 
     @precomputed_layouts.setter
     def precomputed_layouts(self, value: PreComputedLayouts | None) -> None:
         """Set the precomputed layouts."""
-        self._backend.precomputed_layouts = value
+        # Note that the type ignore here is to handle the fact that the setter
+        # needs to be able to take None (in order to make it easier to the user)
+        # but that will be transformed into a empty PreComputedLayouts object
+        # by the backend as and when it sees fit.
+        self._backend.precomputed_layouts = value  # type: ignore
 
     def graph(
         self,

--- a/src/pixelator/pixeldataset/aggregation.py
+++ b/src/pixelator/pixeldataset/aggregation.py
@@ -148,10 +148,7 @@ def simple_aggregate(
     }
 
     precomputed_layouts = aggregate_precomputed_layouts(
-        [
-            (name, dataset.precomputed_layouts)
-            for name, dataset in zip(sample_names, datasets)
-        ],
+        [(name, dataset) for name, dataset in zip(sample_names, datasets)],
         all_markers=set(datasets[0].adata.var.index),
     )
 

--- a/src/pixelator/pixeldataset/backends.py
+++ b/src/pixelator/pixeldataset/backends.py
@@ -284,14 +284,15 @@ class FileBasedPixelDatasetBackend:
         """Get the precomputed layouts."""
         # If it is None it means it is uninitialized, and we should
         # attempt to read it lazily
+
         if self._precomputed_layouts is None:
-            return self._datastore.read_precomputed_layouts()
+            self._precomputed_layouts = self._datastore.read_precomputed_layouts()
 
         # It can also be empty, in which case it has been read and
         # found to be empty. Or it has been initialized to be empty,
         # which means that it should be cleared.
-        if self._precomputed_layouts.is_empty:
-            return None
+        if self._precomputed_layouts.is_empty:  # type: ignore
+            self._precomputed_layouts = PreComputedLayouts.create_empty()
 
         return self._precomputed_layouts
 

--- a/src/pixelator/pixeldataset/backends.py
+++ b/src/pixelator/pixeldataset/backends.py
@@ -82,7 +82,7 @@ class PixelDatasetBackend(Protocol):
         """Set the metadata object."""
 
     @property
-    def precomputed_layouts(self) -> Optional[PreComputedLayouts]:
+    def precomputed_layouts(self) -> PreComputedLayouts:
         """Get the precomputed layouts for the component graphs.
 
         Please note that since these have been pre-computed, if you have made
@@ -91,12 +91,12 @@ class PixelDatasetBackend(Protocol):
         ...
 
     @precomputed_layouts.setter
-    def precomputed_layouts(self, value: PreComputedLayouts) -> None:
+    def precomputed_layouts(self, value: PreComputedLayouts | None) -> None:
         """Set the precomputed layouts for the component graphs."""
         ...
 
 
-class ObjectBasedPixelDatasetBackend:
+class ObjectBasedPixelDatasetBackend(PixelDatasetBackend):
     """A backend for PixelDataset that is backed by in memory objects.
 
     `ObjectBasedPixelDatasetBackend` provides a backend for PixelDatasets that
@@ -209,12 +209,10 @@ class ObjectBasedPixelDatasetBackend:
         self._colocalization = value
 
     @property
-    def precomputed_layouts(self) -> PreComputedLayouts | None:
+    def precomputed_layouts(self) -> PreComputedLayouts:
         """Get the precomputed layouts."""
         if self._precomputed_layouts is None:
-            return None
-        if self._precomputed_layouts.is_empty:
-            return None
+            return PreComputedLayouts.create_empty()
         return self._precomputed_layouts
 
     @precomputed_layouts.setter
@@ -225,7 +223,7 @@ class ObjectBasedPixelDatasetBackend:
         self._precomputed_layouts = value
 
 
-class FileBasedPixelDatasetBackend:
+class FileBasedPixelDatasetBackend(PixelDatasetBackend):
     """A file based backend for PixelDataset.
 
     `FileBasedPixelDatasetBackend` is used to lazily fetch information from
@@ -280,20 +278,16 @@ class FileBasedPixelDatasetBackend:
         return self._datastore.read_metadata()
 
     @property
-    def precomputed_layouts(self) -> PreComputedLayouts | None:
+    def precomputed_layouts(self) -> PreComputedLayouts:
         """Get the precomputed layouts."""
         # If it is None it means it is uninitialized, and we should
         # attempt to read it lazily
 
+        if isinstance(self._precomputed_layouts, PreComputedLayouts):
+            return self._precomputed_layouts
+
         if self._precomputed_layouts is None:
             self._precomputed_layouts = self._datastore.read_precomputed_layouts()
-
-        # It can also be empty, in which case it has been read and
-        # found to be empty. Or it has been initialized to be empty,
-        # which means that it should be cleared.
-        if self._precomputed_layouts.is_empty:  # type: ignore
-            self._precomputed_layouts = PreComputedLayouts.create_empty()
-
         return self._precomputed_layouts
 
     @precomputed_layouts.setter

--- a/src/pixelator/pixeldataset/precomputed_layouts.py
+++ b/src/pixelator/pixeldataset/precomputed_layouts.py
@@ -364,7 +364,10 @@ def aggregate_precomputed_layouts(
             if layout.is_empty:
                 continue
             layout_with_name = layout.lazy.with_columns(
-                sample=pl.lit(sample_name)
+                sample=pl.lit(sample_name),
+                component=pl.concat_str(
+                    pl.col("component"), pl.lit(sample_name), separator="_"
+                ),
             ).pipe(zero_fill_missing_markers, all_markers=all_markers)
             yield layout_with_name
 

--- a/tests/pixeldataset/test_aggregation.py
+++ b/tests/pixeldataset/test_aggregation.py
@@ -200,9 +200,10 @@ def test_simple_aggregate_do_not_have_problems_with_layouts_when_working_with_fi
     dataset_1.save(tmp_data_set_path_1)
     dataset_1.save(tmp_data_set_path_2)
 
+    datasets = list([read(tmp_data_set_path_1), read(tmp_data_set_path_2)])
     result = simple_aggregate(
         sample_names=["sample1", "sample2"],
-        datasets=[read(tmp_data_set_path_1), read(tmp_data_set_path_2)],
+        datasets=datasets,
     )
 
     assert len(result.precomputed_layouts.to_df()) == 2 * len(

--- a/tests/pixeldataset/test_backends.py
+++ b/tests/pixeldataset/test_backends.py
@@ -33,7 +33,7 @@ def assert_backend_can_set_values(pixel_dataset_backend):
 
     assert pixel_dataset_backend.precomputed_layouts
     pixel_dataset_backend.precomputed_layouts = None
-    assert not pixel_dataset_backend.precomputed_layouts
+    assert pixel_dataset_backend.precomputed_layouts.is_empty
 
 
 def test_file_based_pixel_dataset_backend_set_attrs(pixel_dataset_file):

--- a/tests/pixeldataset/test_datastores.py
+++ b/tests/pixeldataset/test_datastores.py
@@ -4,6 +4,7 @@ Copyright © 2024 Pixelgen Technologies AB.
 """
 
 from pathlib import Path
+from shutil import make_archive
 from unittest.mock import patch
 from zipfile import ZipFile
 
@@ -11,6 +12,7 @@ import pandas as pd
 import polars as pl
 import pytest
 from anndata import AnnData
+from fsspec.implementations.zip import ZipFileSystem
 from pandas.core.frame import DataFrame
 from pandas.testing import assert_frame_equal
 from pixelator.pixeldataset import PixelDataset
@@ -21,6 +23,7 @@ from pixelator.pixeldataset.datastores import (
     ZipBasedPixelFile,
     ZipBasedPixelFileWithCSV,
     ZipBasedPixelFileWithParquet,
+    _CustomZipFileSystem,
 )
 from pixelator.pixeldataset.precomputed_layouts import PreComputedLayouts
 
@@ -40,7 +43,7 @@ class TestPixelDataStore:
         dataset, *_ = setup_basic_pixel_dataset
         file_target = tmp_path / "dataset.pxl"
         # Writing pre-computed layouts is not supported for csv files
-        dataset.precomputed_layouts = None
+        dataset.precomputed_layouts = None  # type: ignore
         dataset.save(str(file_target), file_format="csv")
         res = PixelDataStore.guess_datastore_from_path(file_target)
         assert isinstance(res, ZipBasedPixelFileWithCSV)
@@ -67,7 +70,7 @@ class TestPixelDataStore:
     ):
         dataset, *_ = setup_basic_pixel_dataset
         # Writing pre-computed layouts is not supported for csv files
-        dataset.precomputed_layouts = None
+        dataset.precomputed_layouts = None  # type: ignore
         file_target = tmp_path / "dataset.pxl"
         dataset.save(str(file_target), file_format="csv")
         res = PixelDataStore.from_path(file_target)
@@ -141,7 +144,7 @@ class TestPixelDataStore:
     ):
         dataset, *_ = setup_basic_pixel_dataset
         # Writing pre-computed layouts is not supported for csv files
-        dataset.precomputed_layouts = None
+        dataset.precomputed_layouts = None  # type: ignore
         file_target = tmp_path / "dataset.pxl"
         dataset.save(
             str(file_target),
@@ -338,6 +341,104 @@ class TestZipBasedPixelFileWithCSV:
         file_target = tmp_path / "dataset.pxl"
         assert not file_target.is_file()
         # Writing pre-computed layouts is not supported for csv files
-        dataset.precomputed_layouts = None
+        dataset.precomputed_layouts = None  # type: ignore
         ZipBasedPixelFileWithCSV(file_target).save(dataset)
         assert file_target.is_file()
+
+
+@pytest.mark.test_this
+class TestCustomZipFileSystem:
+    @pytest.fixture(name="zip_file")
+    def zip_file_fixture(self, tmp_path):
+        data_dir = tmp_path / "data/"
+        data_dir.mkdir()
+        file1 = data_dir / "file1.txt"
+        file1.write_text("Hello, World!")
+        file2 = data_dir / "file2.txt"
+        file2.write_text("Lorem ipsum dolor sit amet")
+
+        empty_dir = data_dir / "dir1"
+        empty_dir.mkdir()
+
+        dir_with_files = data_dir / "dir2"
+        dir_with_files.mkdir()
+        file3 = dir_with_files / "file3.txt"
+        file3.write_text("Hello!")
+
+        zip_file = tmp_path / "test"
+        return Path(make_archive(zip_file, "zip", data_dir))
+
+    @pytest.mark.parametrize("detail", [True, False])
+    @pytest.mark.parametrize("withdirs", [True, False])
+    @pytest.mark.parametrize("max_depth", [None, 1, 2])
+    def test_ensure_parity(self, zip_file, detail, withdirs, max_depth):
+        custom_zip_file_system = _CustomZipFileSystem(zip_file)
+        zip_file_system = ZipFileSystem(zip_file)
+        result = custom_zip_file_system.find(
+            "/", detail=detail, withdirs=withdirs, max_depth=max_depth
+        )
+        expected_result = zip_file_system.find(
+            "/", detail=detail, withdirs=withdirs, max_depth=max_depth
+        )
+        assert result
+        assert result == expected_result
+
+    def test_find_returns_expected_result_detail_true(self, zip_file):
+        custom_zip_file_system = _CustomZipFileSystem(zip_file)
+        zip_file_system = ZipFileSystem(zip_file)
+
+        result = custom_zip_file_system.find("/", detail=True)
+        expected_result = zip_file_system.find("/", detail=True)
+
+        assert result
+        assert result == expected_result
+
+    def test_find_returns_expected_result_detail_false(self, zip_file):
+        custom_zip_file_system = _CustomZipFileSystem(zip_file)
+        zip_file_system = ZipFileSystem(zip_file)
+
+        result = custom_zip_file_system.find("/", detail=False)
+        expected_result = zip_file_system.find("/", detail=False)
+
+        assert result
+        assert result == expected_result
+
+    def test_find_returns_expected_result_detail_true_include_dirs(self, zip_file):
+        custom_zip_file_system = _CustomZipFileSystem(zip_file)
+        zip_file_system = ZipFileSystem(zip_file)
+
+        result = custom_zip_file_system.find("/", detail=True, withdirs=True)
+        expected_result = zip_file_system.find("/", detail=True, withdirs=True)
+
+        assert result
+        assert result == expected_result
+
+    def test_find_returns_expected_result_detail_false_include_dirs(self, zip_file):
+        custom_zip_file_system = _CustomZipFileSystem(zip_file)
+        zip_file_system = ZipFileSystem(zip_file)
+
+        result = custom_zip_file_system.find("/", detail=False, withdirs=True)
+        expected_result = zip_file_system.find("/", detail=False, withdirs=True)
+
+        assert result
+        assert result == expected_result
+
+    def test_find_returns_expected_result_recursion_depth_set(self, zip_file):
+        custom_zip_file_system = _CustomZipFileSystem(zip_file)
+        zip_file_system = ZipFileSystem(zip_file)
+
+        result = custom_zip_file_system.find("/", maxdepth=1)
+        expected_result = zip_file_system.find("/", maxdepth=1)
+
+        assert result
+        assert result == expected_result
+
+    def test_find_returns_expected_result_path_set(self, zip_file):
+        custom_zip_file_system = _CustomZipFileSystem(zip_file)
+        zip_file_system = ZipFileSystem(zip_file)
+
+        result = custom_zip_file_system.find("/dir2")
+        expected_result = zip_file_system.find("/dir2")
+
+        assert result
+        assert result == expected_result

--- a/tests/pixeldataset/test_precomputed_layouts.py
+++ b/tests/pixeldataset/test_precomputed_layouts.py
@@ -326,7 +326,14 @@ class TestPreComputedLayouts:
             {
                 "x": [1, 2, 3, 7, 8, 9],
                 "y": [4, 5, 6, 10, 11, 12],
-                "component": ["A", "B", "C", "A", "B", "C"],
+                "component": [
+                    "A_sample1",
+                    "B_sample1",
+                    "C_sample1",
+                    "A_sample2",
+                    "B_sample2",
+                    "C_sample2",
+                ],
                 "sample": [
                     "sample1",
                     "sample1",
@@ -366,7 +373,7 @@ class TestPreComputedLayouts:
             {
                 "x": [7, 8, 9],
                 "y": [10, 11, 12],
-                "component": ["A", "B", "C"],
+                "component": ["A_sample2", "B_sample2", "C_sample2"],
                 "sample": [
                     "sample2",
                     "sample2",

--- a/tests/pixeldataset/test_precomputed_layouts.py
+++ b/tests/pixeldataset/test_precomputed_layouts.py
@@ -98,6 +98,11 @@ def precomputed_layouts_fixture(request) -> PreComputedLayouts:
     raise Exception("We should never get here!")
 
 
+class MockPixelDataset:
+    def __init__(self, precomputed_layouts):
+        self.precomputed_layouts = precomputed_layouts
+
+
 class TestPreComputedLayouts:
     def test_is_empty_returns_true_for_empty_layout(self):
         layouts_lazy = pl.DataFrame({"component": []}).lazy()
@@ -285,30 +290,34 @@ class TestPreComputedLayouts:
 
     def test_aggregate_precomputed_layouts(self):
         # Create some sample PreComputedLayouts
-        layout1 = PreComputedLayouts(
-            pl.DataFrame(
-                {
-                    "x": [1, 2, 3],
-                    "y": [4, 5, 6],
-                    "component": ["A", "B", "C"],
-                    "sample": ["sample1", "sample1", "sample1"],
-                }
-            ).lazy()
+        pxl_1 = MockPixelDataset(
+            PreComputedLayouts(
+                pl.DataFrame(
+                    {
+                        "x": [1, 2, 3],
+                        "y": [4, 5, 6],
+                        "component": ["A", "B", "C"],
+                        "sample": ["sample1", "sample1", "sample1"],
+                    }
+                ).lazy()
+            )
         )
-        layout2 = PreComputedLayouts(
-            pl.DataFrame(
-                {
-                    "x": [7, 8, 9],
-                    "y": [10, 11, 12],
-                    "component": ["A", "B", "C"],
-                    "sample": ["sample2", "sample2", "sample2"],
-                }
-            ).lazy()
+        pxl_2 = MockPixelDataset(
+            PreComputedLayouts(
+                pl.DataFrame(
+                    {
+                        "x": [7, 8, 9],
+                        "y": [10, 11, 12],
+                        "component": ["A", "B", "C"],
+                        "sample": ["sample2", "sample2", "sample2"],
+                    }
+                ).lazy()
+            )
         )
 
         # Aggregate the layouts
         aggregated_layouts = aggregate_precomputed_layouts(
-            [("sample1", layout1), ("sample2", layout2)],
+            [("sample1", pxl_1), ("sample2", pxl_2)],
             all_markers={"x", "y", "component", "sample"},
         )
 
@@ -332,21 +341,23 @@ class TestPreComputedLayouts:
 
     def test_aggregate_precomputed_layouts_one_empty_data_frame(self):
         # Create some sample PreComputedLayouts
-        layout1 = PreComputedLayouts(None)
-        layout2 = PreComputedLayouts(
-            pl.DataFrame(
-                {
-                    "x": [7, 8, 9],
-                    "y": [10, 11, 12],
-                    "component": ["A", "B", "C"],
-                    "sample": ["sample2", "sample2", "sample2"],
-                }
-            ).lazy()
+        mock_pxl_1 = MockPixelDataset(PreComputedLayouts(None))
+        mock_pxl_2 = MockPixelDataset(
+            PreComputedLayouts(
+                pl.DataFrame(
+                    {
+                        "x": [7, 8, 9],
+                        "y": [10, 11, 12],
+                        "component": ["A", "B", "C"],
+                        "sample": ["sample2", "sample2", "sample2"],
+                    }
+                ).lazy()
+            )
         )
 
         # Aggregate the layouts
         aggregated_layouts = aggregate_precomputed_layouts(
-            [("sample1", layout1), ("sample2", layout2)],
+            [("sample1", mock_pxl_1), ("sample2", mock_pxl_2)],
             all_markers={"x", "y", "component", "sample"},
         )
 
@@ -367,12 +378,12 @@ class TestPreComputedLayouts:
 
     def test_aggregate_precomputed_layouts_no_layouts_in_data(self):
         # Create some sample PreComputedLayouts
-        layout1 = PreComputedLayouts(None)
-        layout2 = PreComputedLayouts(None)
+        mock_pxl_1 = MockPixelDataset(PreComputedLayouts(None))
+        mock_pxl_2 = MockPixelDataset(PreComputedLayouts(None))
 
         # Aggregate the layouts
         aggregated_layouts = aggregate_precomputed_layouts(
-            [("sample1", layout1), ("sample2", layout2)],
+            [("sample1", mock_pxl_1), ("sample2", mock_pxl_2)],
             all_markers={"x", "y", "component", "sample"},
         )
 


### PR DESCRIPTION
## Description

When aggregating layouts we were eagerly loading all data into memory which is problematic since it's something we often do as part of the data analysis. This will still require quite a lot of memory, but it is on possible to aggregate 6 samples in less than 20 GB RAM. Previously this required considerably more (however I haven't checked exactly how much since it did not fit in my laptop).

The changes that have been applied here to achieve this is:
 - making sure the layouts are not actually materialized until they are requested (see the changes in `aggregate_precomputed_layouts`)
 - when materializing precomputed layouts for saving pxl files, do so one layout set at the time
 - a related problem when working with many layouts in the same file is that the performance for loading layouts was very poor (taking ~2 min load a single one). I eventually found out this was due to poor performance in the zip file systems find function. I provide a temporary custom zip file system here that addresses that, but the plan is to bring those changes upstream into fsspec.

Fixes: exe-1897

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested with associated unit tests, but I have also been manually working through some of the data analysis tutorials to make sure nothing has been broken there.

## PR checklist:

- [ ] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated poetry.lock, and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
