### PR TITLE
Updated probability distance calculations

### DIFF
--- a/tests/graph/test_graph.py
+++ b/tests/graph/test_graph.py
@@ -6,6 +6,7 @@ Copyright © 2023 Pixelgen Technologies AB.
 import random
 from unittest.mock import MagicMock
 
+import networkx as nx
 import numpy as np
 import pandas as pd
 import pytest
@@ -13,6 +14,7 @@ from numpy.testing import assert_array_almost_equal, assert_array_equal
 from pandas.testing import assert_frame_equal
 
 from pixelator.graph import Graph
+from pixelator.graph.backends.implementations._networkx import pmds_layout
 from tests.graph.networkx.test_tools import random_sequence
 from tests.test_tools import enforce_edgelist_types_for_tests
 
@@ -574,6 +576,31 @@ def test_layout_coordinates_3d_pmds_with_weights(pentagram_graph):
         3569.35412551,
         2998.85729688,
         3569.35412551,
+    ]
+
+    assert_array_almost_equal(l2, expected, decimal=4)
+
+
+def test_pmds_layout_3d_with_weights_multigraph(pentagram_graph):
+    g = pentagram_graph.raw
+    g_multi = nx.MultiGraph(g)
+
+    result = pmds_layout(
+        g_multi,
+        pivots=4,
+        dim=3,
+        weights="prob_dist",
+        seed=123,
+    )
+    result = pd.DataFrame.from_dict(result, orient="index", columns=["x", "y", "z"])
+
+    l2 = np.linalg.norm(result[["x", "y", "z"]], axis=1)
+    expected = [
+        3569.35412551,
+        2998.85729688,
+        2998.85729688,
+        3569.35412551,
+        2998.85729688,
     ]
 
     assert_array_almost_equal(l2, expected, decimal=4)


### PR DESCRIPTION
## Description

[Edges in multigraphs](https://networkx.org/documentation/stable/reference/classes/generated/networkx.MultiGraph.edges.html) have an additional key that makes the weighted pMDS algorithm fail. Since we have used simple graphs previously, this was not handled by `_prob_edge_weights` which expected a tuple of two in each edge.

This PR contains a fix to enable running `_prob_edge_weights` regardless of whether the graph is simple or multigraph.

Moreover, the method has been updated to be more performant on larger graphs.

Fixes: exe-1997

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

Added a new test for `pmds_layout` with "prob_dist" weights on a multigraph version of `pentagram_graph`.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
