### PR TITLE
Improve cli start-up speed

### DIFF
--- a/src/pixelator/graph/community_detection.py
+++ b/src/pixelator/graph/community_detection.py
@@ -5,17 +5,13 @@ Copyright © 2022 Pixelgen Technologies AB.
 
 import logging
 from copy import copy
-from dataclasses import dataclass
 from pathlib import Path
-from queue import Queue
-from time import time
-from typing import Optional, Tuple
+from typing import Tuple
 
 import networkx as nx
 import numpy as np
 import pandas as pd
 import polars as pl
-from graspologic.partition import leiden
 
 from pixelator.graph.constants import (
     LEIDEN_RESOLUTION,
@@ -25,7 +21,6 @@ from pixelator.graph.utils import (
     edgelist_metrics,
     map_upis_to_components,
     split_remaining_and_removed_edgelist,
-    update_edgelist_membership,
 )
 from pixelator.report.models.graph import GraphSampleReport
 from pixelator.types import PathType
@@ -296,6 +291,9 @@ def recover_technical_multiplets(
         "Starting multiplets recovery in edge list with %i rows",
         edgelist.shape[0],
     )
+
+    # Import here since the import is very slow and expensive
+    from graspologic.partition import leiden
 
     def id_generator(start=0):
         next_id = start

--- a/src/pixelator/pixeldataset/utils.py
+++ b/src/pixelator/pixeldataset/utils.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 import pandas as pd
 from anndata import AnnData, ImplicitModificationWarning, read_h5ad
-from graspologic.partition import leiden
 
 from pixelator.graph import components_metrics
 from pixelator.graph.constants import LEIDEN_RESOLUTION, RELATIVE_ANNOTATE_RESOLUTION
@@ -222,6 +221,9 @@ def write_anndata(adata: AnnData, filename: PathType) -> None:
 def _compute_sub_communities(
     component_edgelist: pd.DataFrame, n_edges_reconnect: int | None = None
 ) -> pd.Series:
+    # Import here since the import is very slow and expensive
+    from graspologic.partition import leiden
+
     component_edgelist = (
         component_edgelist.groupby(["upia", "upib"], observed=True)["count"]
         .count()


### PR DESCRIPTION
## Description

Since graspologic takes a long time to import we have had those imports done dynamically as they are needed rather than at the module level. This speeds up cli start up times considerably. 

I also cleaned out some unused imports.

Fixes: N/A

## Type of change

Only changes when things are imported.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce it when relevant.

## PR checklist:

- [ ] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated poetry.lock, and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
