### PR TITLE
Fixing the error output for calling pixel graph function with non-existing component name

### DIFF
--- a/src/pixelator/pixeldataset/__init__.py
+++ b/src/pixelator/pixeldataset/__init__.py
@@ -245,7 +245,7 @@ class PixelDataset:
         """
         if component_id:
             potential_component = self.edgelist_lazy.filter(
-                pl.col("component") == component_id
+                pl.col("component").cast(pl.String) == component_id
             )
             if potential_component.head(1).collect().is_empty():
                 raise KeyError(f"{component_id} not found in edgelist")


### PR DESCRIPTION
graph = pxl.graph("missing_component_id") results in a ComputeError instead of a KeyError. 

Fixes: EXE-2058

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The tutorial example that was raising a ComputeError raises a KeyError now.
## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
