### PR TITLE
Better error message when there are fewer nodes than the number of dimensions in pmds layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-_   Add `depth` column to `discarded_edgelist.parquet` output of the GRAPH stage that indicates at which refinement iteration the edge is removed.
-_   Add `edges_removed_in_multiplet_recovery_first_iteration`, `edges_removed_in_multiplet_recovery_refinement` and `fraction_edges_removed_in_refinement` to graph report.json.
+-   Add `depth` column to `discarded_edgelist.parquet` output of the GRAPH stage that indicates at which refinement iteration the edge is removed.
+-   Add `edges_removed_in_multiplet_recovery_first_iteration`, `edges_removed_in_multiplet_recovery_refinement` and `fraction_edges_removed_in_refinement` to graph report.json.
 -   Add `is_potential_doublet` and `n_edges_to_split_doublet` columns to adata.obs.
 -   Add `fraction_potential_doublets` and `n_edges_to_split_potential_doublets` to annotate report.json.
 -   Add `--max-edges-to-split` option to `graph` to specify the maximum number of edges that can be removed between two sub-components during multiplet recovery.
@@ -29,6 +29,11 @@ _   Add `edges_removed_in_multiplet_recovery_first_iteration`, `edges_removed_in
 ### Removed
 
 -   Remove the `components_recovered.csv` output from the GRAPH stage.
+
+
+### Fixed
+
+- better error message when the number of nodes is lower than the number of requested dimensions in `pmds_layout`.
 
 ## [0.18.3] - 2024-09-26
 

--- a/src/pixelator/graph/backends/implementations/_networkx.py
+++ b/src/pixelator/graph/backends/implementations/_networkx.py
@@ -803,7 +803,7 @@ def pmds_layout(
     if pivots < dim:
         raise ValueError("'pivots' must be greater than or equal to dim.")
 
-    if n_nodes < dim:
+    if n_nodes <= dim:
         raise ValueError(
             f"Number of nodes in the graph ({n_nodes}) must be greater than or equal to 'dim' ({dim})."
         )

--- a/src/pixelator/graph/backends/implementations/_networkx.py
+++ b/src/pixelator/graph/backends/implementations/_networkx.py
@@ -788,8 +788,9 @@ def pmds_layout(
     if not nx.is_connected(g):
         raise ValueError("Only connected graphs are supported.")
 
-    if pivots >= len(g.nodes):
-        total_nodes = len(g.nodes)
+    n_nodes = len(g.nodes)
+    if pivots >= n_nodes:
+        total_nodes = n_nodes
         warnings.warn(
             f"'pivots' ({pivots}) should be less than the number of "
             f"nodes ({total_nodes}) in the graph. Using all nodes as 'pivots'."
@@ -801,6 +802,11 @@ def pmds_layout(
 
     if pivots < dim:
         raise ValueError("'pivots' must be greater than or equal to dim.")
+
+    if n_nodes < dim:
+        raise ValueError(
+            f"Number of nodes in the graph ({n_nodes}) must be greater than or equal to 'dim' ({dim})."
+        )
 
     pivot_lower_bound = np.min([np.floor(0.2 * len(g.nodes)), 50])
     if pivots < pivot_lower_bound:
@@ -862,6 +868,7 @@ def pmds_layout(
     # Compute SVD and use distances to compute coordinates for all nodes
     # in an abstract cartesian space
     _, _, Vh = sp.sparse.linalg.svds(D_pivs_centered, k=dim, random_state=seed)
+
     coordinates = D_pivs_centered @ np.transpose(Vh)
     # Flip the coordinates here to make sure that we get the correct coordinate ordering
     # i.e. iqr(x) > iqr(y) > iqr(z)


### PR DESCRIPTION
## Description

Check up-front that the number of nodes is greater than the number of dimensions being requested in the pmds layout - if not give a clearer error message.

Fixes: exe-2061

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit test added and some manual testing.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If a new tool or package is included, I have updated poetry.lock, and [cited it properly](../CITATIONS.md)
- [x] I have checked my code and documentation and corrected any misspellings
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
