### PR TITLE
Feature/exe 2054 bail early on bad demux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Specify maximum number of edges that can be removed between two sub-components during multiplet recovery using `--max-edges-to-split`.
 -   Support for MultiGraphs in `pmds_layout`
 -   Support multiple targets in `plot_colocalization_diff_volcano` and `plot_colocalization_diff_heatmap`.
+-   If demultiplexing has a success rate lower than 50% the command will exit with a status of 1. This prevents further pipeline stages to be run on
+    what is probably bad data.
 
 ### Added
 

--- a/src/pixelator/cli/demux.py
+++ b/src/pixelator/cli/demux.py
@@ -4,6 +4,8 @@ Console script for pixelator (demux)
 Copyright © 2022 Pixelgen Technologies AB.
 """
 
+import sys
+
 import click
 
 from pixelator.cli.common import (
@@ -161,7 +163,7 @@ def demux(
         command_path="pixelator single-cell demux",
     )
 
-    demux_fastq(
+    results_ok = demux_fastq(
         input=str(fastq_file),
         output=str(output_file),
         failed=str(failed_file),
@@ -174,3 +176,6 @@ def demux(
         verbose=ctx.obj["VERBOSE"],
         sample_id=name,
     )
+
+    if not results_ok:
+        sys.exit(1)

--- a/tests/demux/test_process.py
+++ b/tests/demux/test_process.py
@@ -1,0 +1,13 @@
+"""Copyright © 2024 Pixelgen Technologies AB."""
+
+from pixelator.demux.process import check_demux_results_are_ok
+
+
+def test_check_demux_results_are_ok():
+    data = {"read_counts": {"input": 100, "output": 90}}
+    assert check_demux_results_are_ok(data, sample_id="test")
+
+
+def test_check_demux_results_are_not_ok():
+    data = {"read_counts": {"input": 100, "output": 40}}
+    assert not check_demux_results_are_ok(data, sample_id="test")


### PR DESCRIPTION
## Description

Exit with status 1 if less them 50% of reads are demuxed.

Fixes: exe-2054

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

With the added unit test.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If a new tool or package is included, I have updated poetry.lock, and [cited it properly](../CITATIONS.md)
- [x] I have checked my code and documentation and corrected any misspellings
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
