### PR TITLE
Feature/exe 2075 fail if hard and dynamic size limits are both set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Support multiple targets in `plot_colocalization_diff_volcano` and `plot_colocalization_diff_heatmap`.
 -   If demultiplexing has a success rate lower than 50% the command will exit with a status of 1. This prevents further pipeline stages to be run on
     what is probably bad data.
+-   Clarify that `--min-size` and `--max-size` in the `annotate` stage should not be used at the same time as `--dynamic-filter`.
 
 ### Added
 

--- a/src/pixelator/cli/annotate.py
+++ b/src/pixelator/cli/annotate.py
@@ -45,7 +45,7 @@ from pixelator.utils import (
     required=False,
     type=click.INT,
     show_default=False,
-    help="The minimum size (edges) a component must have (default is disabled)",
+    help="The minimum size (edges) a component must have (default is disabled). Note that this cannot be set at the same time as --dynamic-filter.",
 )
 @click.option(
     "--max-size",
@@ -53,7 +53,7 @@ from pixelator.utils import (
     required=False,
     type=click.INT,
     show_default=False,
-    help="The maximum size (edges) a component must have (default is disabled)",
+    help="The maximum size (edges) a component must have (default is disabled). Note that this cannot bet set at the same time as --dynamic-filter.",
 )
 @click.option(
     "--dynamic-filter",
@@ -61,10 +61,9 @@ from pixelator.utils import (
     default=None,
     type=click.Choice(["both", "min", "max"]),
     help=(
-        "Enable the estimation of dynamic size filters using a log-rank approach\n"
-        "\t both: estimate both min and max size"
-        "\t min: estimate min size (--min-size)"
-        "\t max: estimate max size (--max-size)"
+        "Enable the dynamic component size filters. The following modes are available: "
+        "both/max/min. both: estimates both min and max size, min: estimates min size, max: estimates max size. "
+        "Note that this cannot be set at the same time as --min-size or --max-size."
     ),
 )
 @click.option(
@@ -110,11 +109,17 @@ def annotate(
 
     # sanity check on thresholds and input parameters
     if min_size is not None and min_size < 0:
-        click.ClickException("--min-size cannot be less than 0")
+        raise click.ClickException("--min-size cannot be less than 0")
     if max_size is not None and max_size < 0:
-        click.ClickException("--max-size cannot be less than 0")
+        raise click.ClickException("--max-size cannot be less than 0")
     if max_size is not None and min_size is not None and max_size < min_size:
-        click.ClickException("--max-size cannot be less than --min-size")
+        raise click.ClickException("--max-size cannot be less than --min-size")
+
+    if min_size is not None or max_size is not None:
+        if dynamic_filter is not None:
+            raise click.ClickException(
+                "Cannot set --dynamic-filter and --min-size or --max-size at the same time"
+            )
 
     # warn if both --dynamic-filter and hard-coded sizes are input
     if min_size is not None and dynamic_filter in ["min", "both"]:

--- a/src/pixelator/cli/annotate.py
+++ b/src/pixelator/cli/annotate.py
@@ -53,7 +53,7 @@ from pixelator.utils import (
     required=False,
     type=click.INT,
     show_default=False,
-    help="The maximum size (edges) a component must have (default is disabled). Note that this cannot bet set at the same time as --dynamic-filter.",
+    help="The maximum size (edges) a component must have (default is disabled). Note that this cannot be set at the same time as --dynamic-filter.",
 )
 @click.option(
     "--dynamic-filter",


### PR DESCRIPTION
## Description

Fail if both dynamic and hard size limits are set in `annotate` at the same time.

Fixes: exe-2075

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested by manually running the cli.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If a new tool or package is included, I have updated poetry.lock, and [cited it properly](../CITATIONS.md)
- [x] I have checked my code and documentation and corrected any misspellings
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
