### PR TITLE
Exe 2084 bug in local g

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [x.x.x] - ???
+
+### Fixed
+
+ - In some cases `local_g` would return scrambled results due to inconsistent node ordering, this
+   has now been fixed.
+
 ## [0.19.0] - 2024-12-10
 
 ### Changed

--- a/src/pixelator/graph/backends/implementations/_networkx.py
+++ b/src/pixelator/graph/backends/implementations/_networkx.py
@@ -269,7 +269,11 @@ class NetworkXGraphBackend(GraphBackend):
     def get_adjacency_sparse(
         self, node_ordering: Iterable[Any] | None = None
     ) -> csr_matrix:
-        """Get the sparse adjacency matrix."""
+        """Get the sparse adjacency matrix.
+
+        :param node_ordering: Control the node ordering in the adjacency matrix
+        :return: a sparse adjacency matrix
+        """
         return nx.to_scipy_sparse_array(self._raw, nodelist=node_ordering)
 
     def connected_components(self) -> NetworkxBasedVertexClustering:

--- a/src/pixelator/graph/backends/implementations/_networkx.py
+++ b/src/pixelator/graph/backends/implementations/_networkx.py
@@ -266,9 +266,11 @@ class NetworkXGraphBackend(GraphBackend):
         """Get the total number of edges in the Graph instance."""
         return self._raw.number_of_edges()
 
-    def get_adjacency_sparse(self) -> csr_matrix:
+    def get_adjacency_sparse(
+        self, node_ordering: Iterable[Any] | None = None
+    ) -> csr_matrix:
         """Get the sparse adjacency matrix."""
-        return nx.to_scipy_sparse_array(self._raw)
+        return nx.to_scipy_sparse_array(self._raw, nodelist=node_ordering)
 
     def connected_components(self) -> NetworkxBasedVertexClustering:
         """Get the connected components in the Graph instance."""

--- a/src/pixelator/graph/backends/protocol.py
+++ b/src/pixelator/graph/backends/protocol.py
@@ -111,7 +111,9 @@ class GraphBackend(Protocol):
         """Get the total number of edges in the Graph instance."""
         ...
 
-    def get_adjacency_sparse(self) -> csr_matrix:
+    def get_adjacency_sparse(
+        self, node_ordering: Iterable[Any] | None = None
+    ) -> csr_matrix:
         """Get the sparse adjacency matrix."""
         ...
 

--- a/src/pixelator/graph/backends/protocol.py
+++ b/src/pixelator/graph/backends/protocol.py
@@ -114,7 +114,11 @@ class GraphBackend(Protocol):
     def get_adjacency_sparse(
         self, node_ordering: Iterable[Any] | None = None
     ) -> csr_matrix:
-        """Get the sparse adjacency matrix."""
+        """Get the sparse adjacency matrix.
+
+        :param node_ordering: Control the node ordering in the adjacency matrix
+        :return: a sparse adjacency matrix
+        """
         ...
 
     def connected_components(self) -> VertexClustering:

--- a/src/pixelator/graph/graph.py
+++ b/src/pixelator/graph/graph.py
@@ -137,7 +137,11 @@ class Graph:
     def get_adjacency_sparse(
         self, node_ordering: Iterable[Any] | None = None
     ) -> csr_matrix:
-        """Get the sparse adjacency matrix."""
+        """Get the sparse adjacency matrix.
+
+        :param node_ordering: Control the node ordering in the adjacency matrix
+        :return: a sparse adjacency matrix
+        """
         return self._backend.get_adjacency_sparse(node_ordering=node_ordering)
 
     def connected_components(self) -> VertexClustering:

--- a/src/pixelator/graph/graph.py
+++ b/src/pixelator/graph/graph.py
@@ -134,9 +134,11 @@ class Graph:
         """Get the total number of edges in the Graph instance."""
         return self._backend.ecount()
 
-    def get_adjacency_sparse(self) -> csr_matrix:
+    def get_adjacency_sparse(
+        self, node_ordering: Iterable[Any] | None = None
+    ) -> csr_matrix:
         """Get the sparse adjacency matrix."""
-        return self._backend.get_adjacency_sparse()
+        return self._backend.get_adjacency_sparse(node_ordering=node_ordering)
 
     def connected_components(self) -> VertexClustering:
         """Get the connected components in the Graph instance."""
@@ -317,9 +319,11 @@ class Graph:
         expression of the node itself. Default is 'gi'.
         :return: A DataFrame of local G-scores for each node and marker.
         """
+        counts = self.node_marker_counts
+        A = self.get_adjacency_sparse(node_ordering=counts.index)
         return local_g(
-            A=self.get_adjacency_sparse(),
-            counts=self.node_marker_counts,
+            A=A,
+            counts=counts,
             k=k,
             use_weights=use_weights,
             normalize_counts=normalize_counts,

--- a/src/pixelator/graph/node_metrics.py
+++ b/src/pixelator/graph/node_metrics.py
@@ -90,6 +90,10 @@ def local_g(
     as it enhances spatial trends across neighborhoods in the graph, even if the marker counts within
     individual nodes are sparse.
 
+    Note that it is important that the node ordering in the sparse adjacency matrix, and
+    the counts matrix line up. If calling this method directly the caller is responsible for
+    ensuring that this contract is fulfilled.
+
     .. [1] Bivand, R.S., Wong, D.W.S. Comparing implementations of global and
     local indicators of spatial association. TEST 27, 716–748 (2018).
     https://doi.org/10.1007/s11749-018-0599-x


### PR DESCRIPTION
## Description

In some scenarios local g will return scrambled results due to inconsistent node ordering. This fixes that.

Fixes: exe-2084

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit tests, and by manual tests on failing components.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and documentation and corrected any misspellings
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
