### PR TITLE
shorten

### DIFF
--- a/src/pixelator/pna/graph/connected_components.py
+++ b/src/pixelator/pna/graph/connected_components.py
@@ -803,8 +803,13 @@ def _filter_connected_components_by_size(
         .select(pl.col("component"), n_umi=pl.col("n_umi1") + pl.col("n_umi2"))
         .collect()
     )
+    pre_filtering_component_sizes = (
+        component_sizes.group_by("n_umi").len().sort("n_umi")
+    )
     component_stats.pre_filtering_component_sizes = dict(
-        zip(component_sizes["component"], component_sizes["n_umi"])
+        zip(
+            pre_filtering_component_sizes["n_umi"], pre_filtering_component_sizes["len"]
+        )
     )
     if isinstance(component_size_threshold, bool):
         if component_size_threshold:


### PR DESCRIPTION
The pre_filtering_component_sizes is reverted to the old component_id component_size format that is way too long. In this PR we are changing it to the component_size number_of_instances instead that is more compact.

Fixes: PNA-689

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce it when relevant.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated poetry.lock, and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
