### PR TITLE
Read function accepts a list of strings

### DIFF
--- a/src/pixelator/pna/cli/analysis.py
+++ b/src/pixelator/pna/cli/analysis.py
@@ -145,7 +145,7 @@ def analysis(
     logging_setup = LoggingSetup.from_logger(ctx.obj.get("LOGGER"))
     manager = AnalysisManager(analysis_to_run, logging_setup=logging_setup)
     output_pxl_file_target = PxlFile.copy_pxl_file(pxl_file, output_file)
-    pxl_dataset = read(pxl_file)
+    pxl_dataset = read(pxl_file.path)
     pxl_dataset_with_analysis = manager.execute(pxl_dataset, output_pxl_file_target)
 
     write_parameters_file(

--- a/src/pixelator/pna/cli/layout.py
+++ b/src/pixelator/pna/cli/layout.py
@@ -100,7 +100,7 @@ def layout(
     )
 
     pxl_file = PxlFile(Path(pxl_file))
-    pxl_dataset = read(pxl_file)
+    pxl_dataset = read(pxl_file.path)
 
     analysis_to_run = [
         CreateLayout(

--- a/src/pixelator/pna/pixeldataset/__init__.py
+++ b/src/pixelator/pna/pixeldataset/__init__.py
@@ -30,14 +30,16 @@ from pixelator.pna.pixeldataset.io import (
 from pixelator.pna.utils import normalize_input_to_list, normalize_input_to_set
 
 
-def read(paths: Path | list[Path]) -> PNAPixelDataset:
+def read(paths: Path | list[Path] | str | list[str]) -> PNAPixelDataset:
     """Read a PNAPixelDataset from one or more provided .pxl file(s).
 
     :param path: path to the file to read
     :return: an instance of `PNAPixelDataset`
     """
-    paths = paths if isinstance(paths, list) else [paths]
-    return PNAPixelDataset.from_pxl_files(paths)
+    if not isinstance(paths, list):
+        paths = [paths]  # type: ignore
+    normalized_paths = [Path(p) for p in paths]  # type: ignore
+    return PNAPixelDataset.from_pxl_files(normalized_paths)
 
 
 @dataclass(slots=True, frozen=True, repr=True)

--- a/tests/pna/pixeldataset/test_pna_pixeldataset.py
+++ b/tests/pna/pixeldataset/test_pna_pixeldataset.py
@@ -1,6 +1,7 @@
 """Copyright © 2025 Pixelgen Technologies AB."""
 
 from io import StringIO
+from pathlib import Path
 
 import pandas as pd
 import polars as pl
@@ -11,8 +12,27 @@ from polars.testing import assert_frame_equal
 from pixelator.pna.pixeldataset import (
     PixelDatasetConfig,
     PNAPixelDataset,
+    read,
 )
 from pixelator.pna.pixeldataset.io import PixelDataViewer
+
+
+class TestReadPixelDataset:
+    def test_read_pxl_file_single_file(self, pxl_file: Path):
+        dataset = read(pxl_file)
+        assert isinstance(dataset, PNAPixelDataset)
+
+    def test_read_pxl_file_multiple_files(self, pxl_file: Path):
+        dataset = read([pxl_file])
+        assert isinstance(dataset, PNAPixelDataset)
+
+    def test_read_pixel_file_single_file_str(self, pxl_file: Path):
+        dataset = read(str(pxl_file))
+        assert isinstance(dataset, PNAPixelDataset)
+
+    def test_read_pixel_file_multiple_files_str(self, pxl_file: Path):
+        dataset = read([str(pxl_file)])
+        assert isinstance(dataset, PNAPixelDataset)
 
 
 class TestPNAPixelDataset:


### PR DESCRIPTION
## Description

Make it a bit easier to work with the `read` function by making sure that it will also accept raw strings as input. They will then be internally converted to `Path` and passed along. This removes the need for users to always import `pathlib` which I think might be a bit more accessible to folks who are new to bioinformatics/python.

Fixes: -

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Added unit tests and manually tried it out.

## PR checklist:

- [ ] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated poetry.lock, and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
