### PR TITLE
Feature/pna 822 add marker frequency info to proximity scores table

### DIFF
--- a/src/pixelator/pna/pixeldataset/__init__.py
+++ b/src/pixelator/pna/pixeldataset/__init__.py
@@ -199,6 +199,11 @@ class Proximity:
         self, adata: AnnData, proximity_df: pl.DataFrame
     ):
         marker_counts = pl.DataFrame(adata.to_df().reset_index())
+        component_node_counts = (
+            marker_counts.drop("component")
+            .transpose(column_names=marker_counts["component"])
+            .sum()
+        )
         marker_counts = marker_counts.unpivot(
             index="component", variable_name="marker", value_name="marker_1_count"
         )

--- a/tests/pna/pixeldataset/snapshots/test_pna_pixeldataset/test_proximity/proximity.csv
+++ b/tests/pna/pixeldataset/snapshots/test_pna_pixeldataset/test_proximity/proximity.csv
@@ -1,4 +1,4 @@
-component,marker_1,marker_2,join_count,join_count_expected_mean,join_count_expected_sd,join_count_z,join_count_pvalue,sample,marker_1_count,marker_2_count,min_count,log2_ratio
-fc07dea9b679aca7,MarkerA,MarkerB,3,1.65,0.794,1.35,0.088,test_sample,3,7,3,0.8624964762500652
-fc07dea9b679aca7,MarkerA,MarkerA,87,86.5,9.96,0.062,0.575,test_sample,3,3,3,0.008315268212003745
-fc07dea9b679aca7,MarkerB,MarkerC,30,27.3,3.1,0.001,0.999,test_sample,7,4,4,0.13606154957602826
+component,marker_1,marker_2,join_count,join_count_expected_mean,join_count_expected_sd,join_count_z,join_count_pvalue,sample,marker_1_count,marker_1_freq,marker_2_count,marker_2_freq,min_count,log2_ratio
+fc07dea9b679aca7,MarkerA,MarkerB,3,1.65,0.794,1.35,0.088,test_sample,3,0.21428571428571427,7,0.5,3,0.8624964762500652
+fc07dea9b679aca7,MarkerA,MarkerA,87,86.5,9.96,0.062,0.575,test_sample,3,0.21428571428571427,3,0.21428571428571427,3,0.008315268212003745
+fc07dea9b679aca7,MarkerB,MarkerC,30,27.3,3.1,0.001,0.999,test_sample,7,0.5,4,0.2857142857142857,4,0.13606154957602826


### PR DESCRIPTION
Adding two columns marker_1_freq, marker_2_freq to the proximity dataframe when reading the data. Together with the already existing raw counts (i.e. marker_1_count, marker_2_count) they provide information on marker abundances that can be useful when filtering proximity data.

Fixes: PNA-822

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checked that the proximity output from the test is identical besides the added two columns.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have checked my code and documentation and corrected any misspellings
