### PR TITLE
Validate there are no underscores in panel file marker ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     molecules in the cell.
 -   Two columns, `marker_1_freq` and `marker_2_freq`, have been added to the proximity
     data to indicate the respective marker frequencies.
-
+-   Panel files no longer allow `_` as a character in the marker ids, since this causes
+    problems with Seurat in R in downstream analysis.
 
 ## [0.20.1] - 2025-04-24
 

--- a/src/pixelator/pna/config/panel.py
+++ b/src/pixelator/pna/config/panel.py
@@ -123,6 +123,15 @@ class PNAAntibodyPanel(AntibodyPanel):
         """
         errors = super().validate_antibody_panel(panel_df)
 
+        if any(panel_df["marker_id"].str.contains("_")):
+            # Markers should not contain underscores since this messes
+            # things up with Seurat on the R side
+            errors.append(
+                "The marker_id column should not contain underscores. "
+                "Please use dashes instead. Offending values: "
+                f"{panel_df['marker_id'][panel_df['marker_id'].str.contains('_')]}"
+            )
+
         return errors
 
 

--- a/tests/pna/config/test_panel.py
+++ b/tests/pna/config/test_panel.py
@@ -1,0 +1,38 @@
+"""Copyright © 2025 Pixelgen Technologies AB."""
+
+import pandas as pd
+import pytest
+
+from pixelator.pna.config.panel import PNAAntibodyPanel
+
+
+def test_panel_validation():
+    # all is ok
+    data = {
+        "marker_id": ["marker1", "marker2", "marker3"],
+        "control": [False, True, False],
+        "nuclear": [True, False, True],
+        "sequence_1": ["ATCG", "GCTA", "ATCC"],
+        "sequence_2": ["ATCG", "GCTA", "ATCC"],
+        "conj_id": ["conj1", "conj2", "conj3"],
+    }
+    df = pd.DataFrame(data)
+    PNAAntibodyPanel(df=df, metadata=None)
+
+
+def test_panel_validation_fails_on_underscores_in_marker_names():
+    data = {
+        "marker_id": ["marker_1", "marker2", "marker3"],
+        "control": [False, True, False],
+        "nuclear": [True, False, True],
+        "sequence_1": ["ATCG", "GCTA", "ATCC"],
+        "sequence_2": ["ATCG", "GCTA", "ATCC"],
+        "conj_id": ["conj1", "conj2", "conj3"],
+    }
+    df = pd.DataFrame(data)
+
+    with pytest.raises(
+        AssertionError,
+        match=r".*The marker_id column should not contain underscores.*Offending values:.*",
+    ):
+        PNAAntibodyPanel(df=df, metadata=None)


### PR DESCRIPTION
## Description

Check that there are no `_` in the panel marker ids, since these do not play well with Seurat downstream.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Added unit tests.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated poetry.lock, and [cited it properly](../CITATIONS.md)
- [x] I have checked my code and documentation and corrected any misspellings
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
