### PR TITLE
Passing None through _memory_validator in demux

### DIFF
--- a/src/pixelator/common/utils/units.py
+++ b/src/pixelator/common/utils/units.py
@@ -8,12 +8,15 @@ import re
 units = {"K": 10**3, "M": 10**6, "G": 10**9}
 
 
-def parse_size(s: str) -> int | float:
+def parse_size(s: str | None) -> int | float | None:
     """Parse a string as a number with optional unit suffix [K, M, G].
 
     :param s: The string to parse
     :return: The parsed number as a float
     """
+    if s is None:
+        return None
+
     match = re.match(r"(?P<value>\d+(?:.\d+)?)(?P<unit>[KMGkmg])?$", s)
     if not match:
         raise ValueError(f"Invalid number: {s}")

--- a/src/pixelator/common/utils/units.py
+++ b/src/pixelator/common/utils/units.py
@@ -8,15 +8,12 @@ import re
 units = {"K": 10**3, "M": 10**6, "G": 10**9}
 
 
-def parse_size(s: str | None) -> int | float | None:
+def parse_size(s: str) -> int | float:
     """Parse a string as a number with optional unit suffix [K, M, G].
 
     :param s: The string to parse
     :return: The parsed number as a float
     """
-    if s is None:
-        return None
-
     match = re.match(r"(?P<value>\d+(?:.\d+)?)(?P<unit>[KMGkmg])?$", s)
     if not match:
         raise ValueError(f"Invalid number: {s}")

--- a/src/pixelator/pna/cli/common.py
+++ b/src/pixelator/pna/cli/common.py
@@ -62,7 +62,7 @@ def memory_option(func):
 
     @click.option(
         "--memory",
-        default=None,
+        default="30G",
         required=False,
         callback=_memory_validator,
         show_default=True,

--- a/src/pixelator/pna/cli/common.py
+++ b/src/pixelator/pna/cli/common.py
@@ -49,6 +49,8 @@ def threads_option(func):
 
 
 def _memory_validator(ctx, param, value):
+    if value is None:
+        return None
     try:
         return int(parse_size(value))
     except ValueError as exc:

--- a/src/pixelator/pna/cli/common.py
+++ b/src/pixelator/pna/cli/common.py
@@ -62,7 +62,7 @@ def memory_option(func):
 
     @click.option(
         "--memory",
-        default="30G",
+        default=None,
         required=False,
         callback=_memory_validator,
         show_default=True,

--- a/tests/pna/demux/test_demux_cli.py
+++ b/tests/pna/demux/test_demux_cli.py
@@ -25,3 +25,22 @@ def test_demux_invalid_chunk_size(tmp_path, testdata_amplicon_fastq):
 
     assert cmd.exit_code == 2
     assert "Invalid value for '--output-chunk-reads'" in cmd.output
+
+
+def test_demux_valid(tmp_path, testdata_amplicon_fastq):
+    runner = CliRunner()
+
+    args = [
+        "single-cell-pna",
+        "demux",
+        str(testdata_amplicon_fastq),
+        "--output",
+        str(tmp_path),
+        "--design",
+        "pna-2",
+        "--panel",
+        "proxiome-immuno-155",
+    ]
+    cmd = runner.invoke(cli.main_cli, args)
+
+    assert cmd.exit_code == 0


### PR DESCRIPTION
We currently get an error when None is passed to _memory_validator. It is however expected to output None in that case.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit tests.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
