### PR TITLE
Add missing graph sample report entries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     of a cell graph which suggests that they are caused by bleed-over from other cells.
 -   Added the proxiome-immuno-156-FMC63 panel, which includes all the markers from the
     proxiome-immuno-155 panel, but with the addition of the FMC63 marker.
+-   Added molecules_post_umi_collision_removal and reads_post_umi_collision_removal
+    to the graph report file.
 
 ### Changed
 

--- a/src/pixelator/pna/graph/report.py
+++ b/src/pixelator/pna/graph/report.py
@@ -81,6 +81,14 @@ class GraphSampleReport(SampleReport):
         ..., description="The number of reads in the input edgelist."
     )
 
+    molecules_post_umi_collision_removal: int = pydantic.Field(
+        ..., description="The number of molecules after removing UMI collisions."
+    )
+
+    reads_post_umi_collision_removal: int = pydantic.Field(
+        ..., description="The number of reads after removing UMI collisions."
+    )
+
     molecules_post_read_count_filtering: int = pydantic.Field(
         ..., description="The number of molecules after read count filtering."
     )

--- a/tests/pna/graph/snapshots/test_report/test_graph_sample_report_to_json/graph_sample_report.json
+++ b/tests/pna/graph/snapshots/test_report/test_graph_sample_report_to_json/graph_sample_report.json
@@ -4,6 +4,8 @@
     "report_type": "graph",
     "molecules_input": 1000,
     "reads_input": 2000,
+    "molecules_post_umi_collision_removal": 950,
+    "reads_post_umi_collision_removal": 1950,
     "molecules_post_read_count_filtering": 1000,
     "reads_post_read_count_filtering": 2000,
     "molecules_output": 900,

--- a/tests/pna/graph/test_report.py
+++ b/tests/pna/graph/test_report.py
@@ -65,6 +65,8 @@ def test_graph_sample_report():
         product_id="single-cell-pna",
         molecules_input=1000,
         reads_input=2000,
+        molecules_post_umi_collision_removal=950,
+        reads_post_umi_collision_removal=1950,
         molecules_output=900,
         reads_output=1800,
         reads_post_read_count_filtering=1900,
@@ -134,6 +136,8 @@ def test_graph_sample_report():
     assert report.reads_post_read_count_filtering == 1900
     assert report.reads_input == 2000
     assert report.reads_output == 1800
+    assert report.reads_post_umi_collision_removal == 1950
+    assert report.molecules_post_umi_collision_removal == 950
 
 
 def test_graph_sample_report_to_json(snapshot):
@@ -142,6 +146,8 @@ def test_graph_sample_report_to_json(snapshot):
         product_id="single-cell-pna",
         molecules_input=1000,
         molecules_output=900,
+        molecules_post_umi_collision_removal=950,
+        reads_post_umi_collision_removal=1950,
         reads_input=2000,
         reads_output=1800,
         molecules_post_read_count_filtering=1000,


### PR DESCRIPTION
molecules_post_umi_collision_removal and reads_post_umi_collision_removal were added to GraphStatistics but not GraphSampleReport. This PR is to add them there as well.

Fixes: PNA-915

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit tests updated.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated poetry.lock, and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
