### PR TITLE
Feature/pna 944 support single end reads

### DIFF
--- a/src/pixelator/pna/amplicon/build_amplicon.py
+++ b/src/pixelator/pna/amplicon/build_amplicon.py
@@ -527,8 +527,6 @@ class AmpliconBuilder(CombiningModifier, HasFilterStatistics, HasCustomStatistic
         :param region1_slice: the slice from the forward read
         :param region2_slice: the slice from the reverse read
         """
-        assert read1.qualities is not None
-        assert read2.qualities is not None
 
         if not region1_slice and not region2_slice:
             return None, None
@@ -626,11 +624,6 @@ class AmpliconBuilder(CombiningModifier, HasFilterStatistics, HasCustomStatistic
         # Since we only use this for Q30 statistics, this is not a big issue
         # For fully accurate quality scores we would need to have the full alignment
         # instead of just the matched region and this has a very high overhead.
-        if read1 is not None:
-            assert read1.qualities is not None
-        if read2 is not None:
-            assert read2.qualities is not None
-
         if not region1_slice and not region2_slice:
             return template_qual
 

--- a/src/pixelator/pna/amplicon/build_amplicon.py
+++ b/src/pixelator/pna/amplicon/build_amplicon.py
@@ -560,10 +560,10 @@ class AmpliconBuilder(CombiningModifier, HasFilterStatistics, HasCustomStatistic
                 read2, region2_slice, is_reversed=True, as_bytearray=True
             )
 
-            assert len(s1) == len(s2)
-            assert len(q1) == len(q2)
+            assert len(s1) == len(s2)  # type: ignore
+            assert len(q1) == len(q2)  # type: ignore
 
-            s_np = np.select([q1 > q2, q1 <= q2], [s1, s2])
+            s_np = np.select([q1 > q2, q1 <= q2], [s1, s2])  # type: ignore
             q_np = np.max([q1, q2], axis=0)
 
             return s_np.tobytes(), q_np.tobytes()
@@ -944,7 +944,9 @@ class SingleEndAmpliconBuilder(AmpliconBuilder):
             region2_slice=regions.lbs2 if not is_read1 else None,  # type: ignore
         )
         error = self._check_regions(
-            pid1_umi1_region_seq, uei_region_seq, pid2_umi2_region_seq
+            pid1_umi1_region_seq,  # type: ignore
+            uei_region_seq,  # type: ignore
+            pid2_umi2_region_seq,  # type: ignore
         )
 
         return Amplicon(

--- a/src/pixelator/pna/amplicon/build_amplicon.py
+++ b/src/pixelator/pna/amplicon/build_amplicon.py
@@ -527,7 +527,6 @@ class AmpliconBuilder(CombiningModifier, HasFilterStatistics, HasCustomStatistic
         :param region1_slice: the slice from the forward read
         :param region2_slice: the slice from the reverse read
         """
-
         if not region1_slice and not region2_slice:
             return None, None
 

--- a/src/pixelator/pna/amplicon/build_amplicon.py
+++ b/src/pixelator/pna/amplicon/build_amplicon.py
@@ -564,7 +564,7 @@ class AmpliconBuilder(CombiningModifier, HasFilterStatistics, HasCustomStatistic
             assert len(q1) == len(q2)  # type: ignore
 
             s_np = np.select([q1 > q2, q1 <= q2], [s1, s2])  # type: ignore
-            q_np = np.max([q1, q2], axis=0)
+            q_np = np.max([q1, q2], axis=0)  # type: ignore
 
             return s_np.tobytes(), q_np.tobytes()
 

--- a/src/pixelator/pna/amplicon/build_amplicon.py
+++ b/src/pixelator/pna/amplicon/build_amplicon.py
@@ -570,7 +570,11 @@ class AmpliconBuilder(CombiningModifier, HasFilterStatistics, HasCustomStatistic
             return s_np.tobytes(), q_np.tobytes()
 
     def _consensus_qual_lbs1(
-        self, read1: SequenceRecord, read2: SequenceRecord, region1_slice, region2_slice
+        self,
+        read1: SequenceRecord | None,
+        read2: SequenceRecord | None,
+        region1_slice,
+        region2_slice,
     ):
         """Combine the quality scores of the LBS-1 region from forward and reverse reads.
 
@@ -584,7 +588,11 @@ class AmpliconBuilder(CombiningModifier, HasFilterStatistics, HasCustomStatistic
         )
 
     def _consensus_qual_lbs2(
-        self, read1: SequenceRecord, read2: SequenceRecord, region1_slice, region2_slice
+        self,
+        read1: SequenceRecord | None,
+        read2: SequenceRecord | None,
+        region1_slice,
+        region2_slice,
     ):
         """Combine the quality scores of the LBS-2 region from forward and reverse reads.
 
@@ -599,8 +607,8 @@ class AmpliconBuilder(CombiningModifier, HasFilterStatistics, HasCustomStatistic
 
     @staticmethod
     def _consensus_qual_lbs(
-        read1: SequenceRecord,
-        read2: SequenceRecord,
+        read1: SequenceRecord | None,
+        read2: SequenceRecord | None,
         region1_slice,
         region2_slice,
         template_qual,

--- a/src/pixelator/pna/amplicon/build_amplicon.py
+++ b/src/pixelator/pna/amplicon/build_amplicon.py
@@ -533,13 +533,13 @@ class AmpliconBuilder(CombiningModifier, HasFilterStatistics, HasCustomStatistic
 
         if not region1_slice or not region2_slice:
             if region1_slice:
-                s, q = PairedEndAmpliconBuilder._get_region_sequence(
+                s, q = AmpliconBuilder._get_region_sequence(
                     read1,
                     region1_slice,
                     is_reversed=False,
                 )
             else:
-                s, q = PairedEndAmpliconBuilder._get_region_sequence(
+                s, q = AmpliconBuilder._get_region_sequence(
                     read2,
                     region2_slice,
                     is_reversed=True,
@@ -551,10 +551,10 @@ class AmpliconBuilder(CombiningModifier, HasFilterStatistics, HasCustomStatistic
             # TODO: Consensus of non LBS regions with partial lengths?
             #   We can inject both r1 and r2 into an all N template with zero qualities
 
-            s1, q1 = PairedEndAmpliconBuilder._get_region_sequence(
+            s1, q1 = AmpliconBuilder._get_region_sequence(
                 read1, region1_slice, is_reversed=False, as_bytearray=True
             )
-            s2, q2 = PairedEndAmpliconBuilder._get_region_sequence(
+            s2, q2 = AmpliconBuilder._get_region_sequence(
                 read2, region2_slice, is_reversed=True, as_bytearray=True
             )
 

--- a/src/pixelator/pna/amplicon/build_amplicon.py
+++ b/src/pixelator/pna/amplicon/build_amplicon.py
@@ -498,7 +498,6 @@ class AmpliconBuilder(CombiningModifier, HasFilterStatistics, HasCustomStatistic
         :param return_ascii: whether to return the sequence as ASCII bytes
         :return: the sequence  and quality of the region as a tuple, or None if the slice is empty
         """
-        assert read.qualities is not None
         if not region_slice:
             return None, None
 

--- a/src/pixelator/pna/amplicon/build_amplicon.py
+++ b/src/pixelator/pna/amplicon/build_amplicon.py
@@ -490,7 +490,9 @@ class AmpliconBuilder(CombiningModifier, HasFilterStatistics, HasCustomStatistic
         return region_slices
 
     @staticmethod
-    def _get_region_sequence(read, region_slice, is_reversed=False, as_bytearray=False) -> tuple[bytes | None, bytes | None]:
+    def _get_region_sequence(
+        read, region_slice, is_reversed=False, as_bytearray=False
+    ) -> tuple[bytes | None, bytes | None]:
         """Get the sequence of a region from a read.
 
         :param read: the read to extract the region from

--- a/src/pixelator/pna/amplicon/build_amplicon.py
+++ b/src/pixelator/pna/amplicon/build_amplicon.py
@@ -760,7 +760,7 @@ class AmpliconBuilder(CombiningModifier, HasFilterStatistics, HasCustomStatistic
             lbs2_region_qual = self._consensus_qual_lbs2(
                 read1,
                 read2,
-                region1_slice=regions.lbs2 if is_read1 else None,
+                region1_slice=regions.lbs2 if is_read1 else None,  # type: ignore
                 region2_slice=regions.lbs2 if not is_read1 else None,  # type: ignore
             )
             error = self._check_regions(
@@ -790,13 +790,13 @@ class AmpliconBuilder(CombiningModifier, HasFilterStatistics, HasCustomStatistic
                 lbs1_region_qual = self._consensus_qual_lbs1(
                     read1,
                     read2,
-                    r1_regions.lbs1,
+                    r1_regions.lbs1,  # type: ignore
                     r2_regions.lbs1,  # type: ignore
                 )
                 lbs2_region_qual = self._consensus_qual_lbs2(
                     read1,
                     read2,
-                    r1_regions.lbs2,
+                    r1_regions.lbs2,  # type: ignore
                     r2_regions.lbs2,  # type: ignore
                 )
 

--- a/src/pixelator/pna/amplicon/build_amplicon.py
+++ b/src/pixelator/pna/amplicon/build_amplicon.py
@@ -490,7 +490,7 @@ class AmpliconBuilder(CombiningModifier, HasFilterStatistics, HasCustomStatistic
         return region_slices
 
     @staticmethod
-    def _get_region_sequence(read, region_slice, is_reversed=False, as_bytearray=False):
+    def _get_region_sequence(read, region_slice, is_reversed=False, as_bytearray=False) -> tuple[bytes | None, bytes | None]:
         """Get the sequence of a region from a read.
 
         :param read: the read to extract the region from

--- a/src/pixelator/pna/amplicon/build_amplicon.py
+++ b/src/pixelator/pna/amplicon/build_amplicon.py
@@ -639,11 +639,11 @@ class AmpliconBuilder(CombiningModifier, HasFilterStatistics, HasCustomStatistic
             tq = bytearray(template_qual)
 
             if region1_slice:
-                q = read1.qualities[region1_slice].encode("ascii")[: len(tq)]
+                q = read1.qualities[region1_slice].encode("ascii")[: len(tq)]  # type: ignore
                 tq[: len(q)] = q
 
             else:
-                q = (read2.qualities[region2_slice])[::-1].encode("ascii")[: len(tq)]
+                q = (read2.qualities[region2_slice])[::-1].encode("ascii")[: len(tq)]  # type: ignore
                 tq[-len(q) :] = q
 
             return bytes(tq)
@@ -652,10 +652,10 @@ class AmpliconBuilder(CombiningModifier, HasFilterStatistics, HasCustomStatistic
             tq1 = bytearray(template_qual)
             tq2 = bytearray(template_qual)
 
-            q1 = read1.qualities[region1_slice].encode("ascii")[: len(template_qual)]
+            q1 = read1.qualities[region1_slice].encode("ascii")[: len(template_qual)]  # type: ignore
             tq1[: len(q1)] = q1
 
-            q2 = (read2.qualities[region2_slice])[::-1].encode("ascii")[
+            q2 = (read2.qualities[region2_slice])[::-1].encode("ascii")[  # type: ignore
                 : len(template_qual)
             ]
             tq2[-len(q2) :] = q2
@@ -738,26 +738,30 @@ class AmpliconBuilder(CombiningModifier, HasFilterStatistics, HasCustomStatistic
             is_reversed = not is_read1
             pid1_umi1_region_seq, pid1_umi1_region_qual = self._get_region_sequence(
                 read,
-                regions.pid1_umi1,
-                is_reversed=is_reversed,  #
+                regions.pid1_umi1,  # type: ignore
+                is_reversed=is_reversed,
             )
             pid2_umi2_region_seq, pid2_umi2_region_qual = self._get_region_sequence(
-                read, regions.pid2_umi2, is_reversed=is_reversed
+                read,
+                regions.pid2_umi2,  # type: ignore
+                is_reversed=is_reversed,
             )
             uei_region_seq, uei_region_qual = self._get_region_sequence(
-                read, regions.uei, is_reversed=is_reversed
+                read,
+                regions.uei,  # type: ignore
+                is_reversed=is_reversed,
             )
             lbs1_region_qual = self._consensus_qual_lbs1(
                 read1,
                 read2,
-                region1_slice=regions.lbs1 if is_read1 else None,
-                region2_slice=regions.lbs1 if not is_read1 else None,
+                region1_slice=regions.lbs1 if is_read1 else None,  # type: ignore
+                region2_slice=regions.lbs1 if not is_read1 else None,  # type: ignore
             )
             lbs2_region_qual = self._consensus_qual_lbs2(
                 read1,
                 read2,
                 region1_slice=regions.lbs2 if is_read1 else None,
-                region2_slice=regions.lbs2 if not is_read1 else None,
+                region2_slice=regions.lbs2 if not is_read1 else None,  # type: ignore
             )
             error = self._check_regions(
                 pid1_umi1_region_seq, uei_region_seq, pid2_umi2_region_seq
@@ -766,19 +770,34 @@ class AmpliconBuilder(CombiningModifier, HasFilterStatistics, HasCustomStatistic
             try:
                 # Combine the info from forward and reverse reads, or use only the available read
                 pid1_umi1_region_seq, pid1_umi1_region_qual = self._consensus_seq(
-                    read1, read2, r1_regions.pid1_umi1, r2_regions.pid1_umi1
+                    read1,
+                    read2,
+                    r1_regions.pid1_umi1,  # type: ignore
+                    r2_regions.pid1_umi1,  # type: ignore
                 )
                 pid2_umi2_region_seq, pid2_umi2_region_qual = self._consensus_seq(
-                    read1, read2, r1_regions.pid2_umi2, r2_regions.pid2_umi2
+                    read1,
+                    read2,
+                    r1_regions.pid2_umi2,  # type: ignore
+                    r2_regions.pid2_umi2,  # type: ignore
                 )
                 uei_region_seq, uei_region_qual = self._consensus_seq(
-                    read1, read2, r1_regions.uei, r2_regions.uei
+                    read1,
+                    read2,
+                    r1_regions.uei,  # type: ignore
+                    r2_regions.uei,  # type: ignore
                 )
                 lbs1_region_qual = self._consensus_qual_lbs1(
-                    read1, read2, r1_regions.lbs1, r2_regions.lbs1
+                    read1,
+                    read2,
+                    r1_regions.lbs1,
+                    r2_regions.lbs1,  # type: ignore
                 )
                 lbs2_region_qual = self._consensus_qual_lbs2(
-                    read1, read2, r1_regions.lbs2, r2_regions.lbs2
+                    read1,
+                    read2,
+                    r1_regions.lbs2,
+                    r2_regions.lbs2,  # type: ignore
                 )
 
                 # Check for errors and increment the statistics

--- a/src/pixelator/pna/amplicon/build_amplicon.py
+++ b/src/pixelator/pna/amplicon/build_amplicon.py
@@ -909,7 +909,7 @@ class SingleEndAmpliconBuilder(AmpliconBuilder):
         read = read1 if is_read1 else read2
 
         regions = (
-            self._scan_forward_read(read) if is_read1 else self._scan_reverse_read(read)
+            self._scan_forward_read(read) if is_read1 else self._scan_reverse_read(read)  # type: ignore
         )
 
         is_reversed = not is_read1

--- a/src/pixelator/pna/amplicon/build_amplicon.py
+++ b/src/pixelator/pna/amplicon/build_amplicon.py
@@ -708,10 +708,10 @@ class AmpliconBuilder(CombiningModifier, HasFilterStatistics, HasCustomStatistic
 
     def __call__(
         self,
-        read1: Optional[SequenceRecord],
-        read2: Optional[SequenceRecord],
-        info1: Optional[ModificationInfo],
-        info2: Optional[ModificationInfo],
+        read1: SequenceRecord | None,
+        read2: SequenceRecord | None,
+        info1: ModificationInfo | None,
+        info2: ModificationInfo | None,
     ) -> Optional[SequenceRecord]:
         """Build an amplicon from paired-end reads (read1, read2), or a single read if only one is present.
 

--- a/src/pixelator/pna/amplicon/build_amplicon.py
+++ b/src/pixelator/pna/amplicon/build_amplicon.py
@@ -708,10 +708,10 @@ class AmpliconBuilder(CombiningModifier, HasFilterStatistics, HasCustomStatistic
 
     def __call__(
         self,
-        read1: SequenceRecord | None,
-        read2: SequenceRecord | None,
-        info1: ModificationInfo | None,
-        info2: ModificationInfo | None,
+        read1: Optional[SequenceRecord],
+        read2: Optional[SequenceRecord],
+        info1: Optional[ModificationInfo],
+        info2: Optional[ModificationInfo],
     ) -> Optional[SequenceRecord]:
         """Build an amplicon from paired-end reads (read1, read2), or a single read if only one is present.
 
@@ -737,7 +737,9 @@ class AmpliconBuilder(CombiningModifier, HasFilterStatistics, HasCustomStatistic
             regions = r1_regions if is_read1 else r2_regions
             is_reversed = not is_read1
             pid1_umi1_region_seq, pid1_umi1_region_qual = self._get_region_sequence(
-                read, regions.pid1_umi1, is_reversed=is_reversed
+                read,
+                regions.pid1_umi1,
+                is_reversed=is_reversed,  #
             )
             pid2_umi2_region_seq, pid2_umi2_region_qual = self._get_region_sequence(
                 read, regions.pid2_umi2, is_reversed=is_reversed
@@ -798,7 +800,7 @@ class AmpliconBuilder(CombiningModifier, HasFilterStatistics, HasCustomStatistic
                 self._writer.write(read1, read2)
             return None
 
-        if read1 is not None and r1_regions.lbs1 is None:
+        if read1 is not None and r1_regions.lbs1 is None:  # type: ignore
             self._custom_stats.passed_missing_lbs1_anchor += 1
 
         # Combine the regions into a single amplicon sequence
@@ -819,7 +821,7 @@ class AmpliconBuilder(CombiningModifier, HasFilterStatistics, HasCustomStatistic
 
         # Create a new amplicon template to fill with the reads
         amplicon = SequenceRecord(
-            name=read1.name if read1 is not None else read2.name,
+            name=read1.name if read1 is not None else read2.name,  # type: ignore
             sequence=seq.decode("ascii"),
             qualities=qual.decode("ascii"),
         )

--- a/src/pixelator/pna/amplicon/build_amplicon.py
+++ b/src/pixelator/pna/amplicon/build_amplicon.py
@@ -496,7 +496,7 @@ class AmpliconBuilder(CombiningModifier, HasFilterStatistics, HasCustomStatistic
         :param region_slice: the slice for the region
         :param is_reversed: whether the region is reversed (e.g. LBS-2)
         :param return_ascii: whether to return the sequence as ASCII bytes
-        :return: the sequence of the region, or None if the slice is empty
+        :return: the sequence  and quality of the region as a tuple, or None if the slice is empty
         """
         assert read.qualities is not None
         if not region_slice:

--- a/src/pixelator/pna/amplicon/build_amplicon.py
+++ b/src/pixelator/pna/amplicon/build_amplicon.py
@@ -724,9 +724,10 @@ class AmpliconBuilder(CombiningModifier, HasFilterStatistics, HasCustomStatistic
         r1_regions = self._scan_forward_read(read1) if read1 is not None else None
         r2_regions = self._scan_reverse_read(read2) if read2 is not None else None
         if read1 is None or read2 is None:
-            read = read1 if read1 else read2
-            regions = r1_regions if read1 else r2_regions
-            is_reversed = read1 is None
+            is_read1 = read1 is not None
+            read = read1 if is_read1 else read2
+            regions = r1_regions if is_read1 else r2_regions
+            is_reversed = not is_read1
             pid1_umi1_region_seq, pid1_umi1_region_qual = self._get_region_sequence(
                 read, regions.pid1_umi1, is_reversed=is_reversed
             )
@@ -739,14 +740,14 @@ class AmpliconBuilder(CombiningModifier, HasFilterStatistics, HasCustomStatistic
             lbs1_region_qual = self._consensus_qual_lbs1(
                 read1,
                 read2,
-                region1_slice=regions.lbs1 if read1 else None,
-                region2_slice=regions.lbs1 if read2 else None,
+                region1_slice=regions.lbs1 if is_read1 else None,
+                region2_slice=regions.lbs1 if not is_read1 else None,
             )
             lbs2_region_qual = self._consensus_qual_lbs2(
                 read1,
                 read2,
-                region1_slice=regions.lbs2 if read1 else None,
-                region2_slice=regions.lbs2 if read2 else None,
+                region1_slice=regions.lbs2 if is_read1 else None,
+                region2_slice=regions.lbs2 if not is_read1 else None,
             )
             error = self._check_regions(
                 pid1_umi1_region_seq, uei_region_seq, pid2_umi2_region_seq

--- a/src/pixelator/pna/amplicon/process.py
+++ b/src/pixelator/pna/amplicon/process.py
@@ -102,14 +102,9 @@ def amplicon_fastq(
 
     # Construct an amplicon builder class that will be used to combine the reads using the assay design
 
-    builder = (
-        PairedEndAmpliconBuilder(
-            assay=assay, mismatches=mismatches, writer=amplicon_failed_writer
-        )
-        if is_paired_end
-        else SingleEndAmpliconBuilder(
-            assay=assay, mismatches=mismatches, writer=amplicon_failed_writer
-        )
+    builder_factory = PairedEndAmpliconBuilder if is_paired_end else SingleEndAmpliconBuilder
+    builder = builder_factory(
+        assay=assay, mismatches=mismatches, writer=amplicon_failed_writer
     )
 
     pre_steps: list[PairedEndStep | SingleEndStep] = []

--- a/src/pixelator/pna/amplicon/process.py
+++ b/src/pixelator/pna/amplicon/process.py
@@ -102,7 +102,9 @@ def amplicon_fastq(
 
     # Construct an amplicon builder class that will be used to combine the reads using the assay design
 
-    builder_factory = PairedEndAmpliconBuilder if is_paired_end else SingleEndAmpliconBuilder
+    builder_factory = (
+        PairedEndAmpliconBuilder if is_paired_end else SingleEndAmpliconBuilder
+    )
     builder = builder_factory(
         assay=assay, mismatches=mismatches, writer=amplicon_failed_writer
     )

--- a/src/pixelator/pna/amplicon/process.py
+++ b/src/pixelator/pna/amplicon/process.py
@@ -55,8 +55,8 @@ def amplicon_fastq(
     """
     threads = threads if threads > 0 else mp.cpu_count()
 
-    if len(inputs) != 2:
-        raise ValueError("Expected two input files, got %s" % len(inputs))
+    if len(inputs) not in [1, 2]:
+        raise ValueError("Expected one or two input files, got %s" % len(inputs))
 
     # Open file handles for input files
     input_files = InputPaths(*(str(i) for i in inputs))
@@ -85,9 +85,10 @@ def amplicon_fastq(
     failed_1 = Path(
         output.parent / f"{clean_suffixes(Path(inputs[0])).name}.failed.fq.zst"
     )
-    failed_2 = Path(
-        output.parent / f"{clean_suffixes(Path(inputs[1])).name}.failed.fq.zst"
-    )
+    if len(inputs) == 2:
+        failed_2 = Path(
+            output.parent / f"{clean_suffixes(Path(inputs[1])).name}.failed.fq.zst"
+        )
 
     amplicon_failed_writer = None
     if save_failed:

--- a/src/pixelator/pna/amplicon/report.py
+++ b/src/pixelator/pna/amplicon/report.py
@@ -4,7 +4,7 @@ Copyright © 2024 Pixelgen Technologies AB.
 """
 
 import typing
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import pydantic
 from cutadapt.report import Statistics
@@ -178,6 +178,7 @@ class AmpliconStatistics(Statistics):
     def __init__(self) -> None:
         """Initialize the AmpliconStatistics object."""
         super().__init__()
+        self.paired: bool | None = None
         self._custom_stats: dict[str, Any] = dict()
 
     def __iadd__(self, other: Any):
@@ -274,3 +275,21 @@ class AmpliconStatistics(Statistics):
                 self._custom_stats[name] += step.get_statistics()
             else:
                 self._custom_stats[name] = step.get_statistics()
+
+    def collect(
+        self,
+        n: int,
+        total_bp1: int,
+        total_bp2: Optional[int],
+        modifiers,
+        steps,
+        paired: Optional[bool] = None,
+    ):
+        """
+        n -- total number of reads
+        total_bp1 -- number of bases in first reads
+        total_bp2 -- number of bases in second reads. None for single-end data.
+        """
+        stats = super().collect(n, total_bp1, total_bp2, modifiers, steps)
+        stats.paired = paired
+        return stats

--- a/src/pixelator/pna/amplicon/report.py
+++ b/src/pixelator/pna/amplicon/report.py
@@ -285,11 +285,7 @@ class AmpliconStatistics(Statistics):
         steps,
         paired: Optional[bool] = None,
     ):
-        """
-        n -- total number of reads
-        total_bp1 -- number of bases in first reads
-        total_bp2 -- number of bases in second reads. None for single-end data.
-        """
+        """Enable stats.paired to be explicitly set in the collect method."""
         stats = super().collect(n, total_bp1, total_bp2, modifiers, steps)
         stats.paired = paired
         return stats

--- a/src/pixelator/pna/amplicon/report.py
+++ b/src/pixelator/pna/amplicon/report.py
@@ -182,6 +182,8 @@ class AmpliconStatistics(Statistics):
 
     def __iadd__(self, other: Any):
         """Merge statistics from another object into this one."""
+        if other.paired is None:
+            other.paired = self.paired
         super().__iadd__(other)
         if hasattr(other, "_custom_stats"):
             for name, value in other._custom_stats.items():

--- a/src/pixelator/pna/amplicon/report.py
+++ b/src/pixelator/pna/amplicon/report.py
@@ -4,7 +4,7 @@ Copyright © 2024 Pixelgen Technologies AB.
 """
 
 import typing
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import pydantic
 from cutadapt.report import Statistics

--- a/src/pixelator/pna/amplicon/report.py
+++ b/src/pixelator/pna/amplicon/report.py
@@ -283,9 +283,10 @@ class AmpliconStatistics(Statistics):
         total_bp2: Optional[int],
         modifiers,
         steps,
-        paired: Optional[bool] = None,
+        set_paired_to_none: bool = False,
     ):
-        """Enable stats.paired to be explicitly set in the collect method."""
+        """Enable stats.paired to be set to None when unknown."""
         stats = super().collect(n, total_bp1, total_bp2, modifiers, steps)
-        stats.paired = paired
+        if set_paired_to_none:
+            stats.paired = None
         return stats

--- a/src/pixelator/pna/amplicon/report.py
+++ b/src/pixelator/pna/amplicon/report.py
@@ -66,7 +66,7 @@ class BasesCountStatistics(pydantic.BaseModel):
     quality_trimmed_read1: int = pydantic.Field(
         ..., description="The number of quality trimmed bases in read1."
     )
-    quality_trimmed_read2: int = pydantic.Field(
+    quality_trimmed_read2: Optional[int] = pydantic.Field(
         ..., description="The number of quality trimmed bases in read2."
     )
     output: int = pydantic.Field(..., description="The total number of output bases.")

--- a/src/pixelator/pna/amplicon/report.py
+++ b/src/pixelator/pna/amplicon/report.py
@@ -4,7 +4,7 @@ Copyright © 2024 Pixelgen Technologies AB.
 """
 
 import typing
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import pydantic
 from cutadapt.report import Statistics
@@ -280,7 +280,7 @@ class AmpliconStatistics(Statistics):
         self,
         n: int,
         total_bp1: int,
-        total_bp2: Optional[int],
+        total_bp2: int | None,
         modifiers,
         steps,
         set_paired_to_none: bool = False,

--- a/src/pixelator/pna/cli/amplicon.py
+++ b/src/pixelator/pna/cli/amplicon.py
@@ -155,13 +155,13 @@ def amplicon(
             msg = "Read 1 file does not contain a recognised read 1 suffix."
             logger.log(level=error_level, msg=msg)
             if not skip_input_checks:
-                sys.exit(1)
+                ctx.exit(1)
 
         if fastq_2 and not is_read_file(fastq_2, "r2"):
             msg = "Read 2 file does not contain a recognised read 2 suffix."
             logger.log(level=error_level, msg=msg)
             if not skip_input_checks:
-                sys.exit(1)
+                ctx.exit(1)
 
         r2_sample_name = get_read_sample_name(fastq_2) if fastq_2 else None
 
@@ -173,7 +173,7 @@ def amplicon(
             )
             logger.log(level=error_level, msg=msg)
             if not skip_input_checks:
-                sys.exit(1)
+                ctx.exit(1)
 
     sample_name = sample_name or r1_sample_name
     output_file = amplicon_output / f"{sample_name}.amplicon.fq.zst"
@@ -192,7 +192,7 @@ def amplicon(
     if assay is None:
         msg = f"Could not find assay design with name '{design}'"
         logger.error(msg)
-        return sys.exit(1)
+        return ctx.exit(1)
 
     stats = amplicon_fastq(
         inputs=fastq_inputs,
@@ -216,4 +216,4 @@ def amplicon(
             "This may indicate a problem with the amplicon design."
         )
         if not force_run:
-            sys.exit(1)
+            ctx.exit(1)

--- a/src/pixelator/pna/demux/report.py
+++ b/src/pixelator/pna/demux/report.py
@@ -3,7 +3,7 @@
 Copyright © 2024 Pixelgen Technologies AB.
 """
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import pydantic
 from cutadapt.report import Statistics
@@ -66,7 +66,7 @@ class BarcodeCorrectionStatistics(Statistics):
         self,
         n: int,
         total_bp1: int,
-        total_bp2: Optional[int],
+        total_bp2: int | None,
         modifiers,
         steps,
         set_paired_to_none: bool = False,

--- a/src/pixelator/pna/demux/report.py
+++ b/src/pixelator/pna/demux/report.py
@@ -3,7 +3,7 @@
 Copyright © 2024 Pixelgen Technologies AB.
 """
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import pydantic
 from cutadapt.report import Statistics
@@ -61,6 +61,21 @@ class BarcodeCorrectionStatistics(Statistics):
                 self._custom_stats[name] += step.get_statistics()
             else:
                 self._custom_stats[name] = step.get_statistics()
+
+    def collect(
+        self,
+        n: int,
+        total_bp1: int,
+        total_bp2: Optional[int],
+        modifiers,
+        steps,
+        set_paired_to_none: bool = False,
+    ):
+        """Enable stats.paired to be set to None when unknown."""
+        stats = super().collect(n, total_bp1, total_bp2, modifiers, steps)
+        if set_paired_to_none:
+            stats.paired = None
+        return stats
 
 
 class DemuxSampleReport(SampleReport):

--- a/src/pixelator/pna/read_processing/pipeline.py
+++ b/src/pixelator/pna/read_processing/pipeline.py
@@ -73,10 +73,11 @@ class AmpliconPipeline(Pipeline):
         combiner: CombiningModifier,
         pre_modifiers: (
             Iterable[
-                Union[
-                    PairedEndModifier,
-                    SingleEndModifier,
-                    tuple[SingleEndModifier | None, SingleEndModifier | None],
+                PairedEndModifier
+                | SingleEndModifier
+                | tuple[
+                    SingleEndModifier | None,
+                    SingleEndModifier | None,
                 ]
             ]
             | None
@@ -97,11 +98,9 @@ class AmpliconPipeline(Pipeline):
         """
         self._combiner = combiner
         self._pre_modifiers: list[
-            Union[
-                PairedEndModifier,
-                tuple[SingleEndModifier | None, SingleEndModifier | None],
-                SingleEndModifier,
-            ]
+            SingleEndModifier
+            | PairedEndModifier
+            | tuple[SingleEndModifier | None, SingleEndModifier | None]
         ] = []
         self._pre_steps: list[Union[PairedEndStep, SingleEndStep]] = []
         self._post_modifiers: list[SingleEndModifier] = []

--- a/src/pixelator/pna/read_processing/pipeline.py
+++ b/src/pixelator/pna/read_processing/pipeline.py
@@ -96,7 +96,13 @@ class AmpliconPipeline(Pipeline):
         :param post_steps: A list of steps that are applied to the reads after the combining step.
         """
         self._combiner = combiner
-        self._pre_modifiers: list[Union[PairedEndModifier, tuple[SingleEndModifier | None, SingleEndModifier | None], SingleEndModifier]] = []
+        self._pre_modifiers: list[
+            Union[
+                PairedEndModifier,
+                tuple[SingleEndModifier | None, SingleEndModifier | None],
+                SingleEndModifier,
+            ]
+        ] = []
         self._pre_steps: list[Union[PairedEndStep, SingleEndStep]] = []
         self._post_modifiers: list[SingleEndModifier] = []
         self._post_steps: list[SingleEndStep] = list(post_steps) if post_steps else []

--- a/src/pixelator/pna/read_processing/pipeline.py
+++ b/src/pixelator/pna/read_processing/pipeline.py
@@ -52,7 +52,7 @@ ModifierStage = typing.Literal["pre", "post"]
 
 
 class AmpliconPipeline(Pipeline):
-    """Processing pipeline for combining paired‐end reads now extended to also accept single‐end input (either R1 _or_ R2).
+    """Processing pipeline for processing single-end or paired‐end reads into a single amplicon sequence.
 
     - If two files (R1+R2) are provided: pre‐steps (paired), then combine, then post‐steps (single).
     - If only one file is provided (single‐end), you detect “R1” vs “R2” by looking at

--- a/src/pixelator/pna/read_processing/pipeline.py
+++ b/src/pixelator/pna/read_processing/pipeline.py
@@ -74,8 +74,9 @@ class AmpliconPipeline(Pipeline):
         pre_modifiers: (
             Iterable[
                 Union[
-                    PairedModifiers,
+                    PairedEndModifier,
                     SingleEndModifier,
+                    tuple[SingleEndModifier | None, SingleEndModifier | None],
                 ]
             ]
             | None
@@ -95,7 +96,7 @@ class AmpliconPipeline(Pipeline):
         :param post_steps: A list of steps that are applied to the reads after the combining step.
         """
         self._combiner = combiner
-        self._pre_modifiers: list[Union[PairedModifiers, SingleEndModifier]] = []
+        self._pre_modifiers: list[Union[PairedEndModifier, tuple[SingleEndModifier | None, SingleEndModifier | None], SingleEndModifier]] = []
         self._pre_steps: list[Union[PairedEndStep, SingleEndStep]] = []
         self._post_modifiers: list[SingleEndModifier] = []
         self._post_steps: list[SingleEndStep] = list(post_steps) if post_steps else []
@@ -125,8 +126,8 @@ class AmpliconPipeline(Pipeline):
         self,
         modifiers: Iterable[
             Union[
-                PairedModifiers,
                 SingleEndModifier,
+                PairedEndModifier,
                 Tuple[Optional[SingleEndModifier], Optional[SingleEndModifier]],
             ]
         ],

--- a/src/pixelator/pna/read_processing/pipeline.py
+++ b/src/pixelator/pna/read_processing/pipeline.py
@@ -28,7 +28,7 @@ THE SOFTWARE.
 
 import logging
 import typing
-from typing import Iterable, Optional, Tuple, Union
+from typing import Iterable, Optional, Tuple
 
 from cutadapt.files import InputFiles
 from cutadapt.info import ModificationInfo
@@ -82,7 +82,7 @@ class AmpliconPipeline(Pipeline):
             ]
             | None
         ) = None,
-        pre_steps: Iterable[Union[PairedEndStep, SingleEndStep]] | None = None,
+        pre_steps: Iterable[PairedEndStep | SingleEndStep] | None = None,
         post_modifiers: Iterable[SingleEndModifier] | None = None,
         post_steps: Iterable[SingleEndStep] | None = None,
     ):
@@ -102,7 +102,7 @@ class AmpliconPipeline(Pipeline):
             | PairedEndModifier
             | tuple[SingleEndModifier | None, SingleEndModifier | None]
         ] = []
-        self._pre_steps: list[Union[PairedEndStep, SingleEndStep]] = (
+        self._pre_steps: list[PairedEndStep | SingleEndStep] = (
             list(pre_steps) if pre_steps else []
         )
         self._post_modifiers: list[SingleEndModifier] = []
@@ -132,11 +132,9 @@ class AmpliconPipeline(Pipeline):
     def _add_modifiers(
         self,
         modifiers: Iterable[
-            Union[
-                SingleEndModifier,
-                PairedEndModifier,
-                Tuple[Optional[SingleEndModifier], Optional[SingleEndModifier]],
-            ]
+            SingleEndModifier
+            | PairedEndModifier
+            | Tuple[Optional[SingleEndModifier], Optional[SingleEndModifier]],
         ],
         stage: ModifierStage,
     ) -> None:

--- a/src/pixelator/pna/read_processing/runners.py
+++ b/src/pixelator/pna/read_processing/runners.py
@@ -252,6 +252,7 @@ class WorkerProcess(mpctx_Process):
                 0 if self._pipeline.paired else None,
                 self._pipeline._modifiers,
                 self._pipeline._steps,
+                paired=self._pipeline.paired,
             )
             self._write_pipe.send(-1)
             self._write_pipe.send(stats)

--- a/src/pixelator/pna/read_processing/runners.py
+++ b/src/pixelator/pna/read_processing/runners.py
@@ -252,7 +252,7 @@ class WorkerProcess(mpctx_Process):
                 0 if self._pipeline.paired else None,
                 self._pipeline._modifiers,
                 self._pipeline._steps,
-                paired=self._pipeline.paired,
+                set_paired_to_none=self._pipeline.paired is None,
             )
             self._write_pipe.send(-1)
             self._write_pipe.send(stats)

--- a/tests/pna/amplicon/test_amplicon.py
+++ b/tests/pna/amplicon/test_amplicon.py
@@ -18,3 +18,17 @@ def test_amplicon_300k(tmp_path, testdata_300k):
     )
 
     assert (tmp_path / "testdata_300k.fq.zst").exists()
+
+
+@pytest.mark.slow
+def test_amplicon_300k_single_end(tmp_path, testdata_300k):
+    input_files = testdata_300k
+    pna_assay = pna_config.get_assay("pna-2")
+
+    amplicon_fastq(
+        inputs=input_files[0:1],
+        assay=pna_assay,
+        output=tmp_path / "testdata_300k.fq.zst",
+    )
+
+    assert (tmp_path / "testdata_300k.fq.zst").exists()

--- a/tests/pna/amplicon/test_amplicon.py
+++ b/tests/pna/amplicon/test_amplicon.py
@@ -4,6 +4,8 @@ import pytest
 
 from pixelator.pna.amplicon.process import amplicon_fastq
 from pixelator.pna.config import pna_config
+import zstandard as zstd
+import numpy as np
 
 
 @pytest.mark.slow
@@ -21,14 +23,65 @@ def test_amplicon_300k(tmp_path, testdata_300k):
 
 
 @pytest.mark.slow
-def test_amplicon_300k_single_end(tmp_path, testdata_300k):
-    input_files = testdata_300k
+def test_amplicon_unbalanced_single_end(tmp_path, testdata_unbalanced_r12):
+    input_files = testdata_unbalanced_r12
     pna_assay = pna_config.get_assay("pna-2")
+
+    out_paired = tmp_path / "testdata_unbalanced.fq.zst"
+    out_r1 = tmp_path / "testdata_unbalanced_r1.fq.zst"
+    out_r2 = tmp_path / "testdata_unbalanced_r2.fq.zst"
+
+    amplicon_fastq(
+        inputs=input_files,
+        assay=pna_assay,
+        output=out_paired,
+    )
 
     amplicon_fastq(
         inputs=input_files[0:1],
         assay=pna_assay,
-        output=tmp_path / "testdata_300k.fq.zst",
+        output=out_r1,
     )
 
-    assert (tmp_path / "testdata_300k.fq.zst").exists()
+    amplicon_fastq(
+        inputs=input_files[1:],
+        assay=pna_assay,
+        output=out_r2,
+    )
+
+    assert out_paired.exists()
+    assert out_r1.exists()
+    assert out_r2.exists()
+
+    def read_zst_lines(path):
+        with open(path, "rb") as f:
+            dctx = zstd.ZstdDecompressor()
+            with dctx.stream_reader(f) as reader:
+                return reader.read().splitlines()
+
+    paired_lines = read_zst_lines(out_paired)
+    r1_lines = read_zst_lines(out_r1)
+    r2_lines = read_zst_lines(out_r2)
+
+    min_diffs_r1 = []
+    min_diffs_r2 = []
+    for p in paired_lines[1::4]:
+        min_diff_r1 = 142
+        min_diff_r2 = 142
+        for p1 in r1_lines[1::4]:
+            diff = sum([b != a for a, b in zip(p, p1)])
+            if diff < min_diff_r1:
+                min_diff_r1 = diff
+            if min_diff_r1 == 0:
+                break
+        for p2 in r2_lines[1::4]:
+            diff = sum([b != a for a, b in zip(p, p2)])
+            if diff < min_diff_r2:
+                min_diff_r2 = diff
+            if min_diff_r2 == 0:
+                break
+        min_diffs_r1.append(min_diff_r1)
+        min_diffs_r2.append(min_diff_r2)
+
+    assert np.mean([m > 6 for m in min_diffs_r1]) < 0.1
+    assert np.mean([m > 6 for m in min_diffs_r2]) < 0.1

--- a/tests/pna/amplicon/test_amplicon.py
+++ b/tests/pna/amplicon/test_amplicon.py
@@ -1,11 +1,11 @@
 """Copyright © 2025 Pixelgen Technologies AB."""
 
+import numpy as np
 import pytest
+import zstandard as zstd
 
 from pixelator.pna.amplicon.process import amplicon_fastq
 from pixelator.pna.config import pna_config
-import zstandard as zstd
-import numpy as np
 
 
 @pytest.mark.slow

--- a/tests/pna/amplicon/test_amplicon.py
+++ b/tests/pna/amplicon/test_amplicon.py
@@ -2,10 +2,24 @@
 
 import numpy as np
 import pytest
-import zstandard as zstd
+import xopen
 
 from pixelator.pna.amplicon.process import amplicon_fastq
 from pixelator.pna.config import pna_config
+
+
+def _match_amplicon_reads(r1, r2):
+    r1_names = [r[:-2] for r in r1[0::4]]
+    r2_names = [r[:-2] for r in r2[0::4]]
+    common_reads = set(r1_names).intersection(set(r2_names))
+    distances = {}
+    for r in common_reads:
+        index_1 = next(i for i, s in enumerate(r1_names) if r in s)
+        index_2 = next(i for i, s in enumerate(r2_names) if r in s)
+        r1_seq = r1[index_1 * 4 + 1]
+        r2_seq = r2[index_2 * 4 + 1]
+        distances[r] = sum([b != a for a, b in zip(r1_seq, r2_seq)])
+    return distances
 
 
 @pytest.mark.slow
@@ -24,6 +38,7 @@ def test_amplicon_300k(tmp_path, testdata_300k):
 
 @pytest.mark.slow
 def test_amplicon_unbalanced_single_end(tmp_path, testdata_unbalanced_r12):
+    # Testing paired-end vs single-end amplicon where one read (R2) has higher read quality.
     input_files = testdata_unbalanced_r12
     pna_assay = pna_config.get_assay("pna-2")
 
@@ -53,35 +68,19 @@ def test_amplicon_unbalanced_single_end(tmp_path, testdata_unbalanced_r12):
     assert out_r1.exists()
     assert out_r2.exists()
 
-    def read_zst_lines(path):
-        with open(path, "rb") as f:
-            dctx = zstd.ZstdDecompressor()
-            with dctx.stream_reader(f) as reader:
-                return reader.read().splitlines()
+    def read_lines(path):
+        with xopen.xopen(path, "rt") as f:
+            return f.read().splitlines()
 
-    paired_lines = read_zst_lines(out_paired)
-    r1_lines = read_zst_lines(out_r1)
-    r2_lines = read_zst_lines(out_r2)
+    paired_lines = read_lines(out_paired)
+    r1_lines = read_lines(out_r1)
+    r2_lines = read_lines(out_r2)
 
-    min_diffs_r1 = []
-    min_diffs_r2 = []
-    for p in paired_lines[1::4]:
-        min_diff_r1 = 142
-        min_diff_r2 = 142
-        for p1 in r1_lines[1::4]:
-            diff = sum([b != a for a, b in zip(p, p1)])
-            if diff < min_diff_r1:
-                min_diff_r1 = diff
-            if min_diff_r1 == 0:
-                break
-        for p2 in r2_lines[1::4]:
-            diff = sum([b != a for a, b in zip(p, p2)])
-            if diff < min_diff_r2:
-                min_diff_r2 = diff
-            if min_diff_r2 == 0:
-                break
-        min_diffs_r1.append(min_diff_r1)
-        min_diffs_r2.append(min_diff_r2)
+    min_diffs_r1 = _match_amplicon_reads(r1_lines, paired_lines)
+    min_diffs_r2 = _match_amplicon_reads(r2_lines, paired_lines)
 
-    assert np.mean([m > 6 for m in min_diffs_r1]) < 0.1
-    assert np.mean([m > 6 for m in min_diffs_r2]) < 0.1
+    assert np.mean([m > 6 for m in min_diffs_r1.values()]) < 0.1
+    assert np.mean([m > 6 for m in min_diffs_r2.values()]) < 0.1
+
+    # Verify that R2 matches the paired read more closely than R1
+    assert np.mean(list(min_diffs_r2.values())) < np.mean(list(min_diffs_r1.values()))

--- a/tests/pna/amplicon/test_amplicon_builder.py
+++ b/tests/pna/amplicon/test_amplicon_builder.py
@@ -230,7 +230,7 @@ def test_amplicon_crappy_lbs1():
 
 def test_amplicon_intersecting_reads():
     assay = pna_config.get_assay("pna-2")
-    step = AmpliconBuilder(assay, mismatches=0.1)
+    step = PairedEndAmpliconBuilder(assay, mismatches=0.1)
 
     r1 = SequenceRecord(
         name="@VH00725:177:AAFHGNGM5:1:1101:65059:1057 1:N:0:AGGTCTTG+GATGAGGA",

--- a/tests/pna/amplicon/test_amplicon_builder.py
+++ b/tests/pna/amplicon/test_amplicon_builder.py
@@ -3,13 +3,13 @@
 from cutadapt.info import ModificationInfo
 from dnaio import SequenceRecord
 
-from pixelator.pna.amplicon.build_amplicon import AmpliconBuilder
+from pixelator.pna.amplicon.build_amplicon import PairedEndAmpliconBuilder
 from pixelator.pna.config import pna_config
 
 
 def test_amplicon_builder_no_mismatches():
     assay = pna_config.get_assay("pna-2")
-    step = AmpliconBuilder(assay, mismatches=0.1)
+    step = PairedEndAmpliconBuilder(assay, mismatches=0.1)
 
     r1 = SequenceRecord(
         name="@VH00725:177:AAFHGNGM5:1:1101:65059:1057 1:N:0:AGGTCTTG+GATGAGGA",
@@ -53,7 +53,7 @@ def test_amplicon_builder_no_mismatches():
 
 def test_amplicon_builder_shift():
     assay = pna_config.get_assay("pna-2")
-    step = AmpliconBuilder(assay, mismatches=0.2)
+    step = PairedEndAmpliconBuilder(assay, mismatches=0.2)
 
     r1 = SequenceRecord(
         name="@VH00725:177:AAFHGNGM5:1:1101:65059:1057 1:N:0:AGGTCTTG+GATGAGGA",
@@ -90,7 +90,7 @@ def test_amplicon_builder_shift():
 
 def test_amplicon_builder_large_shift():
     assay = pna_config.get_assay("pna-2")
-    step = AmpliconBuilder(assay, mismatches=0.1)
+    step = PairedEndAmpliconBuilder(assay, mismatches=0.1)
 
     r1 = SequenceRecord(
         name="VH00725:177:AAFHGNGM5:1:1101:68505:3745 1:N:0:AGGTCTTG+GATGAGGA",
@@ -129,7 +129,7 @@ def test_uei_deletion():
     # NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNCCGACATCTAAGCGAAGCNNNNNNNNNNNNNNNGACATGAGTGTTTGACATGCCCAGCGTCACTTGNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
     # Rev comp template
 
-    step = AmpliconBuilder(assay, mismatches=0.1)
+    step = PairedEndAmpliconBuilder(assay, mismatches=0.1)
     info1 = ModificationInfo(r1)
     info2 = ModificationInfo(r2)
     amplicon = step(r1, r2, info1, info2)
@@ -160,7 +160,7 @@ def test_bad_lbs2():
         qualities="CC-CCCCCCCCCCC-CCCC;C;CCCCCCCCCCCC;CCCCCCCCCCCCC;CCCCC-CCCCCCCCCCCCCCCCCCCCCCC",
     )
 
-    step = AmpliconBuilder(assay, mismatches=0.2)
+    step = PairedEndAmpliconBuilder(assay, mismatches=0.2)
     info1 = ModificationInfo(r1)
     info2 = ModificationInfo(r2)
     amplicon = step(r1, r2, info1, info2)
@@ -183,7 +183,7 @@ def test_lbs2_insertion():
         qualities="CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC;CCCCCCCCCCCCCCCCCCCCCCCCC;C",
     )
 
-    step = AmpliconBuilder(assay, mismatches=0.2)
+    step = PairedEndAmpliconBuilder(assay, mismatches=0.2)
     info1 = ModificationInfo(r1)
     info2 = ModificationInfo(r2)
     amplicon = step(r1, r2, info1, info2)
@@ -205,7 +205,7 @@ def test_lbs2_insertion():
 
 def test_amplicon_crappy_lbs1():
     assay = pna_config.get_assay("pna-2")
-    step = AmpliconBuilder(assay, mismatches=0.1)
+    step = PairedEndAmpliconBuilder(assay, mismatches=0.1)
 
     r1 = SequenceRecord(
         name="@VH00725:177:AAFHGNGM5:1:1101:65059:1057 1:N:0:AGGTCTTG+GATGAGGA",

--- a/tests/pna/amplicon/test_pna_cli.py
+++ b/tests/pna/amplicon/test_pna_cli.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-import zstandard as zstd
+import xopen
 from click.testing import CliRunner
 
 from pixelator import cli
@@ -143,12 +143,10 @@ def test_fastq_single_end(testdata_unbalanced_r12):
 
         assert cmd.exit_code == 0
 
-        def read_zst_lines(path):
-            with open(path, "rb") as f:
-                dctx = zstd.ZstdDecompressor()
-                with dctx.stream_reader(f) as reader:
-                    return reader.read().splitlines()
+        def read_lines(path):
+            with xopen.xopen(path, "rt") as f:
+                return f.read().splitlines()
 
-        reads = read_zst_lines(d + "/amplicon/unbalanced.amplicon.fq.zst")
+        reads = read_lines(d + "/amplicon/unbalanced.amplicon.fq.zst")
         assert len(reads) % 4 == 0
         assert len(reads) > 300

--- a/tests/pna/amplicon/test_pna_cli.py
+++ b/tests/pna/amplicon/test_pna_cli.py
@@ -122,3 +122,21 @@ def test_can_skip_input_checks(mocker, testdata_300k_sample_mismatch):
         ]
         cmd = runner.invoke(cli.main_cli, args)
         assert cmd.exit_code == 0
+
+
+def test_fastq_single_end(testdata_unbalanced_r12):
+    runner = CliRunner()
+
+    with tempfile.TemporaryDirectory() as d:
+        args = [
+            "single-cell-pna",
+            "amplicon",
+            str(testdata_unbalanced_r12[0]),
+            "--output",
+            str(d),
+            "--design",
+            "pna-2",
+        ]
+        cmd = runner.invoke(cli.main_cli, args)
+
+        assert cmd.exit_code == 0

--- a/tests/pna/amplicon/test_pna_cli.py
+++ b/tests/pna/amplicon/test_pna_cli.py
@@ -125,6 +125,7 @@ def test_can_skip_input_checks(mocker, testdata_300k_sample_mismatch):
         assert cmd.exit_code == 0
 
 
+@pytest.mark.slow
 def test_fastq_single_end(testdata_unbalanced_r12):
     runner = CliRunner()
 

--- a/tests/pna/conftest.py
+++ b/tests/pna/conftest.py
@@ -66,6 +66,14 @@ def testdata_300k(pna_data_root) -> tuple[Path, Path]:
 
 
 @pytest.fixture(scope="module")
+def testdata_unbalanced_r12(pna_data_root) -> tuple[Path, Path]:
+    return (
+        Path(pna_data_root / "unbalanced_R1.fastq.gz"),
+        Path(pna_data_root / "unbalanced_R2.fastq.gz"),
+    )
+
+
+@pytest.fixture(scope="module")
 def testdata_amplicon_fastq(full_run_dir) -> Path:
     p = full_run_dir / "amplicon" / "PNA055_Sample07_filtered_S7.amplicon.fq.zst"
     return p

--- a/tests/pna/data/unbalanced_R1.fastq.gz
+++ b/tests/pna/data/unbalanced_R1.fastq.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8df8b8a74c6f21d31b58f856b137290ead87063951b6ec8b2c44632f241a7d7e
+size 10583

--- a/tests/pna/data/unbalanced_R2.fastq.gz
+++ b/tests/pna/data/unbalanced_R2.fastq.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:91b66ead42061f3c00eb12ca87a3013fd6837f4d9e4b41bdd79083c65909af21
+size 8871


### PR DESCRIPTION
Adding support for single-end reads.

Fixes: PNA-944

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Added unit tests with single-end reads.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated poetry.lock, and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
