### PR TITLE
Expose one core layer threshhold parameter through cli

### DIFF
--- a/src/pixelator/pna/analysis/denoise.py
+++ b/src/pixelator/pna/analysis/denoise.py
@@ -182,6 +182,7 @@ def denoise_one_core_layer(
     component: PNAGraph,
     pval_significance_threshold: float = 0.05,
     inflate_factor: float = 1.5,
+    one_core_ratio_threshold: float = 0.9,
 ) -> list:
     """Identify and remove markers over-expressed in the one-core layer of a graph.
 
@@ -205,7 +206,7 @@ def denoise_one_core_layer(
     """
     node_marker_counts = component.node_marker_counts
     node_core_numbers = pd.Series(nx.core_number(component.raw))
-    if (node_core_numbers <= 1).mean() >= 0.5:
+    if (node_core_numbers <= 1).mean() >= one_core_ratio_threshold:
         logger.debug(
             "Too many low core number nodes. Skipping denoising for this component."
         )
@@ -230,7 +231,10 @@ class DenoiseOneCore(PerComponentTask):
     TASK_NAME = "denoise-one-core"
 
     def __init__(
-        self, pval_significance_threshold: float = 0.05, inflate_factor: float = 1.5
+        self,
+        pval_significance_threshold: float = 0.05,
+        inflate_factor: float = 1.5,
+        one_core_ratio_threshold: float = 0.9,
     ):
         """Initialize a DenoiseOneCore instance.
 
@@ -242,6 +246,7 @@ class DenoiseOneCore(PerComponentTask):
         """
         self.pval_significance_threshold = pval_significance_threshold
         self.inflate_factor = inflate_factor
+        self.one_core_ratio_threshold = one_core_ratio_threshold
 
     def run_on_component_graph(
         self, component: PNAGraph, component_id: str
@@ -269,6 +274,7 @@ class DenoiseOneCore(PerComponentTask):
                 component,
                 pval_significance_threshold=self.pval_significance_threshold,
                 inflate_factor=self.inflate_factor,
+                one_core_ratio_threshold=self.one_core_ratio_threshold,
             ),
             columns=["umi"],
         )

--- a/src/pixelator/pna/cli/denoise.py
+++ b/src/pixelator/pna/cli/denoise.py
@@ -44,6 +44,20 @@ logger = logging.getLogger(__name__)
     help="Run the denoise step to remove markers that are over-expressed in the one-core layer of a component.",
 )
 @click.option(
+    "--one-core-ratio-threshold",
+    default=0.9,
+    required=False,
+    type=click.FloatRange(
+        0,
+        1,
+    ),
+    show_default=True,
+    help=(
+        "ratio of the number of nodes in the one-core layer to the total number of nodes in a component. "
+        "If the ratio is above this threshold, the component is marked as disqualified for denoising."
+    ),
+)
+@click.option(
     "--pval-threshold",
     default=0.05,
     required=False,
@@ -72,6 +86,7 @@ def denoise(
     ctx,
     pxl_file,
     run_one_core_graph_denoising,
+    one_core_ratio_threshold,
     pval_threshold,
     inflate_factor,
     output,
@@ -82,6 +97,7 @@ def denoise(
         "denoise",
         input_files=input_files,
         run_one_core_graph_denoising=run_one_core_graph_denoising,
+        one_core_ratio_threshold=one_core_ratio_threshold,
         pval_threshold=pval_threshold,
         inflate_factor=inflate_factor,
         output=output,
@@ -115,7 +131,9 @@ def denoise(
         report.write_json_file(metrics, indent=4)
         return
 
-    analysis_to_run = [DenoiseOneCore(pval_threshold, inflate_factor)]
+    analysis_to_run = [
+        DenoiseOneCore(pval_threshold, inflate_factor, one_core_ratio_threshold)
+    ]
     logging_setup = LoggingSetup.from_logger(ctx.obj.get("LOGGER"))
     manager = AnalysisManager(analysis_to_run, logging_setup=logging_setup)
     pxl_dataset = read(pxl_file.path)


### PR DESCRIPTION
Expose the one-core ratio layer threshhold in the denoise step as a cli parameter. It is also increased to 0.9 by default to effectively denoise every cell. Cells with a higher ratio of node in their core-1 layer will be marked as disqualified for being denoised.

Fixes: PNA-909

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce it when relevant.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated poetry.lock, and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
