### PR TITLE
Feature/pna 999 support adata rewrite for pxl files with dashes in their name

### DIFF
--- a/src/pixelator/pna/pixeldataset/io/__init__.py
+++ b/src/pixelator/pna/pixeldataset/io/__init__.py
@@ -137,7 +137,7 @@ class PixelFileWriter:
         adata_tables = tables.pl().filter((pl.col("name").str.starts_with("__adata__")))
         for table in adata_tables.iter_rows(named=True):
             self._connection.sql(
-                f"DROP TABLE {table['database']}.{table['schema']}.{table['name']}"
+                f'DROP TABLE "{table["database"]}"."{table["schema"]}"."{table["name"]}"'
             )
 
     def write_adata(self, adata: AnnData) -> None:

--- a/tests/pna/pixeldataset/test_pna_pixeldataset.py
+++ b/tests/pna/pixeldataset/test_pna_pixeldataset.py
@@ -407,9 +407,9 @@ class TestPixelDatasetNames:
 
 
 def test_rewriting_anndata(pxl_file_w_sample_names):
-    pxl_dataset = pxl_file_w_sample_names
-    pxl = PNAPixelDataset.from_pxl_files(pxl_dataset)
+    pxl_file = pxl_file_w_sample_names
+    pxl = PNAPixelDataset.from_pxl_files(pxl_file)
     adata = pxl.adata()
 
-    with PixelFileWriter(pxl_dataset) as writer:
+    with PixelFileWriter(pxl_file) as writer:
         writer.write_adata(adata)

--- a/tests/pna/pixeldataset/test_pna_pixeldataset.py
+++ b/tests/pna/pixeldataset/test_pna_pixeldataset.py
@@ -3,6 +3,7 @@
 from io import StringIO
 from pathlib import Path
 
+import anndata
 import pandas as pd
 import polars as pl
 import pytest
@@ -14,7 +15,7 @@ from pixelator.pna.pixeldataset import (
     PNAPixelDataset,
     read,
 )
-from pixelator.pna.pixeldataset.io import PixelDataViewer
+from pixelator.pna.pixeldataset.io import PixelDataViewer, PixelFileWriter
 from tests.pna.pixeldataset.conftest import create_pxl_file
 
 
@@ -334,15 +335,15 @@ class TestPrecomputedLayouts:
         "✅-sample-with-emoji",
     ],
 )
-def pixel_file_with_different_sample_names_fixture(
+def pixel_dataset_with_different_sample_names_fixture(
     request,
     tmp_path_factory,
     edgelist_parquet_path,
     proximity_parquet_path,
     layout_parquet_path,
 ):
-    target = tmp_path_factory.mktemp("data") / "file.pxl"
     sample_name = request.param
+    target = tmp_path_factory.mktemp("data") / (sample_name + ".pxl")
     target = create_pxl_file(
         target=target,
         sample_name=sample_name,
@@ -351,6 +352,35 @@ def pixel_file_with_different_sample_names_fixture(
         layout_parquet_path=layout_parquet_path,
     )
     return PNAPixelDataset.from_pxl_files([target]), sample_name
+
+
+@pytest.fixture(
+    name="pxl_file_w_sample_names",
+    scope="module",
+    params=[
+        "1-sample-starting-with-nbr",
+        "sample-containing-dash",
+        "sample_with_underscores",
+        "✅-sample-with-emoji",
+    ],
+)
+def pxl_file_with_sample_names_fixture(
+    request,
+    tmp_path_factory,
+    edgelist_parquet_path,
+    proximity_parquet_path,
+    layout_parquet_path,
+):
+    sample_name = request.param
+    target = tmp_path_factory.mktemp("data") / (sample_name + ".pxl")
+    target = create_pxl_file(
+        target=target,
+        sample_name=sample_name,
+        edgelist_parquet_path=edgelist_parquet_path,
+        proximity_parquet_path=proximity_parquet_path,
+        layout_parquet_path=layout_parquet_path,
+    )
+    return target
 
 
 class TestPixelDatasetNames:
@@ -374,3 +404,12 @@ class TestPixelDatasetNames:
         actual_sample_name = df.obs["sample"].unique()
         assert actual_sample_name.shape[0] == 1
         assert actual_sample_name[0] == sample_name
+
+
+def test_rewriting_anndata(pxl_file_w_sample_names):
+    pxl_dataset = pxl_file_w_sample_names
+    pxl = PNAPixelDataset.from_pxl_files(pxl_dataset)
+    adata = pxl.adata()
+
+    with PixelFileWriter(pxl_dataset) as writer:
+        writer.write_adata(adata)


### PR DESCRIPTION
We aim to support pxl file names with dashes ("-") in them. An issue surfaced for such files when the adata is being re-written (for example, after denoising). The dash is interpreted as part of syntax when dropping the corresponding entries from duckDB 

Fixes: PNA-999

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added test for rewriting adata with different pxl file names. 

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
