### PR TITLE
Push containers to quay.io

### DIFF
--- a/.github/actions/build-dev-image/action.yml
+++ b/.github/actions/build-dev-image/action.yml
@@ -26,6 +26,7 @@ runs:
         images: |
           ghcr.io/pixelgentechnologies/pixelator
           890888997283.dkr.ecr.eu-north-1.amazonaws.com/pixelator
+          quay.io/pixelgen-technologies/pixelator
         tags: |
           type=ref,event=branch
           type=ref,event=pr

--- a/.github/actions/setup-image-build-env/action.yml
+++ b/.github/actions/setup-image-build-env/action.yml
@@ -38,3 +38,10 @@ runs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ github.token }}
+
+    - name: Login to Quay Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_IO_USERNAME }}
+        password: ${{ secrets.QUAY_IO_PASSWORD }}


### PR DESCRIPTION
Add `quay.io/pixelgen-technologies/pixelator` as an image source.
This is preferable for public access since it allows anonymous pulls unlike ghcr.io