### PR TITLE
Try run_on_component_edgelist before run_on_component_edgelist

### DIFF
--- a/src/pixelator/pna/analysis_engine.py
+++ b/src/pixelator/pna/analysis_engine.py
@@ -154,13 +154,13 @@ class PerComponentTask(Protocol, Generic[T]):
         :raises TypeError: If the component is not a Graph or a LazyFrame.
         """
         try:
-            return self.run_on_component_graph(component.graph, component.component_id)
-        except NotImplementedError:
-            pass
-        try:
             return self.run_on_component_edgelist(
                 component.frame, component.component_id
             )
+        except NotImplementedError:
+            pass
+        try:
+            return self.run_on_component_graph(component.graph, component.component_id)
         except NotImplementedError as e:
             logger.error(
                 "Either `run_on_component_graph` or `run_on_component_edgelist` "


### PR DESCRIPTION
In PerComponentTask try run_on_component_edgelist before run_on_component_edgelist. The advantage would be that we don't call component.graph if we have an operation that runs on the edgelist. 

Fixes: #PNA-1109

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Existing unit tests.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
