### PR TITLE
Set .html files as vendored for repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@ tests/snapshots/test_plot/*.png filter=lfs diff=lfs merge=lfs -text
 *.pxl filter=lfs diff=lfs merge=lfs -text
 *.zst filter=lfs diff=lfs merge=lfs -text
 *.gz filter=lfs diff=lfs merge=lfs -text
+*.html linguist-vendored


### PR DESCRIPTION
## Description

Set html as vendored so that github will give correct language stats for the repo.