### PR TITLE
Use read_only mode duckdb connection in PxlFile and PixelDataViewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [x.x.x] - 2025-??-??
+
+### Added
+
+-   Support limited concurrent access to pixelfiles for selected read-only operations
+
 ## [0.21.3] - 2025-07-04
 
 ### Fixed

--- a/src/pixelator/pna/pixeldataset/io/__init__.py
+++ b/src/pixelator/pna/pixeldataset/io/__init__.py
@@ -910,7 +910,7 @@ def copy_databases(src_db: Path, target_db: Path) -> None:
     :param target_db: The target PXL file.
     """
     query = f"""
-    ATTACH '{str(src_db)}' AS src;
+    ATTACH '{str(src_db)}' AS src (READ_ONLY);
     ATTACH '{str(target_db)}' AS target;
     COPY FROM DATABASE src TO target;
     """

--- a/src/pixelator/pna/pixeldataset/io/__init__.py
+++ b/src/pixelator/pna/pixeldataset/io/__init__.py
@@ -263,7 +263,7 @@ class PxlFile:
 
     def is_pxl_file(self) -> bool:
         """Check if the file is a PXL file."""
-        with duckdb.connect(self.path) as con:
+        with duckdb.connect(self.path, read_only=True) as con:
             tables = con.sql("SHOW ALL TABLES").to_df()
             return len(
                 set(PXL_FILE_MANDATOR_TABLES).intersection(
@@ -274,7 +274,7 @@ class PxlFile:
     def metadata(self) -> dict:
         """Read the metadata from the PXL file."""
         try:
-            with duckdb.connect(self.path) as con:
+            with duckdb.connect(self.path, read_only=True) as con:
                 metadata = con.sql("SELECT * FROM metadata").fetchone()
                 return json.loads(metadata[0]) if metadata else {}
         except duckdb.CatalogException:

--- a/src/pixelator/pna/pixeldataset/io/__init__.py
+++ b/src/pixelator/pna/pixeldataset/io/__init__.py
@@ -500,7 +500,7 @@ class PixelDataViewer:
 
     def _attach_to_files(self, connection: duckdb.DuckDBPyConnection):
         for name, path in self._db_to_file_mapping.items():
-            query = f"ATTACH DATABASE '{path}' AS {self._get_normalized_name(name)}"
+            query = f"ATTACH DATABASE '{path}' AS {self._get_normalized_name(name)} (READ_ONLY);"
             connection.execute(query)
 
     def _simple_union_table_view(

--- a/src/pixelator/pna/pixeldataset/io/__init__.py
+++ b/src/pixelator/pna/pixeldataset/io/__init__.py
@@ -894,9 +894,10 @@ class InplacePixelDataFilterer:
             self._filter_edgelist(connection, components_as_list)
             self._filter_proximity(connection, components_as_list)
             self._filter_layouts(connection, components_as_list)
-            self._filter_adata(self.pxl_file, components_as_list)
             if metadata:
                 self._update_metadata(connection, metadata)
+
+        self._filter_adata(self.pxl_file, components_as_list)
 
 
 def copy_databases(src_db: Path, target_db: Path) -> None:


### PR DESCRIPTION

## Description

Use DuckDB read-only connections where appropriate to allow multiple python processes on
the same database file. This issue can pop up during testing of the nf-core pipelines when files are staged as symlinks.

Fixes: PNA-1231

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Existing test suite, pipeline tests with nf-test.
