### PR TITLE
Maintain sparsity in adjacency matrix power and refactor PNA graph construction

### DIFF
--- a/src/pixelator/common/graph/backends/implementations/_networkx.py
+++ b/src/pixelator/common/graph/backends/implementations/_networkx.py
@@ -893,14 +893,19 @@ def _prob_edge_weights(
     A = nx.to_scipy_sparse_array(g, weight=None, format="csr")
 
     # Add 1 to the diagonal to allow self-loops
-    A = A + sp.sparse.diags([1] * A.shape[0], format="csr")
+    A = A + sp.sparse.diags_array([1] * A.shape[0], format="csr")
 
     # Divide by row sum to get the stochastic matrix
-    D = sp.sparse.diags(1 / A.sum(axis=1), format="csr")
+    D = sp.sparse.diags_array(1 / A.sum(axis=1), format="csr")
     P = D @ A
 
     # Compute the transition probabilities for a k-step walk
-    P_step = _mat_pow(P, k)
+    min_weight = 0.001  # To avoid having the sparse matrix grow too dense
+    P_step = _mat_pow(P, k, prune_threshold=min_weight)
+    P_step = P_step + P  # Ensure that the original values are not pruned
+    # Redivide by row sum to ensure rows sum up to 1 after pruning.
+    D_P = sp.sparse.diags_array(1 / P_step.sum(axis=1), format="csr", offsets=0)
+    P_step = D_P @ P_step
 
     # Keep edges from original graph
     P_step = P_step.multiply(A)
@@ -925,13 +930,16 @@ def _prob_edge_weights(
     col_indices = vectorized_index(node_to)
 
     # Extract the probabilities
-    edge_probs = np.asarray(P_step_bidirectional[row_indices, col_indices])[0]
+    edge_probs = np.asarray(P_step_bidirectional[row_indices, col_indices])
 
     return edge_probs
 
 
-def _mat_pow(mat, power):
-    mat_power = mat
+def _mat_pow(mat, power, prune_threshold: float | None = None):
+    mat_power = mat.copy()
     for _ in range(power - 1):
+        if prune_threshold:
+            mat_power.data[np.abs(mat_power.data) < prune_threshold] = 0
+            mat_power.eliminate_zeros()
         mat_power = mat @ mat_power
     return mat_power

--- a/src/pixelator/common/graph/backends/implementations/_networkx.py
+++ b/src/pixelator/common/graph/backends/implementations/_networkx.py
@@ -902,7 +902,7 @@ def _prob_edge_weights(
     # Compute the transition probabilities for a k-step walk
     min_weight = 0.001  # To avoid having the sparse matrix grow too dense
     P_step = _mat_pow(P, k, prune_threshold=min_weight)
-    P_step = P_step + P  # Ensure that the original values are not pruned
+    P_step = P_step + min_weight * P  # Ensure that the original values are not pruned
     # Redivide by row sum to ensure rows sum up to 1 after pruning.
     D_P = sp.sparse.diags_array(1 / P_step.sum(axis=1), format="csr", offsets=0)
     P_step = D_P @ P_step

--- a/src/pixelator/common/graph/backends/implementations/_networkx.py
+++ b/src/pixelator/common/graph/backends/implementations/_networkx.py
@@ -902,10 +902,9 @@ def _prob_edge_weights(
     # Compute the transition probabilities for a k-step walk
     min_weight = 0.001  # To avoid having the sparse matrix grow too dense
     P_step = _mat_pow(P, k, prune_threshold=min_weight)
-    P_step = P_step + min_weight * P  # Ensure that the original values are not pruned
-    # Redivide by row sum to ensure rows sum up to 1 after pruning.
-    D_P = sp.sparse.diags_array(1 / P_step.sum(axis=1), format="csr", offsets=0)
-    P_step = D_P @ P_step
+    P_step = (P_step + min_weight * P) / (
+        1 + min_weight
+    )  # Ensure that the original values are not pruned
 
     # Keep edges from original graph
     P_step = P_step.multiply(A)

--- a/src/pixelator/pna/analysis_engine.py
+++ b/src/pixelator/pna/analysis_engine.py
@@ -141,23 +141,6 @@ class PerComponentTask(Protocol, Generic[T]):
         raise NotImplementedError
 
     @with_logging
-    def run(self, component: PNAGraph | pl.LazyFrame | str, component_id: str) -> T:
-        """Run the analysis on this component.
-
-        :param component: The component to run the analysis on. Either a Graph or a LazyFrame.
-        :param component_id: The id of the component.
-        :raises TypeError: If the component is not a Graph or a LazyFrame.
-        """
-        if isinstance(component, str):
-            return self.run_from_component_id(component)
-        elif isinstance(component, PNAGraph):
-            return self.run_on_component_graph(component, component_id)
-        elif isinstance(component, pl.LazyFrame):
-            return self.run_on_component_edgelist(component, component_id)
-        else:
-            raise TypeError(f"Unknown component type: {type(component)}")
-
-    @with_logging
     def run_on_component(
         self, component: Component | str, logging_setup: LoggingSetup | None = None
     ) -> T:
@@ -340,7 +323,7 @@ class AnalysisManager:
         iterator = pixel_dataset.edgelist().iterator()
         return self._execute_on_iterator(iterator, pxl_file_target)
 
-    def _share_data(self, input_pxl_file_path: Path):
+    def _set_path_to_dataset(self, input_pxl_file_path: Path):
         for key in self.analysis_to_run.keys():
             self.analysis_to_run[key].set_dataset(input_pxl_file_path)
 
@@ -348,7 +331,7 @@ class AnalysisManager:
         self, input_pxl_file_path: Path, pxl_file_target: PxlFile
     ) -> PNAPixelDataset:
         """Execute the analysis on the provided pixel file path."""
-        self._share_data(input_pxl_file_path)
+        self._set_path_to_dataset(input_pxl_file_path)
         pixel_dataset = read(input_pxl_file_path)
         iterator = pixel_dataset.components()
         return self._execute_on_iterator(iterator, pxl_file_target)

--- a/src/pixelator/pna/graph/__init__.py
+++ b/src/pixelator/pna/graph/__init__.py
@@ -103,6 +103,7 @@ class PNAGraphBackend(NetworkXGraphBackend):
     ):
         read_count_per_node: dict[str, int] = defaultdict(int)
         node_marker_type: dict[str, str] = defaultdict(str)
+        node_type: dict[str, str] = defaultdict(str)
 
         def create_edges():
             for row in row_iterator:

--- a/src/pixelator/pna/graph/__init__.py
+++ b/src/pixelator/pna/graph/__init__.py
@@ -103,8 +103,6 @@ class PNAGraphBackend(NetworkXGraphBackend):
     ):
         read_count_per_node: dict[str, int] = defaultdict(int)
         node_marker_type: dict[str, str] = defaultdict(str)
-        node_type: dict[str, str] = defaultdict(str)
-        pixel_type: dict[str, str] = defaultdict(str)
 
         def create_edges():
             for row in row_iterator:

--- a/src/pixelator/pna/graph/__init__.py
+++ b/src/pixelator/pna/graph/__init__.py
@@ -36,6 +36,10 @@ class PNAGraph(BaseGraph):
         self._connected_components_needs_recompute = False
         self._connected_components: VertexClustering | None = None
 
+    def from_record_batches(edgelist: Iterable[pa.RecordBatch], **kwargs) -> "PNAGraph":
+        """Create a graph from record batches."""
+        return PNAGraph(PNAGraphBackend.from_record_batches(edgelist, **kwargs))
+
     def from_edgelist(edgelist: pl.LazyFrame, **kwargs):  # type: ignore
         """Create a graph from an edgelist."""
         return PNAGraph(PNAGraphBackend.from_edgelist(edgelist, **kwargs))
@@ -109,8 +113,8 @@ class PNAGraphBackend(NetworkXGraphBackend):
                 read_count_per_node[node2] += row["read_count"]
                 node_marker_type[node1] = row["marker_1"]
                 node_marker_type[node2] = row["marker_2"]
-                node_type[node1] = row["A"]
-                node_type[node2] = row["B"]
+                node_type[node1] = "A"
+                node_type[node2] = "B"
                 yield node1, node2
 
         g.add_edges_from(create_edges())
@@ -124,7 +128,7 @@ class PNAGraphBackend(NetworkXGraphBackend):
 
     @staticmethod
     def _build_graph_from_lazy_frame(g: nx.Graph, edgelist: pl.LazyFrame, **kwargs):
-        return _build_graph_from_row_iterator(
+        return PNAGraphBackend._build_graph_from_row_iterator(
             g, edgelist.collect().iter_rows(named=True), **kwargs
         )
 

--- a/src/pixelator/pna/graph/__init__.py
+++ b/src/pixelator/pna/graph/__init__.py
@@ -133,10 +133,20 @@ class PNAGraphBackend(NetworkXGraphBackend):
         )
 
     @staticmethod
-    def from_edgelist(edgelist: pl.LazyFrame, **kwargs):  # type: ignore
+    def _build_graph_from_pandas(g: nx.Graph, edgelist: pd.DataFrame, **kwargs):
+        return PNAGraphBackend._build_graph_from_row_iterator(
+            g, [edge for _, edge in edgelist.iterrows()], **kwargs
+        )
+
+    @staticmethod
+    def from_edgelist(edgelist: pl.LazyFrame | pd.DataFrame, **kwargs):  # type: ignore
         """Create a graph from an edgelist."""
         g: nx.Graph = nx.empty_graph(0, nx.Graph)
-        g = PNAGraphBackend._build_graph_from_lazy_frame(g, edgelist, **kwargs)
+        if isinstance(edgelist, pl.LazyFrame):
+            g = PNAGraphBackend._build_graph_from_lazy_frame(g, edgelist, **kwargs)
+        elif isinstance(edgelist, pd.DataFrame):
+            g = PNAGraphBackend._build_graph_from_pandas(g, edgelist, **kwargs)
+
         return PNAGraphBackend(g)
 
     @staticmethod

--- a/src/pixelator/pna/layout/__init__.py
+++ b/src/pixelator/pna/layout/__init__.py
@@ -3,11 +3,13 @@
 Copyright © 2024 Pixelgen Technologies AB.
 """
 
+import itertools
 import os
 import tempfile
 from pathlib import Path
 from typing import Iterable
 
+import pandas as pd
 import polars as pl
 import pyarrow as pa
 
@@ -64,12 +66,11 @@ class CreateLayout(PerComponentTask):
 
     def run_on_component_graph(
         self, component: PNAGraph, component_id: str
-    ) -> pl.LazyFrame:
+    ) -> list[str]:
         """Run the layout on a component.
 
-        :param component: The component to run the analysis on. Either a Graph or a LazyFrame.
-        :param component_id: The id of the component.
-        :return: a LazyFrame containing the layout data.
+        :param component: The component graph to run the analysis on.
+        :return: Name of the parquet file containing the layout data.
         :raises TypeError: If the component is not a Graph or a LazyFrame.
         """
         results = []
@@ -77,50 +78,47 @@ class CreateLayout(PerComponentTask):
             # TODO to get things working working with setting a different
             # k for pmgs w need to pass the weights from here, or change
             # the code in pixelator to have that as a parameter
-            layout = pl.DataFrame(
-                component.layout_coordinates(
-                    algo,
-                    get_node_marker_matrix=False,
-                    **self._algorithm_kwargs,
-                )
+            layout = component.layout_coordinates(
+                algo,
+                get_node_marker_matrix=False,
+                **self._algorithm_kwargs,
             )
-            layout = layout.with_columns(
-                component=pl.lit(component_id),
-                graph_projection=pl.lit("full"),
-                layout=pl.lit(algo),
-            )
+            layout["component"] = component_id
+            layout["graph_projection"] = "full"
+            layout["layout"] = algo
             results.append(layout)
 
-        concatenated = pl.concat(results, how="vertical")
+        concatenated = pd.concat(results, axis=0).reset_index(drop=True)
         tmp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".parquet")
-        concatenated.write_parquet(Path(tmp_file.name))
-        return pl.LazyFrame({"filenames": [tmp_file.name]})
+        concatenated.to_parquet(Path(tmp_file.name))
+        return [tmp_file.name]
 
     def run_on_component_edgelist(
         self, component: pa.RecordBatch | pl.LazyFrame, component_id: str
-    ) -> pl.LazyFrame:
+    ) -> list[str]:
         """Run the layout on a component.
 
         :param component: The component to run the analysis on. Either a Graph or a LazyFrame.
         :param component_id: The id of the component.
-        :return: a LazyFrame containing the layout data.
+        :return: Name of the parquet file containing the layout data.
         """
         if isinstance(component, pl.LazyFrame):
             graph = PNAGraph.from_edgelist(component)
         else:
             graph = PNAGraph.from_record_batches(component)
         result = self.run_on_component_graph(graph, component_id)
+
         return result
 
-    def concatenate_data(self, data: Iterable[pl.LazyFrame]) -> pl.LazyFrame:
+    def concatenate_data(self, data: Iterable[str]) -> list[str]:
         """Concatenate the data. Override this if you need custom concatenation behavior."""
-        return pl.concat(data, how="vertical_relaxed")
+        return list(itertools.chain.from_iterable(data))
 
-    def add_to_pixel_file(self, data: pl.LazyFrame, pxl_file_target: PxlFile) -> None:
+    def add_to_pixel_file(self, data: list[str], pxl_file_target: PxlFile) -> None:
         """Add the data in the right place in the pxl_dataset."""
-        tmp_component_files = data.collect()
-
+        paths = [Path(fname) for fname in data]
         with PixelFileWriter(pxl_file_target.path) as writer:
-            for fname in tmp_component_files["filenames"]:
-                writer.write_layouts(Path(fname), append=True)
-                os.remove(Path(fname))
+            writer.write_layouts(paths)
+
+        for fname in data:
+            os.remove(Path(fname))

--- a/src/pixelator/pna/pixeldataset/__init__.py
+++ b/src/pixelator/pna/pixeldataset/__init__.py
@@ -96,7 +96,7 @@ class Edgelist:
 
     def to_df(self) -> pd.DataFrame:
         """Get the edgelist as a pandas DataFrame."""
-        return self.to_polars().to_pandas()
+        return self._querier.read_edglist(components=self.components, as_pandas=True)
 
     def to_polars(self) -> pl.DataFrame:
         """Get the edgelist as a polars DataFrame."""
@@ -110,7 +110,7 @@ class Edgelist:
     ) -> Iterable[pa.RecordBatch]:
         """Get the edgelist as a stream of pyarrow RecordBatches."""
         return self._querier.read_edgelist_stream(
-            components=self._components, batch_size=batch_size
+            components=self.components, batch_size=batch_size
         )
 
     def _iterator(self) -> Iterable[tuple[str, pl.DataFrame]]:

--- a/src/pixelator/pna/pixeldataset/__init__.py
+++ b/src/pixelator/pna/pixeldataset/__init__.py
@@ -82,9 +82,16 @@ class Edgelist:
         """Get the component names."""
         return self._components or set(self._querier.read_all_component_names())
 
-    def _handle_backwards_compatibility(self, df: pl.DataFrame) -> pl.DataFrame:
+    def _handle_backwards_compatibility(
+        self, df: pl.DataFrame | pd.DataFrame
+    ) -> pl.DataFrame | pd.DataFrame:
         # Handle legacy marker names
-        return df.rename({"marker1": "marker_1", "marker2": "marker_2"}, strict=False)
+        if isinstance(df, pl.DataFrame):
+            return df.rename(
+                {"marker1": "marker_1", "marker2": "marker_2"}, strict=False
+            )
+        else:
+            return df.rename(columns={"marker1": "marker_1", "marker2": "marker_2"})
 
     def __len__(self) -> int:
         """Get the number of edges in the edgelist."""

--- a/src/pixelator/pna/pixeldataset/__init__.py
+++ b/src/pixelator/pna/pixeldataset/__init__.py
@@ -96,7 +96,8 @@ class Edgelist:
 
     def to_df(self) -> pd.DataFrame:
         """Get the edgelist as a pandas DataFrame."""
-        return self._querier.read_edglist(components=self.components, as_pandas=True)
+        df = self._querier.read_edgelist(components=self.components, as_pandas=True)
+        return self._handle_backwards_compatibility(df)
 
     def to_polars(self) -> pl.DataFrame:
         """Get the edgelist as a polars DataFrame."""

--- a/src/pixelator/pna/pixeldataset/io/__init__.py
+++ b/src/pixelator/pna/pixeldataset/io/__init__.py
@@ -607,7 +607,7 @@ class PixelDataQuerier:
                     components if len(components) > 1 else components[0]
                 )
             if as_pandas:
-                return connection.sql(query, params=params).pd()
+                return connection.sql(query, params=params).df()
             return connection.sql(query, params=params).pl()
 
     def read_edgelist_len(

--- a/tests/mpx/graph/test_graph.py
+++ b/tests/mpx/graph/test_graph.py
@@ -537,11 +537,11 @@ def test_layout_coordinates_3d_pmds_with_weights(pentagram_graph):
 
     l2 = np.linalg.norm(result[["x", "y", "z"]], axis=1)
     expected = [
-        974.8546,
-        974.8546,
-        1160.309,
-        974.8546,
-        1160.309,
+        2991.8175,
+        2991.8175,
+        3560.975,
+        2991.8175,
+        3560.975,
     ]
 
     assert_array_almost_equal(l2, expected, decimal=4)
@@ -562,11 +562,11 @@ def test_pmds_layout_3d_with_weights_multigraph(pentagram_graph):
 
     l2 = np.linalg.norm(result[["x", "y", "z"]], axis=1)
     expected = [
-        1160.309,
-        974.8546,
-        974.8546,
-        1160.309,
-        974.8546,
+        3560.975,
+        2991.8175,
+        2991.8175,
+        3560.975,
+        2991.8175,
     ]
 
     assert_array_almost_equal(l2, expected, decimal=4)

--- a/tests/mpx/graph/test_graph.py
+++ b/tests/mpx/graph/test_graph.py
@@ -537,11 +537,11 @@ def test_layout_coordinates_3d_pmds_with_weights(pentagram_graph):
 
     l2 = np.linalg.norm(result[["x", "y", "z"]], axis=1)
     expected = [
-        2998.85729688,
-        2998.85729688,
-        3569.35412551,
-        2998.85729688,
-        3569.35412551,
+        974.8546,
+        974.8546,
+        1160.309,
+        974.8546,
+        1160.309,
     ]
 
     assert_array_almost_equal(l2, expected, decimal=4)
@@ -562,11 +562,11 @@ def test_pmds_layout_3d_with_weights_multigraph(pentagram_graph):
 
     l2 = np.linalg.norm(result[["x", "y", "z"]], axis=1)
     expected = [
-        3569.35412551,
-        2998.85729688,
-        2998.85729688,
-        3569.35412551,
-        2998.85729688,
+        1160.309,
+        974.8546,
+        974.8546,
+        1160.309,
+        974.8546,
     ]
 
     assert_array_almost_equal(l2, expected, decimal=4)

--- a/tests/pna/graph/test_graph.py
+++ b/tests/pna/graph/test_graph.py
@@ -8,8 +8,6 @@ import pytest
 from pixelator.pna.graph import PNAGraph
 
 EDGELIST_DATA = """umi1,umi2,count,uei,marker_1,marker_2,component
-16718381540940362211,4765690112321800547,10,2210194,MarkerC,MarkerB,fc07dea9b679aca7
-16718381540940362211,13496407243000087834,10,54146122,MarkerC,MarkerB,fc07dea9b679aca7
 16718381540940362211,3120322361086630706,10,8039964,MarkerC,MarkerA,fc07dea9b679aca7
 16718381540940362211,3381206478569230700,10,40323847,MarkerC,MarkerA,fc07dea9b679aca7
 16718381540940362211,1906719288004785482,10,12428327,MarkerC,MarkerC,fc07dea9b679aca7
@@ -18,7 +16,6 @@ EDGELIST_DATA = """umi1,umi2,count,uei,marker_1,marker_2,component
 16718381540940362211,10575684261142813337,10,52561776,MarkerC,MarkerB,fc07dea9b679aca7
 16718381540940362211,11601060255102815255,10,64718951,MarkerC,MarkerC,fc07dea9b679aca7
 16718381540940362211,5412574254597463076,10,25729979,MarkerC,MarkerC,fc07dea9b679aca7
-4765690112321800547,13496407243000087834,10,76405491,MarkerB,MarkerB,fc07dea9b679aca7
 4765690112321800547,3120322361086630706,10,38367755,MarkerB,MarkerA,fc07dea9b679aca7
 4765690112321800547,3381206478569230700,10,46092159,MarkerB,MarkerA,fc07dea9b679aca7
 4765690112321800547,11449696640771709155,10,99720993,MarkerB,MarkerB,fc07dea9b679aca7
@@ -28,15 +25,11 @@ EDGELIST_DATA = """umi1,umi2,count,uei,marker_1,marker_2,component
 13496407243000087834,3120322361086630706,10,95010031,MarkerB,MarkerA,fc07dea9b679aca7
 13496407243000087834,3381206478569230700,10,65045927,MarkerB,MarkerA,fc07dea9b679aca7
 13496407243000087834,11449696640771709155,10,38892142,MarkerB,MarkerB,fc07dea9b679aca7
-3120322361086630706,3381206478569230700,10,84548057,MarkerA,MarkerA,fc07dea9b679aca7
-3120322361086630706,2986818696398050493,10,52535432,MarkerA,MarkerB,fc07dea9b679aca7
-3120322361086630706,11449696640771709155,10,37541664,MarkerA,MarkerB,fc07dea9b679aca7
 3093013882117452616,17578746049728489641,10,31024187,MarkerA,MarkerA,e7d82bca9694eea7
 3093013882117452616,5828273475010330184,10,42295915,MarkerA,MarkerB,e7d82bca9694eea7
 4633887202036215820,17578746049728489641,10,48583535,MarkerA,MarkerA,e7d82bca9694eea7
 4633887202036215820,5828273475010330184,10,71882171,MarkerA,MarkerB,e7d82bca9694eea7
 4633887202036215820,6367193580528650492,10,88948783,MarkerA,MarkerB,e7d82bca9694eea7
-17578746049728489641,6367193580528650492,10,93404351,MarkerA,MarkerB,e7d82bca9694eea7
 12237051952843152705,6006701602935914176,10,53134349,MarkerA,MarkerC,4920229146151c29
 12237051952843152705,1657631243467327470,10,35779519,MarkerA,MarkerA,4920229146151c29
 12237051952843152705,8754864093431251381,10,67273937,MarkerA,MarkerC,4920229146151c29
@@ -56,15 +49,10 @@ EDGELIST_DATA = """umi1,umi2,count,uei,marker_1,marker_2,component
 9914041027802204156,11721705052923611698,10,78709830,MarkerB,MarkerC,3770519d30f36d18
 9914041027802204156,3527325133011089308,10,31646617,MarkerB,MarkerA,3770519d30f36d18
 9914041027802204156,4489093624312168814,10,23936944,MarkerB,MarkerA,3770519d30f36d18
-11721705052923611698,4489093624312168814,10,79168886,MarkerC,MarkerA,3770519d30f36d18
-4419594517623728635,10605176534183593997,10,87648423,MarkerB,MarkerC,4920229146151c29
 4419594517623728635,8754864093431251381,10,7929971,MarkerB,MarkerC,4920229146151c29
 17533628619506136151,4489093624312168814,10,67126331,MarkerC,MarkerA,3770519d30f36d18
 10605176534183593997,1657631243467327470,10,57364873,MarkerC,MarkerA,4920229146151c29
 10605176534183593997,8754864093431251381,10,15027946,MarkerC,MarkerC,4920229146151c29
-6006701602935914176,1657631243467327470,10,86004090,MarkerC,MarkerA,4920229146151c29
-6006701602935914176,8754864093431251381,10,45033936,MarkerC,MarkerC,4920229146151c29
-1657631243467327470,8754864093431251381,10,23064220,MarkerA,MarkerC,4920229146151c29
 """
 
 
@@ -95,7 +83,7 @@ def test_graph_from_edgelist():
         16718381540940362211: {
             "marker": "MarkerC",
             "pixel_type": "A",
-            "read_count": 100,
+            "read_count": 80,
             "name": 16718381540940362211,
         },
         3093013882117452616: {
@@ -107,7 +95,7 @@ def test_graph_from_edgelist():
         4419594517623728635: {
             "marker": "MarkerB",
             "pixel_type": "A",
-            "read_count": 20,
+            "read_count": 10,
             "name": 4419594517623728635,
         },
         17533628619506136151: {
@@ -125,7 +113,7 @@ def test_graph_from_edgelist():
         3120322361086630706: {
             "marker": "MarkerA",
             "pixel_type": "B",
-            "read_count": 60,
+            "read_count": 30,
             "name": 3120322361086630706,
         },
         14716292412758382347: {
@@ -142,8 +130,8 @@ def test_graph_from_edgelist():
         },
         13496407243000087834: {
             "marker": "MarkerB",
-            "pixel_type": "B",
-            "read_count": 50,
+            "pixel_type": "A",
+            "read_count": 30,
             "name": 13496407243000087834,
         },
         1645819806523959612: {
@@ -155,7 +143,7 @@ def test_graph_from_edgelist():
         6006701602935914176: {
             "marker": "MarkerC",
             "pixel_type": "B",
-            "read_count": 30,
+            "read_count": 10,
             "name": 6006701602935914176,
         },
         9914041027802204156: {
@@ -191,37 +179,37 @@ def test_graph_from_edgelist():
         17578746049728489641: {
             "marker": "MarkerA",
             "pixel_type": "B",
-            "read_count": 30,
+            "read_count": 20,
             "name": 17578746049728489641,
         },
         1657631243467327470: {
             "marker": "MarkerA",
             "pixel_type": "B",
-            "read_count": 90,
+            "read_count": 70,
             "name": 1657631243467327470,
         },
         4765690112321800547: {
             "marker": "MarkerB",
-            "pixel_type": "B",
-            "read_count": 80,
+            "pixel_type": "A",
+            "read_count": 60,
             "name": 4765690112321800547,
         },
         10605176534183593997: {
             "marker": "MarkerC",
-            "pixel_type": "B",
-            "read_count": 30,
+            "pixel_type": "A",
+            "read_count": 20,
             "name": 10605176534183593997,
         },
         11721705052923611698: {
             "marker": "MarkerC",
             "pixel_type": "B",
-            "read_count": 30,
+            "read_count": 20,
             "name": 11721705052923611698,
         },
         11449696640771709155: {
             "marker": "MarkerB",
             "pixel_type": "B",
-            "read_count": 40,
+            "read_count": 30,
             "name": 11449696640771709155,
         },
         3527325133011089308: {
@@ -233,19 +221,19 @@ def test_graph_from_edgelist():
         4489093624312168814: {
             "marker": "MarkerA",
             "pixel_type": "B",
-            "read_count": 30,
+            "read_count": 20,
             "name": 4489093624312168814,
         },
         2986818696398050493: {
             "marker": "MarkerB",
             "pixel_type": "B",
-            "read_count": 20,
+            "read_count": 10,
             "name": 2986818696398050493,
         },
         3381206478569230700: {
             "marker": "MarkerA",
             "pixel_type": "B",
-            "read_count": 40,
+            "read_count": 30,
             "name": 3381206478569230700,
         },
         1906719288004785482: {
@@ -269,13 +257,13 @@ def test_graph_from_edgelist():
         8754864093431251381: {
             "marker": "MarkerC",
             "pixel_type": "B",
-            "read_count": 110,
+            "read_count": 90,
             "name": 8754864093431251381,
         },
         6367193580528650492: {
             "marker": "MarkerB",
             "pixel_type": "B",
-            "read_count": 20,
+            "read_count": 10,
             "name": 6367193580528650492,
         },
         10575684261142813337: {


### PR DESCRIPTION
Calculating matrix power can become very expensive for adjacancy matrices, especially when there are nodes with many (>1000) edges resulting in power matrix becoming dense. A remedy to this implemented here is to set very small values (<0.001) to 0. In addition, to be able to avoid using polars as it appears to have some issues with releasing memory, we are refactoring PNA graph step to be able to construct networkx graphs using pyarrow instead of polars.

Fixes: PNA-1175

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Existing tests pass and a large sample that was previously failining in the layout step can now go through it without issues.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated poetry.lock, and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
