### PR TITLE
MPX demux should respect cores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [x.x.x] - 2025-xx-xx
+
+### Fixed
+
+-   `pixelator single-cell demux` respects the `--cores` option.
+
 ## [0.21.4] - 2025-08-27
 
 ### Added

--- a/src/pixelator/mpx/cli/demux.py
+++ b/src/pixelator/mpx/cli/demux.py
@@ -172,7 +172,7 @@ def demux(
         mismatches=mismatches,
         barcodes=barcodes,
         min_length=min_length,
-        cores=0,  # cutadapt will choose the optimal number
+        cores=ctx.obj["CORES"],
         verbose=ctx.obj["VERBOSE"],
         sample_id=name,
     )

--- a/src/pixelator/pna/cli/common.py
+++ b/src/pixelator/pna/cli/common.py
@@ -32,7 +32,7 @@ def output_option(func):
 
 
 def threads_option(func):
-    """Decorate a click command and add the --design option."""
+    """Decorate a click command and add the --threads option."""
 
     @click.option(
         "--threads",
@@ -139,7 +139,7 @@ def panel_option(func):
         default=None,
         type=click.UNPROCESSED,
         callback=validate_panel,
-        help="The name of a  panel to load from the supported panels. Optionally, provide a path to a custom panel file.",
+        help="The name of a panel to load from the supported panels. Optionally, provide a path to a custom panel file.",
     )
     @functools.wraps(func)
     def wrapper(*args, **kwargs):


### PR DESCRIPTION
## Description

The `pixelator single-cell-mpx demux` commands was not respecting the `--cores` argument. 

Fixes: pna-1350

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

By manually running the command and checking the output logs.

## PR checklist:

- [ ] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated poetry.lock, and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
