### PR TITLE
PNA-1424: Fix demux statistics counter not accumulating `missing_pid1_pid2` counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   `pixelator single-cell demux` respects the `--cores` option.
+-    Fix a bug in `pixelator single-cell demux` where the total number of input reads
+     report in the report.json files would be slightly smaller than the actual number of reads in the input files.
 
 ### Added
 

--- a/src/pixelator/pna/demux/barcode_identifier.py
+++ b/src/pixelator/pna/demux/barcode_identifier.py
@@ -67,6 +67,7 @@ class BarcodeIdentifierStatistics:
             self.corrected += other.corrected
             self.missing_pid1 += other.missing_pid1
             self.missing_pid2 += other.missing_pid2
+            self.missing_pid1_pid2 += other.missing_pid1_pid2
             self.pid1_matches_distance_distribution += (
                 other.pid1_matches_distance_distribution
             )

--- a/tests/pna/demux/test_barcode_demuxer.py
+++ b/tests/pna/demux/test_barcode_demuxer.py
@@ -262,4 +262,4 @@ def test_marker_correction_pipeline(tmp_path, testdata_amplicon_fastq):
         threads=threads,
     )
 
-    assert (demux_output / "PNA055_Sample07_filtered_S7.failed.fq.zst").exists()
+    assert (demux_output / "PNA055_Sample07_filtered_S7.demux.failed.fq.zst").exists()

--- a/tests/pna/demux/test_barcode_demuxer.py
+++ b/tests/pna/demux/test_barcode_demuxer.py
@@ -15,6 +15,7 @@ from pixelator.pna.demux.barcode_demuxer import (
     create_barcode_group_to_batch_mapping,
     independent_marker_groups_mapping,
 )
+from pixelator.pna.demux.barcode_identifier import BarcodeIdentifierStatistics
 
 
 @pytest.fixture
@@ -214,6 +215,34 @@ def test_finalize_batched_groups_independent(demux_intermediary_dir):
     assert is_sorted(df2["marker_2"].to_numpy())
 
 
+def test_barcode_identifier_statistics_accumulation():
+    acc = BarcodeIdentifierStatistics()
+    acc.corrected = 3094
+    acc.exact = 128662
+    acc.missing_pid1 = 897
+    acc.missing_pid2 = 1794
+    acc.missing_pid1_pid2 = 8
+
+    assert acc.input == 134455
+
+    ch = BarcodeIdentifierStatistics()
+    ch.corrected = 1396
+    ch.exact = 68605
+    ch.missing_pid1 = 425
+    ch.missing_pid2 = 684
+    ch.missing_pid1_pid2 = 4
+    ch.n_in_umi1 = 0
+    ch.n_in_umi2 = 0
+
+    assert ch.input == 71114
+    assert ch.failed == 1113
+
+    acc += ch
+
+    assert acc.input == 205569
+    assert acc.failed == 2699 + 1113
+
+
 @pytest.mark.slow
 def test_marker_correction_pipeline(tmp_path, testdata_amplicon_fastq):
     input_file = testdata_amplicon_fastq
@@ -232,3 +261,5 @@ def test_marker_correction_pipeline(tmp_path, testdata_amplicon_fastq):
         save_failed=True,
         threads=threads,
     )
+
+    assert (demux_output / "PNA055_Sample07_filtered_S7.failed.fq.zst").exists()


### PR DESCRIPTION
## Description

Fix a bug in the metrics written to results.json of the PNA demux stage.
Input reads that failed because of both unrecoverable PID1 and PID2 are not properly accumulated in the failed reads statistic. The total is caluculated as passed + failed so that value too would be smaller than expected.

The number of reads that are failing in demux because of unrecoverable PID1 and PID2 is very small so most statistics were not effected in a meaningful way. (0.004 % of reads in the test sample).

Fixes: #PNA-1424

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

A new test case for the statistics accumulation.