### PR TITLE
Use pa.large_string for marker_1 / marker_2 columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `pixelator single-cell demux` respects the `--cores` option.
 -    Fix a bug in `pixelator single-cell demux` where the total number of input reads
      report in the report.json files would be slightly smaller than the actual number of reads in the input files.
+-    Fix an issue where very large samples (3k cells) could not be collapsed
+     due to the limits of the PyArrow string array type.
 
 ### Added
 

--- a/src/pixelator/pna/collapse/independent/collapser.py
+++ b/src/pixelator/pna/collapse/independent/collapser.py
@@ -331,8 +331,8 @@ class RegionCollapser:
 
     _umi1_schema = pa.schema(
         fields=[
-            pa.field("marker_1", pa.string()),
-            pa.field("marker_2", pa.string()),
+            pa.field("marker_1", pa.large_string()),
+            pa.field("marker_2", pa.large_string()),
             pa.field("read_count", pa.uint16()),
             pa.field("original_umi1", pa.uint64()),
             pa.field("original_umi2", pa.uint64()),
@@ -342,8 +342,8 @@ class RegionCollapser:
     )
     _umi2_schema = pa.schema(
         fields=[
-            pa.field("marker_1", pa.string()),
-            pa.field("marker_2", pa.string()),
+            pa.field("marker_1", pa.large_string()),
+            pa.field("marker_2", pa.large_string()),
             pa.field("read_count", pa.uint16()),
             pa.field("original_umi1", pa.uint64()),
             pa.field("original_umi2", pa.uint64()),

--- a/src/pixelator/pna/collapse/paired/collapser.py
+++ b/src/pixelator/pna/collapse/paired/collapser.py
@@ -134,8 +134,8 @@ class MoleculeCollapser:
 
     _output_schema = pa.schema(
         [
-            pa.field("marker_1", pa.string()),
-            pa.field("marker_2", pa.string()),
+            pa.field("marker_1", pa.large_string()),
+            pa.field("marker_2", pa.large_string()),
             pa.field("umi1", pa.uint64()),
             pa.field("umi2", pa.uint64()),
             pa.field("read_count", pa.int64()),
@@ -673,10 +673,10 @@ class MoleculeCollapser:
             marker2_array[:] = marker2_name
 
             records = records.add_column(
-                0, self._output_schema.field("marker_1"), pa.array(marker1_array)
+                0, self._output_schema.field("marker_1"), pa.array(marker1_array, type=pa.large_string())
             )
             records = records.add_column(
-                1, self._output_schema.field("marker_2"), pa.array(marker2_array)
+                1, self._output_schema.field("marker_2"), pa.array(marker2_array, type=pa.large_string())
             )
 
             _logger.info(

--- a/src/pixelator/pna/collapse/paired/collapser.py
+++ b/src/pixelator/pna/collapse/paired/collapser.py
@@ -673,10 +673,14 @@ class MoleculeCollapser:
             marker2_array[:] = marker2_name
 
             records = records.add_column(
-                0, self._output_schema.field("marker_1"), pa.array(marker1_array, type=pa.large_string())
+                0,
+                self._output_schema.field("marker_1"),
+                pa.array(marker1_array, type=pa.large_string()),
             )
             records = records.add_column(
-                1, self._output_schema.field("marker_2"), pa.array(marker2_array, type=pa.large_string())
+                1,
+                self._output_schema.field("marker_2"),
+                pa.array(marker2_array, type=pa.large_string()),
             )
 
             _logger.info(


### PR DESCRIPTION
Collapsing very large PID groups where the combined marker array content exceeds 2 GiB would return an error when casting to the intermediary table format for sorting.
Explicitly use pa.large_string() instead for the table schema.

## Description

Please include a summary of the change and which issue(s) have been fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes: PNA-1486

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
