### PR TITLE
No white-spaces in marker names allowed

### DIFF
--- a/src/pixelator/pna/config/panel.py
+++ b/src/pixelator/pna/config/panel.py
@@ -242,10 +242,11 @@ class PNAAntibodyPanel:
             # Markers should not contain white-spaces since this causes
             # issues in the demultiplexing step (and other places that
             # might assume that marker names are single tokens)
+            problematic_lines = panel_df.index[panel_df.index.str.contains("\s")]
             errors.append(
                 "The marker_id column should not contain white-spaces. "
                 "Please use dashes instead. Offending values: "
-                f"{panel_df.index[panel_df.index.str.contains('\s')]}"
+                f"{problematic_lines}"
             )
         return errors
 

--- a/src/pixelator/pna/config/panel.py
+++ b/src/pixelator/pna/config/panel.py
@@ -245,7 +245,7 @@ class PNAAntibodyPanel:
             problematic_lines = panel_df.index[panel_df.index.str.contains("\s")]
             errors.append(
                 "The marker_id column should not contain white-spaces. "
-                "Please use dashes instead. Offending values: "
+                "Please use dashes instead or remove the white-spaces. Offending values: "
                 f"{problematic_lines}"
             )
         return errors

--- a/src/pixelator/pna/config/panel.py
+++ b/src/pixelator/pna/config/panel.py
@@ -227,6 +227,28 @@ class PNAAntibodyPanel:
 
         return errors
 
+    @staticmethod
+    def _validate_marker_names(panel_df):
+        errors = []
+        if any(panel_df.index.str.contains("_")):
+            # Markers should not contain underscores since this messes
+            # things up with Seurat on the R side
+            errors.append(
+                "The marker_id column should not contain underscores. "
+                "Please use dashes instead. Offending values: "
+                f"{panel_df.index[panel_df.index.str.contains('_')]}"
+            )
+        if any(panel_df.index.str.contains("\s")):
+            # Markers should not contain white-spaces since this causes
+            # issues in the demultiplexing step (and other places that
+            # might assume that marker names are single tokens)
+            errors.append(
+                "The marker_id column should not contain white-spaces. "
+                "Please use dashes instead. Offending values: "
+                f"{panel_df.index[panel_df.index.str.contains('\s')]}"
+            )
+        return errors
+
     @classmethod
     def validate_antibody_panel(cls, panel_df: pd.DataFrame) -> list[str]:
         """Validate the antibody panel dataframe.
@@ -255,14 +277,7 @@ class PNAAntibodyPanel:
             errors.append(f"`{cls._INDEX_COLUMN}` is missing or is not set as index")
             return errors
 
-        if any(panel_df.index.str.contains("_")):
-            # Markers should not contain underscores since this messes
-            # things up with Seurat on the R side
-            errors.append(
-                "The marker_id column should not contain underscores. "
-                "Please use dashes instead. Offending values: "
-                f"{panel_df.index[panel_df.index.str.contains('_')]}"
-            )
+        errors += cls._validate_marker_names(panel_df)
 
         if panel_df["control"].dtype != bool:
             errors.append("`control` column is not boolean")

--- a/tests/pna/config/test_panel.py
+++ b/tests/pna/config/test_panel.py
@@ -62,6 +62,16 @@ def test_panel_validation_fails_on_underscores_in_marker_names(panel_df):
         PNAAntibodyPanel(df=panel_df, metadata=None)
 
 
+def test_panel_validation_fails_on_white_space_in_marker_names(panel_df):
+    panel_df.rename(index={"marker1": "marker 1"}, inplace=True)
+
+    with pytest.raises(
+        AssertionError,
+        match=r".*The marker_id column should not contain white-spaces.*Offending values:.*",
+    ):
+        PNAAntibodyPanel(df=panel_df, metadata=None)
+
+
 def test_panel_validation_fails_on_invalid_uniprot_ids(panel_df):
     panel_df.loc["marker1", "uniprot_id"] = "PAAAAA"
 


### PR DESCRIPTION
## Description

Validate that there are no white-spaces in the marker names.

Fixes: pna-1671

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Added new test to validate this.