### PR TITLE
Fix SyntaxWarning from white-space check

### DIFF
--- a/src/pixelator/pna/config/panel.py
+++ b/src/pixelator/pna/config/panel.py
@@ -238,11 +238,11 @@ class PNAAntibodyPanel:
                 "Please use dashes instead. Offending values: "
                 f"{panel_df.index[panel_df.index.str.contains('_')]}"
             )
-        if any(panel_df.index.str.contains("\s")):
+        if any(panel_df.index.str.contains(r"\s")):
             # Markers should not contain white-spaces since this causes
             # issues in the demultiplexing step (and other places that
             # might assume that marker names are single tokens)
-            problematic_lines = panel_df.index[panel_df.index.str.contains("\s")]
+            problematic_lines = panel_df.index[panel_df.index.str.contains(r"\s")]
             errors.append(
                 "The marker_id column should not contain white-spaces. "
                 "Please use dashes instead or remove the white-spaces. Offending values: "


### PR DESCRIPTION
## Description

I had missed this syntax warning when we added white-space checking to the panels.

Fixes: N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Check manually that is is gone.