### PR TITLE
Update polars (and move to rt64 version)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+
+-   Update polars dependency to version >=1.36 and enabling tables with >2^32 rows through `polars[rt64]`.
+
 ## [0.23.0] - 2025-12-01
 
 ### Important changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "semver>=3.0.0,<4",
     "ruamel-yaml>=0.17.21,<0.18",
     "pydantic>=2.12.4,<3.0",
-    "polars>=1.0.0,<1.27.0",
+    "polars[rt64]>=1.0.0,<2.0.0",
     "importlib-resources>=5.12.0,<6",
     "fsspec",
     "fastparquet",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "semver>=3.0.0,<4",
     "ruamel-yaml>=0.17.21,<0.18",
     "pydantic>=2.12.4,<3.0",
-    "polars[rt64]>=1.0.0,<2.0.0",
+    "polars[rt64]>=1.36.1,<2.0.0",
     "importlib-resources>=5.12.0,<6",
     "fsspec",
     "fastparquet",

--- a/src/pixelator/pna/graph/connected_components.py
+++ b/src/pixelator/pna/graph/connected_components.py
@@ -696,7 +696,8 @@ def _remove_umi_clashes_and_get_stats(input_edgelist, component_stats):
     component_stats.reads_input = raw_stat["read_count"][0]
     umi1_clashes, umi2_clashes = _find_clashing_umis(input_edgelist)
     no_clash_edgelist = input_edgelist.filter(
-        ~pl.col("umi1").is_in(umi1_clashes) & ~pl.col("umi2").is_in(umi2_clashes)
+        ~pl.col("umi1").is_in(set(umi1_clashes.to_list()))
+        & ~pl.col("umi2").is_in(set(umi2_clashes.to_list()))
     )
     post_collision_stat = (
         no_clash_edgelist.select(["read_count", "uei_count"]).sum().collect()
@@ -907,6 +908,8 @@ def _filter_connected_components_by_size(
         passing_components
     )
 
-    edgelist = edgelist.filter(pl.col("component").is_in(passing_components))
+    edgelist = edgelist.filter(
+        pl.col("component").is_in(set(passing_components.to_list()))
+    )
 
     return edgelist

--- a/src/pixelator/pna/graph/connected_components.py
+++ b/src/pixelator/pna/graph/connected_components.py
@@ -428,9 +428,9 @@ def recover_multiplets(
 
 
 def filter_components_by_size_dynamic(
-    component_sizes: pd.DataFrame,
+    component_sizes: pl.DataFrame,
     lowest_passable_bound: int | None = MIN_PNA_COMPONENT_SIZE,
-) -> tuple[pd.DataFrame, int | None]:
+) -> tuple[pl.Series, int | None]:
     """Filter components by size using dynamic thresholds.
 
     :param component_sizes: A DataFrame with columns `component` and `n_umi`.
@@ -456,7 +456,7 @@ def filter_components_by_size_dynamic(
 
 def filter_components_by_size_hard_thresholds(
     component_sizes: pd.DataFrame, lower_bound: int | None, higher_bound: int | None
-) -> pd.DataFrame:
+) -> pl.Series:
     """Filter components by size using hard thresholds.
 
     :param component_sizes: A DataFrame with columns `component` and `n_umi`.

--- a/src/pixelator/pna/graph/connected_components.py
+++ b/src/pixelator/pna/graph/connected_components.py
@@ -696,8 +696,7 @@ def _remove_umi_clashes_and_get_stats(input_edgelist, component_stats):
     component_stats.reads_input = raw_stat["read_count"][0]
     umi1_clashes, umi2_clashes = _find_clashing_umis(input_edgelist)
     no_clash_edgelist = input_edgelist.filter(
-        ~pl.col("umi1").is_in(set(umi1_clashes.to_list()))
-        & ~pl.col("umi2").is_in(set(umi2_clashes.to_list()))
+        ~pl.col("umi1").is_in(umi1_clashes) & ~pl.col("umi2").is_in(umi2_clashes)
     )
     post_collision_stat = (
         no_clash_edgelist.select(["read_count", "uei_count"]).sum().collect()
@@ -908,8 +907,6 @@ def _filter_connected_components_by_size(
         passing_components
     )
 
-    edgelist = edgelist.filter(
-        pl.col("component").is_in(set(passing_components.to_list()))
-    )
+    edgelist = edgelist.filter(pl.col("component").is_in(passing_components))
 
     return edgelist

--- a/tests/mpx/pixeldataset/test_pixeldataset.py
+++ b/tests/mpx/pixeldataset/test_pixeldataset.py
@@ -47,6 +47,7 @@ def test_pixeldataset(setup_basic_pixel_dataset):
     assert_frame_equal(
         edgelist,
         _enforce_edgelist_types(dataset.edgelist_lazy.collect().to_pandas()),
+        check_categorical=False,
     )
 
     assert_frame_equal(
@@ -101,7 +102,7 @@ def test_pixeldataset_from_file_parquet(setup_basic_pixel_dataset, tmp_path):
     dataset.save(str(file_target))
     dataset_new = PixelDataset.from_file(str(file_target))
 
-    assert_frame_equal(edgelist, dataset_new.edgelist)
+    assert_frame_equal(edgelist, dataset_new.edgelist, check_categorical=False)
     assert_frame_equal(
         edgelist,
         # Note that we need to enforce the types manually here for this to work,
@@ -109,6 +110,7 @@ def test_pixeldataset_from_file_parquet(setup_basic_pixel_dataset, tmp_path):
         # where the user will need to manage the required datatypes themselves
         # as needed.
         _enforce_edgelist_types(dataset_new.edgelist_lazy.collect().to_pandas()),
+        check_categorical=False,
     )
 
     assert_frame_equal(

--- a/tests/pna/analysis/test_analysis.py
+++ b/tests/pna/analysis/test_analysis.py
@@ -61,7 +61,10 @@ def test_proximity_analysis_jcs(pna_pxl_file: Path, pna_data_root, tmp_path):
     expected_proximity = expected_proximity.astype({"join_count": "uint32"})
 
     assert_frame_equal(
-        proximity, expected_proximity, check_like=True, check_dtype=False
+        proximity.sort_index(),
+        expected_proximity.sort_index(),
+        check_like=True,
+        check_dtype=False,
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2020,7 +2020,7 @@ dependencies = [
     { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pandas" },
     { name = "plotly" },
-    { name = "polars" },
+    { name = "polars", extra = ["rt64"] },
     { name = "pyarrow" },
     { name = "pydantic" },
     { name = "pyfastx" },
@@ -2081,7 +2081,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.0.0,<3.0.0" },
     { name = "pandas", specifier = ">=2.0.0,<3.0.0" },
     { name = "plotly" },
-    { name = "polars", extras = ["rt64"], specifier = ">=1.0.0,<2.0.0" },
+    { name = "polars", extras = ["rt64"], specifier = ">=1.36.1,<2.0.0" },
     { name = "pyarrow", specifier = ">=14" },
     { name = "pydantic", specifier = ">=2.12.4,<3.0" },
     { name = "pyfastx" },
@@ -2175,16 +2175,47 @@ wheels = [
 
 [[package]]
 name = "polars"
-version = "1.26.0"
+version = "1.36.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/c2/56a750b82e74c5af7b821215eab3ee992d9ef11310dad353f5b2086ef7db/polars-1.26.0.tar.gz", hash = "sha256:b5492d38e5ec2ae6a8853833c5a31549194a361b901134fc5f2f57b49bd563ea", size = 4522991, upload-time = "2025-03-23T11:53:37.373Z" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/dc/56f2a90c79a2cb13f9e956eab6385effe54216ae7a2068b3a6406bae4345/polars-1.36.1.tar.gz", hash = "sha256:12c7616a2305559144711ab73eaa18814f7aa898c522e7645014b68f1432d54c", size = 711993, upload-time = "2025-12-10T01:14:53.033Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/99/ce4427576a6134504e6dd58f5d411d55b228a05950c5fff5b75e90263cb1/polars-1.26.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:2afefcd356608981b2e15d46df9ddaa6e77f36095ebeb73c3261e198bd51c925", size = 34767938, upload-time = "2025-03-23T11:52:27.477Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/0a/5c9455ff271c3583bf0fd505911e5787ca7bc0f247968853cb6dcfbedffb/polars-1.26.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:587eb3c5000423eb20be998f523e605ddba0d3c598ba4a7e2a4d0b92b1fd2a7e", size = 31612374, upload-time = "2025-03-23T11:52:32.896Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/0a/c9e388b35533fc1827eaeb0f3940ba0a1058511bf77aaa689ebb1b0bef88/polars-1.26.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66c30f4b7e060c2e7f3a45d6ac94ab3b179831a2f1e629401bf7912d54311529", size = 35404704, upload-time = "2025-03-23T11:52:36.764Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/eb/b420131563a42ac0866224aa6284a356107d036c32d825c5478767a1446e/polars-1.26.0-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:110d6987d37ae954a5ef16d739fb717df9d39b144790d12d98fb3e72ed35621c", size = 32569800, upload-time = "2025-03-23T11:52:40.68Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/8d/b28ae5d63a4bafdfe81d132efc6b8d076ef2c866ecbf5d24ca3b1f53b88b/polars-1.26.0-cp39-abi3-win_amd64.whl", hash = "sha256:189a58aaf393003515fa6d83e2dea815a2b448265f2007a926274ed12672583c", size = 35617074, upload-time = "2025-03-23T11:52:44.279Z" },
-    { url = "https://files.pythonhosted.org/packages/af/21/7a76c58203f0806cb5b1155e4994693e618d4de5ca6a34388ae85267ccc4/polars-1.26.0-cp39-abi3-win_arm64.whl", hash = "sha256:58db2dce39cad5f8fc8e8c5c923a250eb21eff4146b03514d570d1c205a4874c", size = 31895936, upload-time = "2025-03-23T11:52:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/c6/36a1b874036b49893ecae0ac44a2f63d1a76e6212631a5b2f50a86e0e8af/polars-1.36.1-py3-none-any.whl", hash = "sha256:853c1bbb237add6a5f6d133c15094a9b727d66dd6a4eb91dbb07cdb056b2b8ef", size = 802429, upload-time = "2025-12-10T01:13:53.838Z" },
+]
+
+[package.optional-dependencies]
+rt64 = [
+    { name = "polars-runtime-64" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.36.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/df/597c0ef5eb8d761a16d72327846599b57c5d40d7f9e74306fc154aba8c37/polars_runtime_32-1.36.1.tar.gz", hash = "sha256:201c2cfd80ceb5d5cd7b63085b5fd08d6ae6554f922bcb941035e39638528a09", size = 2788751, upload-time = "2025-12-10T01:14:54.172Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/ea/871129a2d296966c0925b078a9a93c6c5e7facb1c5eebfcd3d5811aeddc1/polars_runtime_32-1.36.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:327b621ca82594f277751f7e23d4b939ebd1be18d54b4cdf7a2f8406cecc18b2", size = 43494311, upload-time = "2025-12-10T01:13:56.096Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/76/0038210ad1e526ce5bb2933b13760d6b986b3045eccc1338e661bd656f77/polars_runtime_32-1.36.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ab0d1f23084afee2b97de8c37aa3e02ec3569749ae39571bd89e7a8b11ae9e83", size = 39300602, upload-time = "2025-12-10T01:13:59.366Z" },
+    { url = "https://files.pythonhosted.org/packages/54/1e/2707bee75a780a953a77a2c59829ee90ef55708f02fc4add761c579bf76e/polars_runtime_32-1.36.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:899b9ad2e47ceb31eb157f27a09dbc2047efbf4969a923a6b1ba7f0412c3e64c", size = 44511780, upload-time = "2025-12-10T01:14:02.285Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b2/3fede95feee441be64b4bcb32444679a8fbb7a453a10251583053f6efe52/polars_runtime_32-1.36.1-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:d9d077bb9df711bc635a86540df48242bb91975b353e53ef261c6fae6cb0948f", size = 40688448, upload-time = "2025-12-10T01:14:05.131Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0f/e629713a72999939b7b4bfdbf030a32794db588b04fdf3dc977dd8ea6c53/polars_runtime_32-1.36.1-cp39-abi3-win_amd64.whl", hash = "sha256:cc17101f28c9a169ff8b5b8d4977a3683cd403621841623825525f440b564cf0", size = 44464898, upload-time = "2025-12-10T01:14:08.296Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/d8/a12e6aa14f63784cead437083319ec7cece0d5bb9a5bfe7678cc6578b52a/polars_runtime_32-1.36.1-cp39-abi3-win_arm64.whl", hash = "sha256:809e73857be71250141225ddd5d2b30c97e6340aeaa0d445f930e01bef6888dc", size = 39798896, upload-time = "2025-12-10T01:14:11.568Z" },
+]
+
+[[package]]
+name = "polars-runtime-64"
+version = "1.36.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/08/f287dbd8a5695ff03e9e8ea97d135c5a986b1cde887cb6fac21652e90473/polars_runtime_64-1.36.1.tar.gz", hash = "sha256:e77144090cdd13c68f125117bcad5bb9dd2c2d892897785b3375a411b73300f5", size = 2789627, upload-time = "2025-12-10T01:14:55.617Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/64/b3deb2ffc1fbc2d218c3dceda0227ae4ad5748ae4b5189e17d04215e242d/polars_runtime_64-1.36.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c8e176935b08ed595cd8056ca0c6cd271f925740cc8acefb00b59e6a54d8c7cf", size = 43358525, upload-time = "2025-12-10T01:14:14.747Z" },
+    { url = "https://files.pythonhosted.org/packages/22/19/f3b4d670911b96c6fe4235b9710464c93eefb64d37cf2e1b2e6b2b4e5308/polars_runtime_64-1.36.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:932d17d6fea10596e777e0dc4dc8e5a2303dd945aee61a9fc5f125f92a60d199", size = 39207720, upload-time = "2025-12-10T01:14:17.525Z" },
+    { url = "https://files.pythonhosted.org/packages/35/60/6a8673945827150ff16a1ae4c3249ab2d615208cef96bd1a8ab6fca9c902/polars_runtime_64-1.36.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5968655744f876fafb6b2fcb2aebe6ae55d495409fc092b56f147d219484e1c6", size = 44380668, upload-time = "2025-12-10T01:14:20.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/a7/c7c8fa57a69aa75a1c28318ad0c9a84c4dfe05cbd3b08dedcc39da25adba/polars_runtime_64-1.36.1-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:739f15c52e8b62a6e1cbd5b8a91697b664ec1ca191d4e5fb8f092b8c0515a912", size = 40568263, upload-time = "2025-12-10T01:14:23.861Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a4/5a9343b5cb2591f96c2f8cc57fee716cbc0ab32cba137427725445d6a552/polars_runtime_64-1.36.1-cp39-abi3-win_amd64.whl", hash = "sha256:b6f2feb0ff8cfd2df56b2da4437ddff537ada539357fe2baef1e9712591a82d6", size = 44348636, upload-time = "2025-12-10T01:14:27.989Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/b7/a9f0001ccf16c92969b5fc6102ce5beae3c47deb89adcce404b11f002b6e/polars_runtime_64-1.36.1-cp39-abi3-win_arm64.whl", hash = "sha256:3378cd82b8057828d2a6ea46ea9446500315bb2215aa80b85e765d2f78d013be", size = 39656016, upload-time = "2025-12-10T01:14:31.112Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2081,7 +2081,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.0.0,<3.0.0" },
     { name = "pandas", specifier = ">=2.0.0,<3.0.0" },
     { name = "plotly" },
-    { name = "polars", specifier = ">=1.0.0,<1.27.0" },
+    { name = "polars", extras = ["rt64"], specifier = ">=1.0.0,<2.0.0" },
     { name = "pyarrow", specifier = ">=14" },
     { name = "pydantic", specifier = ">=2.12.4,<3.0" },
     { name = "pyfastx" },


### PR DESCRIPTION
Updating polars to bring in the fix on false positives in is_in() function for large values and allow working with tables with over 2^32 (~4.2B) rows.

Fixes: PNA-1348

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Existing unit tests pass. The graph step was also run for a regular 1000-cell sample.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
