### PR TITLE
Adding degree distribution to collapse stats

### DIFF
--- a/src/pixelator/pna/collapse/paired/statistics.py
+++ b/src/pixelator/pna/collapse/paired/statistics.py
@@ -66,6 +66,52 @@ class CollapseSummaryStatistics(pydantic.BaseModel):
 
     read_counts_stats: SummaryStatistics | None = None
     uei_stats: SummaryStatistics | None = None
+    degree_distribution: dict[int, int] = pydantic.Field(
+        ..., description="Distributions of degrees (degree -> count)."
+    )
+
+    @staticmethod
+    def _compute_degree_distribution(df: pl.LazyFrame) -> dict[int, int]:
+        """Compute the degree distribution from a LazyFrame, combining the umi1 and umi2 degrees."""
+
+        def compute_umi_degrees(df: pl.LazyFrame, col: str) -> pl.DataFrame:
+            return (
+                df.group_by(col)
+                .agg(pl.len().alias("degree"))
+                .collect()
+                .group_by("degree")
+                .agg(pl.len().alias("count"))
+            )
+
+        def compute_combined_degrees(df: pl.LazyFrame) -> pl.DataFrame:
+            umi1_degreees = compute_umi_degrees(df, "umi1")
+            umi2_degreees = compute_umi_degrees(df, "umi2")
+            joined_degrees = (
+                umi1_degreees.join(
+                    umi2_degreees,
+                    left_on="degree",
+                    right_on="degree",
+                    how="full",
+                    suffix="_umi2",
+                    coalesce=True,
+                )
+                .fill_null(0)
+                .select(
+                    [
+                        pl.col("degree"),
+                        pl.col("count") + pl.col("count_umi2"),
+                    ]
+                )
+                .sort("degree")
+            )
+            return joined_degrees
+
+        def convert_to_dict(df: pl.DataFrame) -> dict[int, int]:
+            as_dicts = df.to_dict(as_series=False)
+            return dict(zip(as_dicts["degree"], as_dicts["count"]))
+
+        degree_df = compute_combined_degrees(df)
+        return convert_to_dict(degree_df)
 
     @staticmethod
     def from_lazy_frame(collapsed_lz_df: pl.LazyFrame):
@@ -73,10 +119,14 @@ class CollapseSummaryStatistics(pydantic.BaseModel):
         df = collapsed_lz_df.select("uei_count", "read_count").collect()
         uei_stats = SummaryStatistics.from_series(df.get_column("uei_count"))
         read_stats = SummaryStatistics.from_series(df.get_column("read_count"))
+        degree_distribution = CollapseSummaryStatistics._compute_degree_distribution(
+            collapsed_lz_df
+        )
 
         return CollapseSummaryStatistics(
             read_counts_stats=read_stats,
             uei_stats=uei_stats,
+            degree_distribution=degree_distribution,
         )
 
 

--- a/tests/pna/collapse/test_statistics.py
+++ b/tests/pna/collapse/test_statistics.py
@@ -1,0 +1,35 @@
+"""Copyright © 2025 Pixelgen Technologies AB."""
+
+from io import StringIO
+
+import polars as pl
+import pytest
+
+from pixelator.pna.collapse.paired.statistics import CollapseSummaryStatistics
+
+
+@pytest.fixture
+def collapsed_lz_df() -> pl.LazyFrame:
+    data = StringIO("""
+        marker_1,marker_2,umi1,umi2,read_count,uei_count,corrected_read_count
+        CD29,CD43,555638967335511,28226901571890329,6,2,0
+        CD29,CD43,555638967335511,14976911110869850,2,3,0
+        CD29,CD43,555638967335511,10588034069358815,2,2,0
+        B2M,CD44,1592993435260922,33899519959851077,3,1,0
+        B2M,CD5,1772702303642965,23228591926107523,6,4,1
+        CD45,CD45,1905030979812053,14976911110869850,3,2,0
+        CD82,CD82,1927887423101473,8679240914900276,1,1,0
+        CD11a,CD43,2083036410634253,10588034069358815,2,1,0
+        CD102,B2M,2092819761711040,43487857778022885,1,1,0
+        B2M,CD5,3341233760855701,65064780908590549,3,3,0""")
+    return pl.read_csv(data).lazy()
+
+
+def test_collapse_summary_statistics_from_lazy_frame(
+    collapsed_lz_df: pl.LazyFrame,
+):
+    summary_stats = CollapseSummaryStatistics.from_lazy_frame(collapsed_lz_df)
+
+    assert summary_stats.degree_distribution == {1: 13, 2: 2, 3: 1}
+    assert summary_stats.read_counts_stats.mean == 2.9
+    assert summary_stats.uei_stats.mean == 2.0


### PR DESCRIPTION
## Description

Add the degree distribution of umi1+umi2 to the collapse statistics.

Fixes: pna-1587

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce it when relevant.

## PR checklist:

- [ ] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
