### PR TITLE
Add degree distribution to collapse report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Update README with proximity network assay citation information.
+- The degree distribution of UMIs is now included in the collapse report.
 
 ## [0.23.0] - 2025-12-01
 

--- a/src/pixelator/pna/collapse/independent/combine_collapse.py
+++ b/src/pixelator/pna/collapse/independent/combine_collapse.py
@@ -6,11 +6,10 @@ Copyright © 2025 Pixelgen Technologies AB
 """
 
 import dataclasses
-from collections import Counter
+from collections import Counter, OrderedDict
 from pathlib import Path
 from typing import Iterable, MutableMapping
 
-import duckdb as dd
 from duckdb import DuckDBPyConnection
 
 from pixelator.pna.collapse.independent import (
@@ -213,9 +212,9 @@ def combine_independent_parquet_files(
         GROUP BY count
         ORDER BY count DESC
         """)
-    degree_dist_dict = {
-        degree: count for degree, count in degree_distribution.fetchall()
-    }
+    degree_dist_dict = OrderedDict(
+        (degree, count) for degree, count in degree_distribution.fetchall()
+    )
 
     stats = CombineCollapseIndependentStats(
         output_molecules=int(output_molecules),

--- a/src/pixelator/pna/collapse/independent/combine_collapse.py
+++ b/src/pixelator/pna/collapse/independent/combine_collapse.py
@@ -62,11 +62,13 @@ class CombineCollapseIndependentStats:
     Attributes:
         output_molecules: Total number of unique output molecules
         corrected_reads: Total number of corrected reads
+        degree_distribution: The node degree distribution, degree->count
 
     """
 
     output_molecules: int
     corrected_reads: int
+    degree_distribution: dict[int, int]
 
 
 def combine_independent_parquet_files(
@@ -193,8 +195,32 @@ def combine_independent_parquet_files(
 
     output_molecules, corrected_reads = res.row(0)
 
+    logger.info("Calculating degree distribution.")
+    degree_distribution = conn.sql(f"""
+        WITH edgelist AS (SELECT * FROM read_parquet('{output_file}')),
+             all_umis AS (
+                 SELECT umi1 AS umi FROM edgelist
+                 UNION ALL
+                 SELECT umi2 AS umi FROM edgelist
+             ),
+             umi_counts AS (
+                 SELECT umi, COUNT(*) AS count
+                 FROM all_umis
+                 GROUP BY umi
+             )
+        SELECT count as degree, COUNT(*) AS count
+        FROM umi_counts
+        GROUP BY count
+        ORDER BY count DESC
+        """)
+    degree_dist_dict = {
+        degree: count for degree, count in degree_distribution.fetchall()
+    }
+
     stats = CombineCollapseIndependentStats(
-        output_molecules=int(output_molecules), corrected_reads=int(corrected_reads)
+        output_molecules=int(output_molecules),
+        corrected_reads=int(corrected_reads),
+        degree_distribution=degree_dist_dict,
     )
 
     # Sorted UMI files are only intermediates and can be removed
@@ -274,6 +300,7 @@ def combine_independent_report_files(
         input_molecules=umi1_summary_stats["input_molecules"],
         corrected_reads=stats.corrected_reads,
         output_molecules=stats.output_molecules,
+        degree_distribution=stats.degree_distribution,
     )
 
     report.write_json_file(output_file, indent=4)

--- a/src/pixelator/pna/collapse/independent/combine_collapse.py
+++ b/src/pixelator/pna/collapse/independent/combine_collapse.py
@@ -61,13 +61,15 @@ class CombineCollapseIndependentStats:
     Attributes:
         output_molecules: Total number of unique output molecules
         corrected_reads: Total number of corrected reads
-        degree_distribution: The node degree distribution, degree->count
+        umi1_degree_distribution: The node degree distribution for umi1, degree->count
+        umi2_degree_distribution: The node degree distribution for umi2, degree->count
 
     """
 
     output_molecules: int
     corrected_reads: int
-    degree_distribution: dict[int, int]
+    umi1_degree_distribution: dict[int, int]
+    umi2_degree_distribution: dict[int, int]
 
 
 def combine_independent_parquet_files(
@@ -194,32 +196,15 @@ def combine_independent_parquet_files(
 
     output_molecules, corrected_reads = res.row(0)
 
-    logger.info("Calculating degree distribution.")
-    degree_distribution = conn.sql(f"""
-        WITH edgelist AS (SELECT * FROM read_parquet('{output_file}')),
-             all_umis AS (
-                 SELECT umi1 AS umi FROM edgelist
-                 UNION ALL
-                 SELECT umi2 AS umi FROM edgelist
-             ),
-             umi_counts AS (
-                 SELECT umi, COUNT(*) AS count
-                 FROM all_umis
-                 GROUP BY umi
-             )
-        SELECT count as degree, COUNT(*) AS count
-        FROM umi_counts
-        GROUP BY count
-        ORDER BY count DESC
-        """)
-    degree_dist_dict = OrderedDict(
-        (degree, count) for degree, count in degree_distribution.fetchall()
-    )
+    logger.info("Calculating degree distributions.")
+    umi1_degree_dist_dict = _compute_degree_distribution(conn, output_file, "umi1")
+    umi2_degree_dist_dict = _compute_degree_distribution(conn, output_file, "umi2")
 
     stats = CombineCollapseIndependentStats(
         output_molecules=int(output_molecules),
         corrected_reads=int(corrected_reads),
-        degree_distribution=degree_dist_dict,
+        umi1_degree_distribution=umi1_degree_dist_dict,
+        umi2_degree_distribution=umi2_degree_dist_dict,
     )
 
     # Sorted UMI files are only intermediates and can be removed
@@ -229,6 +214,28 @@ def combine_independent_parquet_files(
     conn.close()
 
     return stats
+
+
+def _compute_degree_distribution(
+    conn: DuckDBPyConnection, output_file: Path, umi_type: str
+):
+    umi1_degree_distribution = conn.sql(f"""
+        WITH edgelist AS (SELECT * FROM read_parquet('{output_file}')),
+             umi_counts AS (
+                 SELECT {umi_type} AS umi, COUNT(*) AS degree
+                 FROM edgelist
+                 GROUP BY {umi_type}
+             ),
+             umi_degree_dist AS (
+                 SELECT degree, COUNT(*) AS count
+                 FROM umi_counts
+                 GROUP BY degree
+             )
+        SELECT degree, count FROM umi_degree_dist ORDER BY degree ASC
+        """)
+    return OrderedDict(
+        (degree, count) for degree, count in umi1_degree_distribution.fetchall()
+    )
 
 
 def combine_independent_report_files(
@@ -299,7 +306,8 @@ def combine_independent_report_files(
         input_molecules=umi1_summary_stats["input_molecules"],
         corrected_reads=stats.corrected_reads,
         output_molecules=stats.output_molecules,
-        degree_distribution=stats.degree_distribution,
+        umi1_degree_distribution=stats.umi1_degree_distribution,
+        umi2_degree_distribution=stats.umi2_degree_distribution,
     )
 
     report.write_json_file(output_file, indent=4)

--- a/src/pixelator/pna/collapse/independent/report.py
+++ b/src/pixelator/pna/collapse/independent/report.py
@@ -65,6 +65,10 @@ class IndependentCollapseSampleReport(SampleReport):
         ..., description="The statistics for each marker pair."
     )
 
-    degree_distribution: dict[int, int] = pydantic.Field(
-        ..., description="The degree distribution of the UMIs."
+    umi1_degree_distribution: dict[int, int] = pydantic.Field(
+        ..., description="The degree distribution of the umi1."
+    )
+
+    umi2_degree_distribution: dict[int, int] = pydantic.Field(
+        ..., description="The degree distribution of the umi2."
     )

--- a/src/pixelator/pna/collapse/independent/report.py
+++ b/src/pixelator/pna/collapse/independent/report.py
@@ -64,3 +64,7 @@ class IndependentCollapseSampleReport(SampleReport):
     markers: list[MarkerCorrectionStats] = pydantic.Field(
         ..., description="The statistics for each marker pair."
     )
+
+    degree_distribution: dict[int, int] = pydantic.Field(
+        ..., description="The degree distribution of the UMIs."
+    )

--- a/tests/pna/collapse/snapshots/test_combine_collapse/test_combine_independent_reports/combine_independent_reports
+++ b/tests/pna/collapse/snapshots/test_combine_collapse/test_combine_independent_reports/combine_independent_reports
@@ -814,6 +814,11 @@
             "corrected_unique_umis_fraction": 0.07142857142857142
         }
     ],
+    "degree_distribution": {
+        "1": 50000,
+        "2": 20000,
+        "3": 10000
+    },
     "output_reads": 48991,
     "corrected_umi1_reads": 399,
     "corrected_umi2_reads": 960

--- a/tests/pna/collapse/snapshots/test_combine_collapse/test_combine_independent_reports/combine_independent_reports
+++ b/tests/pna/collapse/snapshots/test_combine_collapse/test_combine_independent_reports/combine_independent_reports
@@ -814,10 +814,15 @@
             "corrected_unique_umis_fraction": 0.07142857142857142
         }
     ],
-    "degree_distribution": {
+    "umi1_degree_distribution": {
         "1": 50000,
         "2": 20000,
         "3": 10000
+    },
+    "umi2_degree_distribution": {
+        "1": 60000,
+        "2": 15000,
+        "3": 5000
     },
     "output_reads": 48991,
     "corrected_umi1_reads": 399,

--- a/tests/pna/collapse/test_combine_collapse.py
+++ b/tests/pna/collapse/test_combine_collapse.py
@@ -555,25 +555,44 @@ def test_combine_independent_parquet(tmp_path, m1_collapsed_data, m2_collapsed_d
     assert combined_parquet.exists()
     assert stats.output_molecules == 118344
     assert stats.corrected_reads == 6409
-    assert stats.degree_distribution == {
-        1: 5942,
-        2: 4871,
-        3: 5073,
-        4: 4617,
-        5: 3758,
-        6: 2871,
-        7: 1872,
-        8: 1193,
-        9: 680,
-        10: 385,
-        11: 201,
-        12: 95,
-        13: 45,
-        14: 25,
-        15: 11,
-        16: 5,
+    assert stats.umi1_degree_distribution == {
+        1: 2899,
+        2: 2647,
+        3: 2700,
+        4: 2316,
+        5: 1778,
+        6: 1356,
+        7: 834,
+        8: 559,
+        9: 351,
+        10: 212,
+        11: 129,
+        12: 65,
+        13: 35,
+        14: 17,
+        15: 7,
+        16: 4,
         17: 3,
         19: 1,
+    }
+
+    assert stats.umi2_degree_distribution == {
+        1: 3043,
+        2: 2224,
+        3: 2373,
+        4: 2301,
+        5: 1980,
+        6: 1515,
+        7: 1038,
+        8: 634,
+        9: 329,
+        10: 173,
+        11: 72,
+        12: 30,
+        13: 10,
+        14: 8,
+        15: 4,
+        16: 1,
     }
 
     combined_df = pd.read_parquet(combined_parquet)
@@ -602,7 +621,8 @@ def test_combine_independent_reports(
         stats=CombineCollapseIndependentStats(
             output_molecules=70937,
             corrected_reads=1203,
-            degree_distribution={1: 50000, 2: 20000, 3: 10000},
+            umi1_degree_distribution={1: 50000, 2: 20000, 3: 10000},
+            umi2_degree_distribution={1: 60000, 2: 15000, 3: 5000},
         ),
         output_file=output_report_path,
     )

--- a/tests/pna/collapse/test_combine_collapse.py
+++ b/tests/pna/collapse/test_combine_collapse.py
@@ -555,6 +555,26 @@ def test_combine_independent_parquet(tmp_path, m1_collapsed_data, m2_collapsed_d
     assert combined_parquet.exists()
     assert stats.output_molecules == 118344
     assert stats.corrected_reads == 6409
+    assert stats.degree_distribution == {
+        1: 5942,
+        2: 4871,
+        3: 5073,
+        4: 4617,
+        5: 3758,
+        6: 2871,
+        7: 1872,
+        8: 1193,
+        9: 680,
+        10: 385,
+        11: 201,
+        12: 95,
+        13: 45,
+        14: 25,
+        15: 11,
+        16: 5,
+        17: 3,
+        19: 1,
+    }
 
     combined_df = pd.read_parquet(combined_parquet)
 
@@ -580,7 +600,9 @@ def test_combine_independent_reports(
         [m2_collapsed_report],
         sample_id=sample_name,
         stats=CombineCollapseIndependentStats(
-            output_molecules=70937, corrected_reads=1203
+            output_molecules=70937,
+            corrected_reads=1203,
+            degree_distribution={1: 50000, 2: 20000, 3: 10000},
         ),
         output_file=output_report_path,
     )

--- a/tests/pna/data/full_run/collapse/PNA055_Sample07_filtered_S7.report.json
+++ b/tests/pna/data/full_run/collapse/PNA055_Sample07_filtered_S7.report.json
@@ -4118,5 +4118,11 @@
     ],
     "output_reads": 201754,
     "corrected_umi1_reads": 1742,
-    "corrected_umi2_reads": 4682
+    "corrected_umi2_reads": 4682,
+    "degree_distribution": {
+        "1": 15045,
+        "2": 4323,
+        "3": 1860,
+        "4": 1125
+    }
 }

--- a/tests/pna/data/full_run/collapse/PNA055_Sample07_filtered_S7.report.json
+++ b/tests/pna/data/full_run/collapse/PNA055_Sample07_filtered_S7.report.json
@@ -4119,10 +4119,16 @@
     "output_reads": 201754,
     "corrected_umi1_reads": 1742,
     "corrected_umi2_reads": 4682,
-    "degree_distribution": {
+    "umi1_degree_distribution": {
         "1": 15045,
         "2": 4323,
         "3": 1860,
+        "4": 1125
+    },
+    "umi2_degree_distribution": {
+        "1": 16045,
+        "2": 3000,
+        "3": 1200,
         "4": 1125
     }
 }

--- a/tests/pna/report/snapshots/test_reporting/test_collapse_metrics_lookup/PNA055_Sample07_filtered_S7/PNA055_Sample07_filtered_S7_collapse_metrics.json
+++ b/tests/pna/report/snapshots/test_reporting/test_collapse_metrics_lookup/PNA055_Sample07_filtered_S7/PNA055_Sample07_filtered_S7_collapse_metrics.json
@@ -4116,10 +4116,16 @@
             "corrected_unique_umis_fraction": 0.19727891156462585
         }
     ],
-    "degree_distribution": {
+    "umi1_degree_distribution": {
         "1": 15045,
         "2": 4323,
         "3": 1860,
+        "4": 1125
+    },
+    "umi2_degree_distribution": {
+        "1": 16045,
+        "2": 3000,
+        "3": 1200,
         "4": 1125
     },
     "output_reads": 201754,

--- a/tests/pna/report/snapshots/test_reporting/test_collapse_metrics_lookup/PNA055_Sample07_filtered_S7/PNA055_Sample07_filtered_S7_collapse_metrics.json
+++ b/tests/pna/report/snapshots/test_reporting/test_collapse_metrics_lookup/PNA055_Sample07_filtered_S7/PNA055_Sample07_filtered_S7_collapse_metrics.json
@@ -4116,6 +4116,12 @@
             "corrected_unique_umis_fraction": 0.19727891156462585
         }
     ],
+    "degree_distribution": {
+        "1": 15045,
+        "2": 4323,
+        "3": 1860,
+        "4": 1125
+    },
     "output_reads": 201754,
     "corrected_umi1_reads": 1742,
     "corrected_umi2_reads": 4682


### PR DESCRIPTION
## Description

Add the degree distribution (of umi1 and two combined) to the combine collapse report.

Fixes: pna-1587

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Updating the tests, and running it manually.

## PR checklist:

- [ ] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
