### PR TITLE
Use a temporary folder for intermediate files in PerComponentTasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Use a temporary folder for intermediate files created during a PerComponentTask to ensure their cleanup in case of task failure.
 - Update README with proximity network assay citation information.
 - The degree distribution of UMIs is now included in the collapse report.
+
+### Fixed
+
+- Ensure temporary files are clean-up in the layout step
 
 ## [0.23.0] - 2025-12-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Use a temporary folder for intermediate files created during a PerComponentTask to ensure their cleanup in case of task failure.
 - Update README with proximity network assay citation information.
 - The degree distribution of UMIs is now included in the collapse report.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Ensure temporary files are clean-up in the layout step
+- Ensure temporary files are cleaned up in the layout step
 
 ## [0.23.0] - 2025-12-01
 

--- a/src/pixelator/pna/analysis_engine.py
+++ b/src/pixelator/pna/analysis_engine.py
@@ -231,7 +231,7 @@ class AnalysisManager:
         if pxl_dataset_builder is None:
             pxl_dataset_builder = PNAPixelDataset.from_pxl_files
         self._pxl_dataset_builder = pxl_dataset_builder
-        self._temp_folders_used = []
+        self._temp_folders_used: list[Path] = []
 
     def _execute_computations_in_parallel(
         self, component_stream: Iterable[Component | str]
@@ -342,5 +342,9 @@ class AnalysisManager:
                 pixel_dataset = read(input_pxl_file_path)
                 iterator = pixel_dataset.components()
                 return self._execute_on_iterator(iterator, pxl_file_target)
-            finally:
-                pass
+            except RuntimeError as e:
+                logger.error("An error occurred during analysis execution.")
+                logger.error(
+                    f"folder used for intermediate files (being deleted): {tmpdir}"
+                )
+                raise e

--- a/src/pixelator/pna/analysis_engine.py
+++ b/src/pixelator/pna/analysis_engine.py
@@ -6,6 +6,7 @@ Copyright © 2024 Pixelgen Technologies AB.
 import itertools
 import logging
 import multiprocessing
+import tempfile
 import typing
 from collections import defaultdict
 from dataclasses import dataclass
@@ -230,6 +231,7 @@ class AnalysisManager:
         if pxl_dataset_builder is None:
             pxl_dataset_builder = PNAPixelDataset.from_pxl_files
         self._pxl_dataset_builder = pxl_dataset_builder
+        self._temp_folders_used = []
 
     def _execute_computations_in_parallel(
         self, component_stream: Iterable[Component | str]
@@ -330,7 +332,15 @@ class AnalysisManager:
         self, input_pxl_file_path: Path, pxl_file_target: PxlFile
     ) -> PNAPixelDataset:
         """Execute the analysis on the provided pixel file path."""
-        self._set_path_to_dataset(input_pxl_file_path)
-        pixel_dataset = read(input_pxl_file_path)
-        iterator = pixel_dataset.components()
-        return self._execute_on_iterator(iterator, pxl_file_target)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._temp_folders_used.append(Path(tmpdir))
+            for analysis in self.analysis_to_run.values():
+                if hasattr(analysis, "_work_folder"):
+                    analysis._work_folder = Path(tmpdir)
+            try:
+                self._set_path_to_dataset(input_pxl_file_path)
+                pixel_dataset = read(input_pxl_file_path)
+                iterator = pixel_dataset.components()
+                return self._execute_on_iterator(iterator, pxl_file_target)
+            finally:
+                pass

--- a/src/pixelator/pna/analysis_engine.py
+++ b/src/pixelator/pna/analysis_engine.py
@@ -6,7 +6,6 @@ Copyright © 2024 Pixelgen Technologies AB.
 import itertools
 import logging
 import multiprocessing
-import tempfile
 import typing
 from collections import defaultdict
 from dataclasses import dataclass
@@ -105,6 +104,14 @@ class PerComponentTask(Protocol, Generic[T]):
     """
 
     TASK_NAME: typing.ClassVar[str]
+
+    def setup(self) -> None:
+        """Setup the analysis before running on any components."""  # noqa: D401
+        pass
+
+    def teardown(self) -> None:
+        """Teardown the analysis after running on all components."""
+        pass
 
     def set_dataset(self, pxl_file_path: Path):
         """Specify a dataset to enable analysis being run directly from component IDs."""
@@ -231,7 +238,14 @@ class AnalysisManager:
         if pxl_dataset_builder is None:
             pxl_dataset_builder = PNAPixelDataset.from_pxl_files
         self._pxl_dataset_builder = pxl_dataset_builder
-        self._temp_folders_used: list[Path] = []
+
+    def _setup(self):
+        for analysis in self.analysis_to_run.values():
+            analysis.setup()
+
+    def _teardown(self):
+        for analysis in self.analysis_to_run.values():
+            analysis.teardown()
 
     def _execute_computations_in_parallel(
         self, component_stream: Iterable[Component | str]
@@ -307,14 +321,20 @@ class AnalysisManager:
         return self._pxl_dataset_builder(pxl_file_target)  # type: ignore
 
     def _execute_on_iterator(self, iterator, pxl_file_target: PxlFile):
-        if self._n_cores is None or self._n_cores > 1:
-            per_component_results = self._execute_computations_in_parallel(iterator)
-        else:
-            per_component_results = self._execute_computations_sequentially(iterator)
-        post_processed_data = self._post_process(per_component_results)
-        pxl_dataset_with_results = self._add_to_pixel_dataset(
-            post_processed_data, pxl_file_target=pxl_file_target
-        )
+        self._setup()
+        try:
+            if self._n_cores is None or self._n_cores > 1:
+                per_component_results = self._execute_computations_in_parallel(iterator)
+            else:
+                per_component_results = self._execute_computations_sequentially(
+                    iterator
+                )
+            post_processed_data = self._post_process(per_component_results)
+            pxl_dataset_with_results = self._add_to_pixel_dataset(
+                post_processed_data, pxl_file_target=pxl_file_target
+            )
+        finally:
+            self._teardown()
         return pxl_dataset_with_results
 
     def execute(
@@ -332,19 +352,7 @@ class AnalysisManager:
         self, input_pxl_file_path: Path, pxl_file_target: PxlFile
     ) -> PNAPixelDataset:
         """Execute the analysis on the provided pixel file path."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            self._temp_folders_used.append(Path(tmpdir))
-            for analysis in self.analysis_to_run.values():
-                if hasattr(analysis, "_work_folder"):
-                    analysis._work_folder = Path(tmpdir)
-            try:
-                self._set_path_to_dataset(input_pxl_file_path)
-                pixel_dataset = read(input_pxl_file_path)
-                iterator = pixel_dataset.components()
-                return self._execute_on_iterator(iterator, pxl_file_target)
-            except RuntimeError as e:
-                logger.error("An error occurred during analysis execution.")
-                logger.error(
-                    f"folder used for intermediate files (being deleted): {tmpdir}"
-                )
-                raise e
+        self._set_path_to_dataset(input_pxl_file_path)
+        pixel_dataset = read(input_pxl_file_path)
+        iterator = pixel_dataset.components()
+        return self._execute_on_iterator(iterator, pxl_file_target)

--- a/src/pixelator/pna/layout/__init__.py
+++ b/src/pixelator/pna/layout/__init__.py
@@ -91,7 +91,7 @@ class CreateLayout(PerComponentTask):
             results.append(layout)
 
         concatenated = pd.concat(results, axis=0).reset_index(drop=True)
-        if self._work_folder is None or not os.path.exists(self._work_folder):
+        if self._work_folder is None:
             tmp_file_path = Path(
                 tempfile.NamedTemporaryFile(suffix="_layout.parquet", delete=False).name
             )

--- a/src/pixelator/pna/layout/__init__.py
+++ b/src/pixelator/pna/layout/__init__.py
@@ -32,6 +32,7 @@ class CreateLayout(PerComponentTask):
         self,
         layout_algorithms: list[SupportedLayoutAlgorithm],
         algorithm_kwargs: dict | None = None,
+        work_folder: Path | None = None,
     ) -> None:
         """Create a new CreateLayout instance.
 
@@ -42,6 +43,7 @@ class CreateLayout(PerComponentTask):
         self._layout_algorithms = layout_algorithms
         self._algorithm_kwargs = algorithm_kwargs or {}
         self.pxl_dataset: PNAPixelDataset | None = None
+        self._work_folder = work_folder
 
     def set_dataset(self, pxl_file_path: Path):
         """Specify a dataset to enable analysis being run directly from component IDs."""
@@ -89,9 +91,15 @@ class CreateLayout(PerComponentTask):
             results.append(layout)
 
         concatenated = pd.concat(results, axis=0).reset_index(drop=True)
-        tmp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".parquet")
-        concatenated.to_parquet(Path(tmp_file.name))
-        return [tmp_file.name]
+        if self._work_folder is None or not os.path.exists(self._work_folder):
+            tmp_file_path = Path(
+                tempfile.NamedTemporaryFile(suffix="_layout.parquet", delete=False).name
+            )
+        else:
+            tmp_file_path = self._work_folder / f"{component_id}_layout.parquet"
+
+        concatenated.to_parquet(tmp_file_path)
+        return [str(tmp_file_path)]
 
     def run_on_component_edgelist(
         self, component: pa.RecordBatch | pl.LazyFrame, component_id: str

--- a/src/pixelator/pna/layout/__init__.py
+++ b/src/pixelator/pna/layout/__init__.py
@@ -32,7 +32,6 @@ class CreateLayout(PerComponentTask):
         self,
         layout_algorithms: list[SupportedLayoutAlgorithm],
         algorithm_kwargs: dict | None = None,
-        work_folder: Path | None = None,
     ) -> None:
         """Create a new CreateLayout instance.
 
@@ -43,7 +42,22 @@ class CreateLayout(PerComponentTask):
         self._layout_algorithms = layout_algorithms
         self._algorithm_kwargs = algorithm_kwargs or {}
         self.pxl_dataset: PNAPixelDataset | None = None
-        self._work_folder = work_folder
+        self._work_folder: Path | None = None
+
+    def setup(self) -> None:
+        """Setup the analysis before running on any components."""  # noqa: D401
+        self._work_folder = Path(tempfile.mkdtemp(prefix="pixelator_layout_work_"))
+
+    def teardown(self) -> None:
+        """Teardown the analysis after running on all components."""
+        if self._work_folder and self._work_folder.exists():
+            for file in self._work_folder.iterdir():
+                file.unlink()
+            self._work_folder.rmdir()
+
+    def get_work_folder(self) -> Path | None:
+        """Get the work folder used for temporary files during analysis."""
+        return self._work_folder
 
     def set_dataset(self, pxl_file_path: Path):
         """Specify a dataset to enable analysis being run directly from component IDs."""
@@ -92,13 +106,12 @@ class CreateLayout(PerComponentTask):
 
         concatenated = pd.concat(results, axis=0).reset_index(drop=True)
         if self._work_folder is None:
-            tmp_file_path = Path(
-                tempfile.NamedTemporaryFile(suffix="_layout.parquet", delete=False).name
+            raise RuntimeError(
+                "Work folder is not set up. Clean call setup before running the task."
             )
-        else:
-            tmp_file_path = self._work_folder / f"{component_id}_layout.parquet"
-
+        tmp_file_path = self._work_folder / f"{component_id}_layout.parquet"
         concatenated.to_parquet(tmp_file_path)
+
         return [str(tmp_file_path)]
 
     def run_on_component_edgelist(

--- a/tests/pna/layout/test_layout.py
+++ b/tests/pna/layout/test_layout.py
@@ -1,5 +1,6 @@
 """Copyright © 2025 Pixelgen Technologies AB."""
 
+import os
 from pathlib import Path
 
 import pytest
@@ -81,3 +82,10 @@ def test_layout_from_path(pna_pxl_dataset: PNAPixelDataset, tmp_path):
     )
     assert "A" in set(result["pixel_type"].to_list())
     assert "B" in set(result["pixel_type"].to_list())
+
+    assert len(manager._temp_folders_used) == 1, (
+        "Expected one temporary folder to be used."
+    )
+    assert os.path.exists(manager._temp_folders_used[0]) is False, (
+        f"Temporary folder {manager._temp_folders_used[0]} was not cleaned up."
+    )

--- a/tests/pna/layout/test_layout.py
+++ b/tests/pna/layout/test_layout.py
@@ -86,6 +86,6 @@ def test_layout_from_path(pna_pxl_dataset: PNAPixelDataset, tmp_path):
     assert len(manager._temp_folders_used) == 1, (
         "Expected one temporary folder to be used."
     )
-    assert os.path.exists(manager._temp_folders_used[0]) is False, (
+    assert not os.path.exists(manager._temp_folders_used[0]), (
         f"Temporary folder {manager._temp_folders_used[0]} was not cleaned up."
     )

--- a/tests/pna/layout/test_layout.py
+++ b/tests/pna/layout/test_layout.py
@@ -49,13 +49,10 @@ def test_layout(pna_pxl_dataset: PNAPixelDataset, tmp_path):
 
 @pytest.mark.slow
 def test_layout_from_path(pna_pxl_dataset: PNAPixelDataset, tmp_path):
-    manager = AnalysisManager(
-        [
-            CreateLayout(
-                ["wpmds_3d"],
-            )
-        ]
+    layout_task = CreateLayout(
+        ["wpmds_3d"],
     )
+    manager = AnalysisManager([layout_task])
 
     pna_pixel_filtered = pna_pxl_dataset.filter(
         components=pna_pxl_dataset.adata().obs.index[:2]
@@ -83,9 +80,5 @@ def test_layout_from_path(pna_pxl_dataset: PNAPixelDataset, tmp_path):
     assert "A" in set(result["pixel_type"].to_list())
     assert "B" in set(result["pixel_type"].to_list())
 
-    assert len(manager._temp_folders_used) == 1, (
-        "Expected one temporary folder to be used."
-    )
-    assert not os.path.exists(manager._temp_folders_used[0]), (
-        f"Temporary folder {manager._temp_folders_used[0]} was not cleaned up."
-    )
+    # Make sure we have clean out the work directory
+    assert not layout_task.get_work_folder().exists()  # type: ignore

--- a/tests/pna/test_analysis_engine.py
+++ b/tests/pna/test_analysis_engine.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+from pixelator.pna.analysis_engine import AnalysisManager, PerComponentTask
+from pixelator.pna.pixeldataset import PixelDatasetSaver, PNAPixelDataset
+
+
+class FailingTask(PerComponentTask):
+    """A task that simulates failure during execution."""
+
+    TASK_NAME = "failing_task"
+
+    def __init__(self, work_folder: Path | None = None):
+        super().__init__()
+        self._work_folder = work_folder
+
+    def run_from_component_id(self, component_id: str):
+        raise RuntimeError("Simulated failure")
+
+
+def test_tempfile_cleanup_on_failure(pna_pxl_dataset: PNAPixelDataset, tmp_path):
+    manager = AnalysisManager(
+        [
+            FailingTask(),
+        ]
+    )
+    pna_pixel_filtered = pna_pxl_dataset.filter(
+        components=pna_pxl_dataset.adata().obs.index[:2]
+    )
+
+    pxl_file_target = PixelDatasetSaver(pxl_dataset=pna_pixel_filtered).save(
+        "PNA055_Sample07_S7", Path(tmp_path) / "layout.pxl"
+    )
+    try:
+        dataset = manager.execute_from_path(pxl_file_target.path, pxl_file_target)
+    except RuntimeError as e:
+        assert str(e) == "Simulated failure", "Unexpected error message."
+        assert manager._temp_folders_used, "No temporary folders were used."
+        for temp_folder in manager._temp_folders_used:
+            assert not temp_folder.exists(), (
+                f"Temporary folder {temp_folder} was not cleaned up."
+            )

--- a/tests/pna/test_analysis_engine.py
+++ b/tests/pna/test_analysis_engine.py
@@ -1,3 +1,5 @@
+"""Copyright © 2026 Pixelgen Technologies AB."""
+
 from pathlib import Path
 
 from pixelator.pna.analysis_engine import AnalysisManager, PerComponentTask
@@ -11,18 +13,22 @@ class FailingTask(PerComponentTask):
 
     def __init__(self, work_folder: Path | None = None):
         super().__init__()
-        self._work_folder = work_folder
+        self._setup_was_called = False
+        self._teardown_was_called = False
+
+    def setup(self) -> None:
+        self._setup_was_called = True
+
+    def teardown(self) -> None:
+        self._teardown_was_called = True
 
     def run_from_component_id(self, component_id: str):
         raise RuntimeError("Simulated failure")
 
 
 def test_tempfile_cleanup_on_failure(pna_pxl_dataset: PNAPixelDataset, tmp_path):
-    manager = AnalysisManager(
-        [
-            FailingTask(),
-        ]
-    )
+    mock_task = FailingTask()  # type: ignore
+    manager = AnalysisManager([mock_task])
     pna_pixel_filtered = pna_pxl_dataset.filter(
         components=pna_pxl_dataset.adata().obs.index[:2]
     )
@@ -33,9 +39,5 @@ def test_tempfile_cleanup_on_failure(pna_pxl_dataset: PNAPixelDataset, tmp_path)
     try:
         dataset = manager.execute_from_path(pxl_file_target.path, pxl_file_target)
     except RuntimeError as e:
-        assert str(e) == "Simulated failure", "Unexpected error message."
-        assert manager._temp_folders_used, "No temporary folders were used."
-        for temp_folder in manager._temp_folders_used:
-            assert not temp_folder.exists(), (
-                f"Temporary folder {temp_folder} was not cleaned up."
-            )
+        assert mock_task._setup_was_called, "Setup was not called before failure."
+        assert mock_task._teardown_was_called, "Teardown was not called after failure"


### PR DESCRIPTION
This PR enables using a temporary folder for intermediate files created during a PerComponentTask to ensure their cleanup in case of task failure. This is applied to the layout step which is already using such intermediate files.

Fixes: PNA-1327

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Existing tests and a new test for cheching that cleanup happens in the case where the PerComponentTask fails.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
