### PR TITLE
remove warning for manual component size threshold setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update README with proximity network assay citation information.
 - The degree distribution of UMIs is now included in the collapse report.
 
+### Changed
+
+- Remove the warning when setting minimum size manually. It is observed that 8000 is a
+  reliable minimum size for components.
+
 ### Fixed
 
 - Ensure temporary files are cleaned up in the layout step

--- a/src/pixelator/pna/cli/graph.py
+++ b/src/pixelator/pna/cli/graph.py
@@ -298,12 +298,6 @@ def graph(
         else True
     )
 
-    if isinstance(component_size_threshold, tuple):
-        logger.warning(
-            "You have explicitly set component size thresholds. This is normally not needed. "
-            "Please make sure you know what you are doing."
-        )
-
     try:
         _, component_statics = build_pxl_file_with_components(
             molecules_lazy_frame=pl.scan_parquet(


### PR DESCRIPTION
We have observed from a variety of cell types that setting minimum component size to 8000 UMIs is a robust threshold for cell calling. So, we are now removing the warning when the graph step is run having --component-size-min-threshold set manually.  

Fixes: #PNA-1966

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Existing tests.

## PR checklist:

- [x] This comment contains a description of changes (with reason).