### PR TITLE
Ensure that additional adata columns are not removed in the denoise step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Ensure that additional adata columns are not removed in the denoise step.
 - Ensure temporary files are cleaned up in the layout step
 - Droped UMI tools as dependency to avoid build issues
 

--- a/src/pixelator/pna/analysis/denoise.py
+++ b/src/pixelator/pna/analysis/denoise.py
@@ -20,7 +20,7 @@ from scipy.stats import fisher_exact
 
 from pixelator.common.annotate.aggregates import call_aggregates
 from pixelator.pna.analysis_engine import PerComponentTask
-from pixelator.pna.anndata import pna_edgelist_to_anndata, add_missing_adata_info
+from pixelator.pna.anndata import add_missing_adata_info, pna_edgelist_to_anndata
 from pixelator.pna.config import pna_config
 from pixelator.pna.config.panel import PNAAntibodyPanel, load_antibody_panel
 from pixelator.pna.graph import PNAGraph
@@ -28,16 +28,6 @@ from pixelator.pna.pixeldataset import PNAPixelDataset, PxlFile
 from pixelator.pna.pixeldataset.io import PixelFileWriter
 
 logger = logging.getLogger(__name__)
-
-
-def _add_missing_adata_info(new_adata, old_adata):
-    missing_obs = set(old_adata.obs.columns) - set(new_adata.obs.columns)
-    missing_var = set(old_adata.var.columns) - set(new_adata.var.columns)
-
-    new_adata.obs = new_adata.obs.join(old_adata.obs[list(missing_obs)], how="left")
-    new_adata.var = new_adata.var.join(old_adata.var[list(missing_var)], how="left")
-
-    return new_adata
 
 
 def _calculate_core_marker_counts(
@@ -366,7 +356,7 @@ class DenoiseOneCore(PerComponentTask):
                 writer.write_edgelist(Path(denoised_edgelist_path))
                 adata = pna_edgelist_to_anndata(writer.get_connection(), panel)
                 call_aggregates(adata)
-                adata = _add_missing_adata_info(adata, old_adata)
+                adata = add_missing_adata_info(adata, old_adata)
                 denoise_info = pd.DataFrame(index=adata.obs.index)
                 denoise_info["disqualified_for_denoising"] = False
                 denoise_info.loc[

--- a/src/pixelator/pna/analysis/denoise.py
+++ b/src/pixelator/pna/analysis/denoise.py
@@ -30,6 +30,16 @@ from pixelator.pna.pixeldataset.io import PixelFileWriter
 logger = logging.getLogger(__name__)
 
 
+def _add_missing_adata_info(new_adata, old_adata):
+    missing_obs = set(old_adata.obs.columns) - set(new_adata.obs.columns)
+    missing_var = set(old_adata.var.columns) - set(new_adata.var.columns)
+
+    new_adata.obs = new_adata.obs.join(old_adata.obs[list(missing_obs)], how="left")
+    new_adata.var = new_adata.var.join(old_adata.var[list(missing_var)], how="left")
+
+    return new_adata
+
+
 def _calculate_core_marker_counts(
     node_marker_counts: pd.DataFrame, node_core_numbers: pd.Series
 ) -> pd.DataFrame:
@@ -335,6 +345,7 @@ class DenoiseOneCore(PerComponentTask):
 
         """
         pxl = PNAPixelDataset.from_files(pxl_file_target)
+        old_adata = pxl.adata()
         try:
             panel = PNAAntibodyPanel.from_pxl(pxl_file_target.path)
         except KeyError:
@@ -355,6 +366,7 @@ class DenoiseOneCore(PerComponentTask):
                 writer.write_edgelist(Path(denoised_edgelist_path))
                 adata = pna_edgelist_to_anndata(writer.get_connection(), panel)
                 call_aggregates(adata)
+                adata = _add_missing_adata_info(adata, old_adata)
                 denoise_info = pd.DataFrame(index=adata.obs.index)
                 denoise_info["disqualified_for_denoising"] = False
                 denoise_info.loc[

--- a/src/pixelator/pna/analysis/denoise.py
+++ b/src/pixelator/pna/analysis/denoise.py
@@ -20,7 +20,7 @@ from scipy.stats import fisher_exact
 
 from pixelator.common.annotate.aggregates import call_aggregates
 from pixelator.pna.analysis_engine import PerComponentTask
-from pixelator.pna.anndata import pna_edgelist_to_anndata
+from pixelator.pna.anndata import pna_edgelist_to_anndata, add_missing_adata_info
 from pixelator.pna.config import pna_config
 from pixelator.pna.config.panel import PNAAntibodyPanel, load_antibody_panel
 from pixelator.pna.graph import PNAGraph

--- a/src/pixelator/pna/anndata.py
+++ b/src/pixelator/pna/anndata.py
@@ -210,3 +210,14 @@ def pna_edgelist_to_anndata(
     adata.obs["intracellular_fraction"] = 0.0
 
     return adata
+
+
+def add_missing_adata_info(new_adata, old_adata):
+    """Add missing obs and var columns from old_adata to new_adata."""
+    missing_obs = set(old_adata.obs.columns) - set(new_adata.obs.columns)
+    missing_var = set(old_adata.var.columns) - set(new_adata.var.columns)
+
+    new_adata.obs = new_adata.obs.join(old_adata.obs[list(missing_obs)], how="left")
+    new_adata.var = new_adata.var.join(old_adata.var[list(missing_var)], how="left")
+
+    return new_adata

--- a/tests/pna/conftest.py
+++ b/tests/pna/conftest.py
@@ -252,6 +252,7 @@ def uns_data_fixture():
 def adata_data_func():
     X = pd.read_csv(StringIO(ADATA_X), index_col="component")
     obs = pd.read_csv(StringIO(ADATA_OBS), index_col="component")
+    obs["dummy_column"] = "dummy_value"
     var = pd.read_csv(StringIO(ADATA_VAR), index_col="marker_id").fillna("")
     var["control"] = var["control"].map(lambda s: s.lower() == "yes")
 

--- a/tests/pna/denoise/test_denoise_cli.py
+++ b/tests/pna/denoise/test_denoise_cli.py
@@ -35,3 +35,4 @@ def test_denoise_runs_ok(pxl_file):
 
         result = read(Path(output_dir) / "denoise" / "file.denoised_graph.pxl")
         assert not result.adata().obs["disqualified_for_denoising"].any()
+        assert "dummy_column" in result.adata().obs.columns


### PR DESCRIPTION
Information added to adata are removed in the denoise step. This happens because marker adata is recalculated since denoising changes marker counts for each component and some of the statistics should be recalculated. The fix is to add back any columns that are missing in the new adata from the old adata.

Fixes: #PNA-2075

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

We now add a dummy column before denoising and check if it still exists after denoising.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
