### PR TITLE
feat: add progress msgs to log for non-tyy runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add progress status updates to the log for `amplicon` and `demux` steps in case of non-tty runs, handled by `LogProgress` utility class.
 - Update README with proximity network assay citation information.
 - The degree distribution of UMIs is now included in the collapse report.
 

--- a/src/pixelator/common/utils/log_progress.py
+++ b/src/pixelator/common/utils/log_progress.py
@@ -1,0 +1,78 @@
+"""Logging utility for reporting progress updates in long-running operations.
+
+Copyright © 2026 Pixelgen Technologies AB.
+"""
+
+import time
+from logging import Logger
+
+
+class LogProgress:
+    """Utility for logging progress updates at a controlled interval.
+
+    This class helps track and log the progress of processing items in a loop or batch job.
+    It periodically writes progress messages to the provided logger, including elapsed time,
+    items processed, and processing speed.
+    """
+
+    def __init__(
+        self,
+        logger: Logger,
+        min_update_intervall_seconds: float = 60.0,
+        item_name: str = "read",
+    ):
+        """Initialize a LogProgress instance.
+
+        :param logger: Logger object to which progress messages will be written.
+        :param min_update_intervall_seconds: Minimum seconds between log updates (default: 60).
+        :param item_name: Name of the item being processed (default: "read").
+        """
+        self.logger = logger
+        self.min_update_intervall_seconds = min_update_intervall_seconds
+        self.item_name = item_name
+        self.n_items = 0
+        self.start_time = time.time()
+        self.last_time = self.start_time
+        self.last_n_items = 0
+
+    def update(self, increment_items: int, final_update: bool = False):
+        """Update the progress and log a message if enough time has passed or if final update.
+
+        :param increment_items: Number of items processed since the last update.
+        :param final_update: If True, forces a final log update regardless of interval (default: False).
+        """
+        self.n_items += increment_items
+        now = time.time()
+        time_delta = now - (self.start_time if final_update else self.last_time)
+        delta_items = self.n_items if final_update else self.n_items - self.last_n_items
+        if delta_items < 1:
+            return
+        if time_delta == 0:
+            return
+        if not final_update:
+            if time_delta < self.min_update_intervall_seconds:
+                return
+
+        seconds_since_start = now - self.start_time
+        hours = int(seconds_since_start) // 3600
+        minutes = (int(seconds_since_start) - hours * 3600) // 60
+        seconds = int(seconds_since_start) % 60
+        items_per_second = delta_items / time_delta
+        seconds_per_item = time_delta / delta_items
+
+        self.logger.info(
+            ("Progress: " if not final_update else "FINISHED: ")
+            + f"{hours:02d}:{minutes:02d}:{seconds:02d} "
+            + f"{self.n_items:13,d} {self.item_name}s "
+            + f"@ {seconds_per_item * 1e6:5.1F} us/{self.item_name}; "
+            + f"{items_per_second * 60 / 1e6:6.2F} M {self.item_name}s/minute"
+        )
+        self.last_time = now
+        self.last_n_items = self.n_items
+
+    def close(self):
+        """Log a final progress update and close the progress logger.
+
+        This should be called at the end of processing to ensure the last update is logged.
+        """
+        self.update(0, final_update=True)

--- a/src/pixelator/common/utils/log_progress.py
+++ b/src/pixelator/common/utils/log_progress.py
@@ -19,16 +19,21 @@ class LogProgress:
         self,
         logger: Logger,
         min_update_intervall_seconds: float = 60.0,
+        min_update_intervall_items: int = 1,
         item_name: str = "read",
     ):
         """Initialize a LogProgress instance.
 
-        :param logger: Logger object to which progress messages will be written.
-        :param min_update_intervall_seconds: Minimum seconds between log updates (default: 60).
-        :param item_name: Name of the item being processed (default: "read").
+        Args:
+            logger (Logger): Logger object to which progress messages will be written.
+            min_update_intervall_seconds (float, optional): Minimum seconds between log updates. Defaults to 60.
+            min_update_intervall_items (int, optional): Minimum number of items between log updates. Defaults to 1.
+            item_name (str, optional): Name of the item being processed. Defaults to "read".
+
         """
         self.logger = logger
         self.min_update_intervall_seconds = min_update_intervall_seconds
+        self.min_update_intervall_items = min_update_intervall_items
         self.item_name = item_name
         self.n_items = 0
         self.start_time = time.time()
@@ -38,16 +43,16 @@ class LogProgress:
     def update(self, increment_items: int, final_update: bool = False):
         """Update the progress and log a message if enough time has passed or if final update.
 
-        :param increment_items: Number of items processed since the last update.
-        :param final_update: If True, forces a final log update regardless of interval (default: False).
+        Args:
+            increment_items (int): Number of items processed since the last update.
+            final_update (bool, optional): If True, forces a final log update regardless of interval. Defaults to False.
+
         """
         self.n_items += increment_items
         now = time.time()
         time_delta = now - (self.start_time if final_update else self.last_time)
         delta_items = self.n_items if final_update else self.n_items - self.last_n_items
-        if delta_items < 1:
-            return
-        if time_delta == 0:
+        if delta_items < self.min_update_intervall_items:
             return
         if not final_update:
             if time_delta < self.min_update_intervall_seconds:

--- a/src/pixelator/pna/amplicon/process.py
+++ b/src/pixelator/pna/amplicon/process.py
@@ -17,6 +17,7 @@ from cutadapt.modifiers import (
 from cutadapt.steps import PairedEndStep, SingleEndFilter, SingleEndSink, SingleEndStep
 from cutadapt.utils import DummyProgress, Progress
 
+from pixelator.common.utils.log_progress import LogProgress
 from pixelator.pna.amplicon.build_amplicon import (
     PairedEndAmpliconBuilder,
     SingleEndAmpliconBuilder,
@@ -218,7 +219,7 @@ def amplicon_fastq(
     if sys.stderr.isatty():
         progress = Progress()
     else:
-        progress = DummyProgress()
+        progress = LogProgress(logger)
 
     n_workers = max(1, threads - write_threads)
     logging.info("Running pipeline with %s worker threads", n_workers)

--- a/src/pixelator/pna/demux/process.py
+++ b/src/pixelator/pna/demux/process.py
@@ -19,6 +19,7 @@ from cutadapt.utils import DummyProgress, Progress
 
 from pixelator.common.exceptions import PixelatorBaseException
 from pixelator.common.utils import get_sample_name
+from pixelator.common.utils.log_progress import LogProgress
 from pixelator.pna.config import PNAAntibodyPanel, PNAAssay
 from pixelator.pna.demux.barcode_demuxer import (
     BarcodeDemuxer,
@@ -116,7 +117,7 @@ def correct_marker_barcodes(
     if sys.stderr.isatty():
         progress = Progress()
     else:
-        progress = DummyProgress()
+        progress = LogProgress(logger)
 
     n_workers = max(1, threads - compression_threads)
     logger.info("Correcting barcodes using %s worker threads", n_workers)
@@ -227,7 +228,11 @@ def demux_barcode_groups(
         output_directory=output_dir,
         filename_policy=filename_policy,
     )
-    progress = Progress()
+
+    if sys.stderr.isatty():
+        progress = Progress()
+    else:
+        progress = LogProgress(logger)
 
     logger.info("Demuxing with %s worker threads", worker_threads)
 


### PR DESCRIPTION
## Description
Add progress update info messages to log for non-tyy runs.
When running un an environment without tty progress updates might be missing from the output.

Fixes: PNA-2100

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## PR checklist:
- [x] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
