### PR TITLE
use UINT64 for counts in collapse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Use 64-bit unsigned integers for counts in collapse step to support >4.2B reads.
 - Remove the warning when setting minimum size manually. It is observed that 8000 is a
   reliable minimum size for components.
 

--- a/src/pixelator/pna/collapse/independent/combine_collapse.py
+++ b/src/pixelator/pna/collapse/independent/combine_collapse.py
@@ -171,9 +171,9 @@ def combine_independent_parquet_files(
         """
         CREATE OR REPLACE TEMP VIEW combined_data AS
             SELECT marker_1, marker_2, umi1, umi2,
-                sum(read_count)::UINTEGER as read_count,
+                sum(read_count)::UINT64 as read_count,
                 count(DISTINCT uei)::USMALLINT as uei_count,
-                ifnull(sum("read_count") FILTER ( umi1_data.umi1_is_corrected OR umi2_data.umi2_is_corrected ), 0)::UINTEGER as corrected_read_count
+                ifnull(sum("read_count") FILTER ( umi1_data.umi1_is_corrected OR umi2_data.umi2_is_corrected ), 0)::UINT64 as corrected_read_count
             FROM umi1_data POSITIONAL JOIN umi2_data
             GROUP BY marker_1, marker_2, umi1, umi2
         """
@@ -188,8 +188,8 @@ def combine_independent_parquet_files(
     # Another pass to collect some stats needed for the reports
     res = conn.sql(
         f"""
-        SELECT sum(uei_count)::UINTEGER as output_molecules,
-               sum(corrected_read_count)::UINTEGER as corrected_reads
+        SELECT sum(uei_count)::UINT64 as output_molecules,
+               sum(corrected_read_count)::UINT64 as corrected_reads
         FROM read_parquet('{output_file}')
         """
     ).pl()


### PR DESCRIPTION
To support cases where reads, UEIs, and/or UMIs are higher than 4.2B we will use 64-bit unsigned integers for count parameters in the collapse step.

Fixes: PNA-2178

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This was tested on a sample with >4.5B reads.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
