### PR TITLE
Prepare 0.24.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.24.0] - 2026-03-16
+
+### Added
+
 - Add progress status updates to the log for `amplicon` and `demux` steps in case of non-tty runs, handled by `LogProgress` utility class.
 - Update README with proximity network assay citation information.
 - The degree distribution of UMIs is now included in the collapse report.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [x.x.x] - 2026-xx-xx
-
-### Added
-
-### Changed
-
-### Fixed
-
 ## [0.24.0] - 2026-03-16
 
 ### Added


### PR DESCRIPTION
Prepare the 0.24.0 release:

## [0.24.0] - 2026-03-16

### Added

- Add progress status updates to the log for `amplicon` and `demux` steps in case of non-tty runs, handled by `LogProgress` utility class.
- Update README with proximity network assay citation information.
- The degree distribution of UMIs is now included in the collapse report.
- New logging messages about the amount of shared memory requested and available from the collapse step
- Add `DownloadableDatasets` helper to download example datasets

### Changed

- Use 64-bit unsigned integers for counts in collapse step to support >4.2B reads.
- Remove the warning when setting minimum size manually. It is observed that 8000 is a
  reliable minimum size for components.

### Fixed

- Ensure that additional adata columns are not removed in the denoise step.
- Ensure temporary files are cleaned up in the layout step.
- Droped UMI tools as dependency to avoid build issues.
- Filtering was not working consistently across all data modalities of the pixeldataset