### PR TITLE
fix: 4bit unpacking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [x.x.x] - 2026-xx-xx
+
+### Added
+
+### Changed
+
+### Fixed
+- Fix bug in unpacking 4bit packed sequences.
+
 ## [0.24.0] - 2026-03-16
 
 ### Added

--- a/src/pixelator/pna/utils/two_bit_encoding.py
+++ b/src/pixelator/pna/utils/two_bit_encoding.py
@@ -19,13 +19,13 @@ _int2str: bytes = b"ACGT"
 
 
 _STR2INT_4: dict[int, np.uint64] = {
-    ord("A"): np.uint64(0b0110),
-    ord("C"): np.uint64(0b0101),
-    ord("T"): np.uint64(0b0011),
+    ord("A"): np.uint64(0b0011),
+    ord("C"): np.uint64(0b0010),
+    ord("T"): np.uint64(0b0001),
     ord("G"): np.uint64(0b0000),
-    ord("N"): np.uint64(0b1111),
+    ord("N"): np.uint64(0b0100),
 }
-_int2str_4: bytes = b"ACTG"
+_int2str_4: bytes = b"GTCAN"
 
 
 def _int2chars(value: np.uint64) -> bytes:
@@ -74,7 +74,7 @@ def pack_4bits(kmer: bytes) -> np.uint64:
     assert len(kmer) <= 16
 
     value = np.uint64(0)
-    for c in kmer[:16]:
+    for c in kmer[16::-1]:
         value <<= np.uint(4)
         value |= _STR2INT_4[c]
     return np.uint64(value)

--- a/src/pixelator/pna/utils/two_bit_encoding.py
+++ b/src/pixelator/pna/utils/two_bit_encoding.py
@@ -19,13 +19,13 @@ _int2str: bytes = b"ACGT"
 
 
 _STR2INT_4: dict[int, np.uint64] = {
-    ord("A"): np.uint64(0b0011),
-    ord("C"): np.uint64(0b0010),
-    ord("T"): np.uint64(0b0001),
+    ord("A"): np.uint64(0b0110),
+    ord("C"): np.uint64(0b0101),
+    ord("T"): np.uint64(0b0011),
     ord("G"): np.uint64(0b0000),
-    ord("N"): np.uint64(0b0100),
+    ord("N"): np.uint64(0b1111),
 }
-_int2str_4: bytes = b"GTCAN"
+_int2str_4 = {v: k for k, v in _STR2INT_4.items()}
 
 
 def _int2chars(value: np.uint64) -> bytes:
@@ -75,7 +75,7 @@ def pack_4bits(kmer: bytes) -> np.uint64:
     assert len(kmer) <= 16
 
     value = np.uint64(0)
-    for c in kmer[16::-1]:
+    for c in kmer[:16]:
         value <<= np.uint(4)
         value |= _STR2INT_4[c]
     return np.uint64(value)
@@ -102,7 +102,7 @@ def unpack_4bits(packed: int, k: np.uint64) -> bytes:
     :param k: the length of the kmer
     """
     seq = bytearray(k)
-    for i in range(k):
-        seq[i] = _int2str_4[packed & 15]
+    for i in range(k - 1, -1, -1):
+        seq[i] = _int2str_4[packed & 15]  # type: ignore
         packed >>= 4
     return bytes(seq)

--- a/src/pixelator/pna/utils/two_bit_encoding.py
+++ b/src/pixelator/pna/utils/two_bit_encoding.py
@@ -47,6 +47,7 @@ def pack_2bits(kmer: bytes) -> np.uint64:
 
     A kmer must be at most 32 nucleotides long.
     Any nucleotides beyond the 32nd are ignored.
+    N bases are not supported (will raise KeyError).
 
     :param kmer: the kmer to pack
     :return: the packed kmer as an integer
@@ -95,7 +96,7 @@ def unpack_2bits(packed: int, k: int) -> bytes:
 
 
 def unpack_4bits(packed: int, k: np.uint64) -> bytes:
-    """Unpack a kmer from an integer using two bits per nucleotides.
+    """Unpack a kmer from an integer using four bits per nucleotides.
 
     :param packed: the packed kmer as an integer
     :param k: the length of the kmer

--- a/tests/pna/collapse/test_pna_embedding.py
+++ b/tests/pna/collapse/test_pna_embedding.py
@@ -4,7 +4,6 @@ import itertools
 
 import numpy as np
 import pytest
-from six import ensure_binary
 
 from pixelator.pna.demux.barcode_demuxer import PNAEmbedding
 from pixelator.pna.utils import pack_2bits, unpack_2bits
@@ -113,7 +112,7 @@ def test_pack_unpack_2_and_4bits():
     i.e. we reduce the full 15 mer space to only 3876 sequences, so this test is not too slow.)
     """
     for dna in itertools.combinations_with_replacement(b"GTCAN", 15):
-        original_dna = ensure_binary("".join(chr(nt) for nt in dna))
+        original_dna = ("".join(chr(nt) for nt in dna)).encode()
         packed_unpacked_dna = unpack_4bits(pack_4bits(original_dna), 15)
         assert original_dna == packed_unpacked_dna, (
             f"4bit packing unpacking failed: {original_dna} != {packed_unpacked_dna}"

--- a/tests/pna/collapse/test_pna_embedding.py
+++ b/tests/pna/collapse/test_pna_embedding.py
@@ -99,3 +99,17 @@ def test_unpack_2bits(umi, packed):
 def test_pack_2bits(umi, packed):
     packed_umi = pack_2bits(umi)
     assert packed_umi == packed
+
+
+def test_pack_unpack_4bits():
+    """Test that packing and unpacking with 4 bits per nucleotide is consistent.
+    itertools.combinations_with_replacement is used to generate all possible combinations of
+    15 nucleotides (G, T, C, A, N) and test that packing and unpacking returns the original
+    sequence. (Note that "all possible combinations" is NOT all possible orders of these combinations
+    i.e. we reduce the full 15 mer space to only 3876 sequences, so this test is not too slow.)
+    """
+    for dna in itertools.combinations_with_replacement(b"GTCAN", 15):
+        dna = ensure_binary("".join(chr(nt) for nt in dna))
+        assert dna == unpack_4bits(pack_4bits(dna), 15), (
+            f"{dna} != {unpack_4bits(pack_4bits(dna), 15)}"
+        )

--- a/tests/pna/collapse/test_pna_embedding.py
+++ b/tests/pna/collapse/test_pna_embedding.py
@@ -105,15 +105,21 @@ def test_pack_2bits(umi, packed):
     assert packed_umi == packed
 
 
-def test_pack_unpack_4bits():
-    """Test that packing and unpacking with 4 bits per nucleotide is consistent.
+def test_pack_unpack_2_and_4bits():
+    """Test that packing and unpacking with 2 and 4 bits per nucleotide is consistent.
     itertools.combinations_with_replacement is used to generate all possible combinations of
     15 nucleotides (G, T, C, A, N) and test that packing and unpacking returns the original
     sequence. (Note that "all possible combinations" is NOT all possible orders of these combinations
     i.e. we reduce the full 15 mer space to only 3876 sequences, so this test is not too slow.)
     """
     for dna in itertools.combinations_with_replacement(b"GTCAN", 15):
-        dna = ensure_binary("".join(chr(nt) for nt in dna))
-        assert dna == unpack_4bits(pack_4bits(dna), 15), (
-            f"{dna} != {unpack_4bits(pack_4bits(dna), 15)}"
+        original_dna = ensure_binary("".join(chr(nt) for nt in dna))
+        packed_unpacked_dna = unpack_4bits(pack_4bits(original_dna), 15)
+        assert original_dna == packed_unpacked_dna, (
+            f"4bit packing unpacking failed: {original_dna} != {packed_unpacked_dna}"
+        )
+    if b"N" not in original_dna:
+        packed_unpacked_dna_2bits = unpack_2bits(pack_2bits(original_dna), 15)
+        assert original_dna == packed_unpacked_dna_2bits, (
+            f"2bit packing unpacking failed: {original_dna} != {packed_unpacked_dna_2bits}"
         )

--- a/tests/pna/collapse/test_pna_embedding.py
+++ b/tests/pna/collapse/test_pna_embedding.py
@@ -1,10 +1,14 @@
 """Copyright © 2025 Pixelgen Technologies AB."""
 
+import itertools
+
 import numpy as np
 import pytest
+from six import ensure_binary
 
 from pixelator.pna.demux.barcode_demuxer import PNAEmbedding
 from pixelator.pna.utils import pack_2bits, unpack_2bits
+from pixelator.pna.utils.two_bit_encoding import pack_4bits, unpack_4bits
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Description
Fix 4bit packing unpacking to properly pack unpack all "N" sequences.

Fixes: PNA-2354

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
See added tests in `tests/pna/collapse/test_pna_embedding.py`

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
