### PR TITLE
Don't lock PRs after they are merged

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -31,3 +31,4 @@ jobs:
           allowlist: johandahlberg,fbdtemme,ptajvar,maxkarlsson,ludvigla,vincent-van-hoef,elhb,dependabot[bot]
           remote-organization-name: PixelgenTechnologies
           remote-repository-name: cla-signatures
+          lock-pullrequest-aftermerge: false


### PR DESCRIPTION
## Description

The CLA action has started to lock PRs after they are merged after the `contributor-assistant` action was updated (see https://github.com/PixelgenTechnologies/pixelator/pull/250/changes#diff-7aa0bb52169dde77e9033b3f574e1c8e686f567ea884691c7aace8f6297d216e).

I don't think this is a desired behavior as it prevents us from reacting to changes after they are merged, e.g. when things remain to be discussed but should not block the PR to be merged.

This PR deactivates this feature, and leaves PR's unlocked after merging.

NB: the `contributor-assistant` action has been archived and is no longer maintained since March 23rd this year, I'll create a maintenance ticket to start looking for some alternative solution.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

This is described in the `contributor-assistant`'s docs: https://github.com/contributor-assistant/github-action?tab=readme-ov-file#configure-contributor-license-agreement-within-two-minutes

## PR checklist:

- [X] This comment contains a description of changes (with reason).
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have checked my code and documentation and corrected any misspellings
