### PR TITLE
fix-node-component-confusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix logging for log1p_transformation and clr_transformation to state that the stats correspond to components and not nodes. 
 - Fix bug in unpacking 4bit packed sequences.
 - Fix bug in sample calling that removed the ending of antibodies that ended with `-<digit>`.
 

--- a/src/pixelator/common/statistics.py
+++ b/src/pixelator/common/statistics.py
@@ -56,7 +56,7 @@ def clr_transformation(
         raise AssertionError("Axis is required to be 0 or 1")
 
     logger.debug(
-        "Computing CLR transformation for antibody counts with %i nodes and %i markers",
+        "Computing CLR transformation for antibody counts with %i components and %i markers",
         df.shape[0],
         df.shape[1],
     )
@@ -131,7 +131,7 @@ def log1p_transformation(df: pd.DataFrame) -> pd.DataFrame:
     logger.debug(
         (
             "Computing LOG1P normalization for antibody counts"
-            " with %i nodes and %i markers"
+            " with %i components and %i markers"
         ),
         df.shape[0],
         df.shape[1],
@@ -147,9 +147,9 @@ def rate_diff_transformation(df: pd.DataFrame) -> pd.DataFrame:
     """Transform antibody counts as deviation from an expected baseline distribution.
 
     The baseline distribution refers to a fixed ratio of different antibody types
-    in each node. For example, if 10% of antibodies are HLA-ABC, in a node with
+    in each component. For example, if 10% of antibodies are HLA-ABC, in a component with
     120 antibodies, the expected count is 12. If the actual count is 8, the
-    transformation for HLA-ABC in this node will be -4.
+    transformation for HLA-ABC in this component will be -4.
 
     Args:
         df (pd.DataFrame): The dataframe of raw antibody counts (antibodies as columns).
@@ -158,11 +158,13 @@ def rate_diff_transformation(df: pd.DataFrame) -> pd.DataFrame:
         pd.DataFrame: A dataframe with the counts difference from expected values.
 
     """
-    antibody_counts_per_node = df.sum(axis=1)
+    antibody_counts_per_component = df.sum(axis=1)
     antibody_rates = df.sum(axis=0)
     antibody_rates = antibody_rates / antibody_rates.sum()
 
-    expected_counts = antibody_counts_per_node.to_frame() @ antibody_rates.to_frame().T
+    expected_counts = (
+        antibody_counts_per_component.to_frame() @ antibody_rates.to_frame().T
+    )
     return df - expected_counts
 
 
@@ -190,7 +192,7 @@ def rel_normalization(df: pd.DataFrame, axis: Literal[0, 1] = 0) -> pd.DataFrame
         raise AssertionError("Axis is required to be 0 or 1")
 
     logger.debug(
-        "Computing REL normalization for antibody counts with %i nodes and %i markers",
+        "Computing REL normalization for antibody counts with %i components and %i markers",
         df.shape[0],
         df.shape[1],
     )


### PR DESCRIPTION
Logging bug fixed for log1p_transformation and clr_transformation where the stats were reported for 'nodes' while they actually correspond to 'components'.

Fixes: #PNA-2490

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Minor change in log text.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
