### PR TITLE
chore: change default value of clr_transformation axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix logging for log1p_transformation and clr_transformation to state that the stats correspond to components and not nodes. 
+- Change default value for parameter axis of function clr_transformation to be 1.
+- Fix logging for log1p_transformation and clr_transformation to state that the stats correspond to components and not nodes.
 - Fix bug in unpacking 4bit packed sequences.
 - Fix bug in sample calling that removed the ending of antibodies that ended with `-<digit>`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add FLAG and FMC63 v3 panels
 
 ### Changed
+- Change default value for parameter axis of function clr_transformation to be 1.
 
 ### Fixed
 
-- Change default value for parameter axis of function clr_transformation to be 1.
 - Fix logging for log1p_transformation and clr_transformation to state that the stats correspond to components and not nodes.
 - Fix bug in unpacking 4bit packed sequences.
 - Fix bug in sample calling that removed the ending of antibodies that ended with `-<digit>`.

--- a/src/pixelator/common/statistics.py
+++ b/src/pixelator/common/statistics.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 def clr_transformation(
     df: pd.DataFrame,
-    axis: Literal[0, 1] = 0,
+    axis: Literal[0, 1] = 1,
     non_negative: bool = True,
 ) -> pd.DataFrame:
     """Transform antibody counts data with CLR (centered log ratio).
@@ -37,7 +37,7 @@ def clr_transformation(
         axis (Literal[0, 1], optional): The axis on which to apply the
             transformation. `axis=0` applies the transformation by columns
             (antibody), and `axis=1` applies it by rows (component). Defaults
-            to 0.
+            to 1.
         non_negative (bool, optional): If `True`, the non-negative CLR
             transformation is used. If `False`, the zero-centered CLR
             transformation is used. Defaults to True.


### PR DESCRIPTION
## Description
Change the default value of axis in function clr_transformation.

Was 0 (i.e. calculating and normalising by the geometric mean of all the cells for each marker) now changed to the more common usecase in our current workflows i.e. 1 (calculating and normalising by the geometric mean of all markers for each cell).

Fixes: PNA-2509

## Type of change

Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
NA

## PR checklist:
- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
