### PR TITLE
add pool name to undetermined output from sample calling

### DIFF
--- a/src/pixelator/pna/cli/sample_calling.py
+++ b/src/pixelator/pna/cli/sample_calling.py
@@ -151,7 +151,7 @@ def sample_calling_cli(
         final_dataset=final_dataset,
     )
     total_report.write_json_file(
-        sample_calling_output / "sample_calling.report.json", indent=4
+        sample_calling_output / f"{pool_name}.sample_calling.report.json", indent=4
     )
 
     if undetermined_sample_name in final_dataset.sample_names():

--- a/src/pixelator/pna/cli/sample_calling.py
+++ b/src/pixelator/pna/cli/sample_calling.py
@@ -96,15 +96,16 @@ def sample_calling_cli(
     sample_calling_output = create_output_stage_dir(output, "sample_calling")
 
     pool_name = Path(input_pxl_file).name.split(".")[0]
+    undetermined_sample_name = f"{pool_name}_undetermined"
 
     panel_info = PNAAntibodyPanel.from_pxl_file(input_pxl_file)
     hashing_antibodies_in_panel = set(
         panel_info.df[panel_info.df["sample_hashing"] == "yes"].index.to_list()
     )
     samplesheet_df = pl.read_csv(samplesheet)
-    if "undetermined" in samplesheet_df["sample"].to_list():
+    if undetermined_sample_name in samplesheet_df["sample"].to_list():
         raise ValueError(
-            "The sample 'undetermined' is not allowed in the samplesheet as it "
+            f"The sample '{undetermined_sample_name}' is not allowed in the samplesheet as it "
             "is reserved for undetermined components. Please edit your "
             "samplesheet to use a different sample name."
         )
@@ -122,6 +123,7 @@ def sample_calling_cli(
         output_folder=sample_calling_output,
         remove_incompatible=remove_incompatible,
         confidence_threshold=confidence_threshold,
+        undetermined_sample_name=undetermined_sample_name,
     )
 
     for pxl_file in output_files:
@@ -152,14 +154,18 @@ def sample_calling_cli(
         sample_calling_output / "sample_calling.report.json", indent=4
     )
 
-    if "undetermined" in final_dataset.sample_names():
+    if undetermined_sample_name in final_dataset.sample_names():
         warn_if_undetermined_has_high_confidence(
-            undetermined_sample_confidences=final_dataset.filter(samples="undetermined")
+            undetermined_sample_confidences=final_dataset.filter(
+                samples=undetermined_sample_name
+            )
             .adata()
             .obs["sample_confidence"],
             confidence_threshold=confidence_threshold,
         )
 
     if not save_undetermined:
-        undetermined_pxl = sample_calling_output / "undetermined.dehashed.pxl"
+        undetermined_pxl = (
+            sample_calling_output / f"{undetermined_sample_name}.dehashed.pxl"
+        )
         undetermined_pxl.unlink(missing_ok=True)

--- a/src/pixelator/pna/cli/sample_calling.py
+++ b/src/pixelator/pna/cli/sample_calling.py
@@ -163,6 +163,7 @@ def sample_calling_cli(
             .adata()
             .obs["sample_confidence"],
             confidence_threshold=confidence_threshold,
+            undetermined_sample_name=undetermined_sample_name,
         )
 
     if not save_undetermined:

--- a/src/pixelator/pna/cli/sample_calling.py
+++ b/src/pixelator/pna/cli/sample_calling.py
@@ -149,6 +149,7 @@ def sample_calling_cli(
     final_dataset = read(output_files)
     total_report = create_final_report(
         final_dataset=final_dataset,
+        undetermined_sample_name=undetermined_sample_name,
     )
     total_report.write_json_file(
         sample_calling_output / f"{pool_name}.sample_calling.report.json", indent=4

--- a/src/pixelator/pna/sample_calling/sample_calling.py
+++ b/src/pixelator/pna/sample_calling/sample_calling.py
@@ -249,7 +249,9 @@ def _build_post_sample_calling_anndata(
 
 
 def _apply_confidence_threshold_to_hash_info(
-    hash_info: pl.DataFrame, confidence_threshold: float
+    hash_info: pl.DataFrame,
+    confidence_threshold: float,
+    undetermined_sample_name: str = "undetermined",
 ) -> pl.DataFrame:
     """Apply confidence threshold to hash info and assign undetermined components.
 
@@ -258,6 +260,7 @@ def _apply_confidence_threshold_to_hash_info(
     Args:
         hash_info (pl.DataFrame): Hash info dataframe.
         confidence_threshold (float): Confidence threshold.
+        undetermined_sample_name (str, optional): Name to use for undetermined components. Defaults to "undetermined".
 
     Returns:
         pl.DataFrame: Hash info dataframe where confidence levels have been applied.
@@ -265,7 +268,7 @@ def _apply_confidence_threshold_to_hash_info(
     """
     return hash_info.with_columns(
         pl.when((pl.col("sample_confidence") < confidence_threshold))
-        .then(pl.lit("undetermined"))
+        .then(pl.lit(undetermined_sample_name))
         .otherwise(pl.col("called_sample"))
         .alias("called_sample")
     )
@@ -276,8 +279,9 @@ def _find_nodes_to_remove(
     remove_incompatible: bool,
     sample_name: str,
     sample_data: PNAPixelDataset,
+    undetermined_sample_name: str = "undetermined",
 ):
-    if remove_incompatible and (sample_name != "undetermined"):
+    if remove_incompatible and (sample_name != undetermined_sample_name):
         task = FindHashedNodesToRemove(  # type: ignore[abstract]
             hashing_antibody_mapping=hashing_antibody_mapping,
             sample_name=sample_name,
@@ -294,6 +298,7 @@ def sample_calling(
     output_folder: Path,
     confidence_threshold: float = 0.8,
     remove_incompatible: bool = True,
+    undetermined_sample_name: str = "undetermined",
 ) -> list[Path]:
     """Split components of a pixel dataset by their sample.
 
@@ -302,7 +307,7 @@ def sample_calling(
     PNAPixelDataset, assigns components to samples based on hash information
     and confidence thresholds, and writes out pxl files for each determined
     sample. It will also write a file for undetermined components (under the name
-    "undetermined.dehashed.pxl").
+    f"{undetermined_sample_name}.dehashed.pxl").
     It supports removing incompatible hashes and renaming hash markers in the output.
 
     Args:
@@ -318,6 +323,8 @@ def sample_calling(
         remove_incompatible (bool, optional):
             Whether to remove hashes incompatible with the current sample from the edgelist.
             Defaults to True.
+        undetermined_sample_name (str, optional):
+            Name to use for undetermined components. Defaults to "undetermined".
 
     Returns: List of all output pxl files created.
 
@@ -326,7 +333,9 @@ def sample_calling(
     panel = PNAAntibodyPanel.from_pxl_dataset(input_pxl)
 
     hash_info = _apply_confidence_threshold_to_hash_info(
-        hash_info, confidence_threshold
+        hash_info,
+        confidence_threshold,
+        undetermined_sample_name=undetermined_sample_name,
     )
 
     dehashed = hash_info.group_by("called_sample")
@@ -351,6 +360,7 @@ def sample_calling(
             remove_incompatible,
             sample_name,
             sample_data,
+            undetermined_sample_name,
         )
 
         with (
@@ -468,11 +478,14 @@ class HashedSampleAnalysisManager(AnalysisManager):
         return result
 
 
-def create_final_report(final_dataset: PNAPixelDataset) -> SampleCallingTotalReport:
+def create_final_report(
+    final_dataset: PNAPixelDataset, undetermined_sample_name: str = "undetermined"
+) -> SampleCallingTotalReport:
     """Create the final report for the sample calling.
 
     Args:
         final_dataset (PNAPixelDataset): The final dataset after sample calling.
+        undetermined_sample_name (str, optional): Name to use for undetermined components. Defaults to "undetermined".
 
     Returns:
         SampleCallingTotalReport: The final report for the sample calling.
@@ -486,9 +499,9 @@ def create_final_report(final_dataset: PNAPixelDataset) -> SampleCallingTotalRep
         )
 
     percentage_of_components_successfully_called = 1.0
-    if "undetermined" in final_dataset.sample_names():
+    if undetermined_sample_name in final_dataset.sample_names():
         n_undetermined_components = len(
-            final_dataset.filter(samples="undetermined").components()
+            final_dataset.filter(samples=undetermined_sample_name).components()
         )
         percentage_of_components_successfully_called = 1.0 - (
             n_undetermined_components / n_components
@@ -515,7 +528,9 @@ def create_final_report(final_dataset: PNAPixelDataset) -> SampleCallingTotalRep
 
 
 def warn_if_undetermined_has_high_confidence(
-    undetermined_sample_confidences: pd.DataFrame, confidence_threshold: float
+    undetermined_sample_confidences: pd.DataFrame,
+    confidence_threshold: float,
+    undetermined_sample_name: str = "undetermined",
 ) -> None:
     """Warn if the undetermined sample has a high confidence score."""
     if (
@@ -524,6 +539,6 @@ def warn_if_undetermined_has_high_confidence(
         > 0.05
     ):
         logger.warning(
-            "There are more than 5% of components in undetermined have a high confidence score. "
+            f"There are more than 5% of components in {undetermined_sample_name} have a high confidence score. "
             "This may indicate that the samplesheet has the wrong sample indices."
         )

--- a/src/pixelator/pna/sample_calling/sample_calling.py
+++ b/src/pixelator/pna/sample_calling/sample_calling.py
@@ -307,7 +307,7 @@ def sample_calling(
     PNAPixelDataset, assigns components to samples based on hash information
     and confidence thresholds, and writes out pxl files for each determined
     sample. It will also write a file for undetermined components (under the name
-    f"{undetermined_sample_name}.dehashed.pxl").
+    "{undetermined_sample_name}.dehashed.pxl").
     It supports removing incompatible hashes and renaming hash markers in the output.
 
     Args:
@@ -528,7 +528,7 @@ def create_final_report(
 
 
 def warn_if_undetermined_has_high_confidence(
-    undetermined_sample_confidences: pd.DataFrame,
+    undetermined_sample_confidences: pd.Series | np.ndarray,
     confidence_threshold: float,
     undetermined_sample_name: str = "undetermined",
 ) -> None:
@@ -539,6 +539,6 @@ def warn_if_undetermined_has_high_confidence(
         > 0.05
     ):
         logger.warning(
-            f"There are more than 5% of components in {undetermined_sample_name} have a high confidence score. "
+            f"There are more than 5% of components in {undetermined_sample_name} that have a high confidence score. "
             "This may indicate that the samplesheet has the wrong sample indices."
         )

--- a/tests/pna/sample_calling/test_sample_calling_cli.py
+++ b/tests/pna/sample_calling/test_sample_calling_cli.py
@@ -7,6 +7,7 @@ import json
 import tempfile
 from pathlib import Path
 
+import numpy as np
 import pytest
 from click.testing import CliRunner
 
@@ -69,7 +70,11 @@ def test_runs_ok(pna_data_root):
         assert total_data["report_type"] == "sample_calling_total"
         assert total_data["sample_id"] == "all"
         assert "sample_confidences_per_sample" in total_data
-
+        assert "percentage_of_components_successfully_called" in total_data
+        assert (
+            np.abs(total_data["percentage_of_components_successfully_called"] - 14 / 15)
+            < 1e-6
+        )
         total_components = 0
         for output in outputs:
             pxl = read(output)

--- a/tests/pna/sample_calling/test_sample_calling_cli.py
+++ b/tests/pna/sample_calling/test_sample_calling_cli.py
@@ -20,10 +20,11 @@ def test_runs_ok(pna_data_root):
     runner = CliRunner()
 
     with tempfile.TemporaryDirectory() as d:
+        pool_name = "small_hashed_sample_1"
         args = [
             "single-cell-pna",
             "sample-calling",
-            str(pna_data_root / "sample_calling/small_hashed_sample_1.pxl"),
+            str(pna_data_root / f"sample_calling/{pool_name}.pxl"),
             "--samplesheet",
             str(pna_data_root) + "/sample_calling/samplesheet.csv",
             "--remove-incompatible",
@@ -41,6 +42,7 @@ def test_runs_ok(pna_data_root):
         outputs = list(sorted(out_dir.glob("*.dehashed.pxl")))
         # One per sample + one for undetermined
         assert len(outputs) == 4
+        assert f"{pool_name}_undetermined.dehashed.pxl" in [o.name for o in outputs]
 
         for pxl_path in outputs:
             sample_name = get_sample_name(pxl_path)
@@ -60,7 +62,7 @@ def test_runs_ok(pna_data_root):
                 == "pixelator single-cell-pna sample-calling"
             )
 
-        total_report = out_dir / "sample_calling.report.json"
+        total_report = out_dir / f"{pool_name}.sample_calling.report.json"
         assert total_report.is_file(), "missing aggregated sample_calling.report.json"
 
         total_data = json.loads(total_report.read_text())


### PR DESCRIPTION
Sample calling step collects all undetermined components in sample named "undetermined". The issue is when trying to merge data from multiple pools we get a naming conflict from all "undetermined" samples. So, we're now going to add the pool name to the undetermined sample names to avoid name conflicts. 

Fixes: PNA-2593

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce it when relevant.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
