### PR TITLE
make undetermined components use the same name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- sample calling will now use the pool name in the file name of undetermined
+  components to avoid file name collisions in the pipeline.
+
 ## [0.25.0] - 2026-04-15
 
 ### Added

--- a/src/pixelator/pna/cli/sample_calling.py
+++ b/src/pixelator/pna/cli/sample_calling.py
@@ -103,6 +103,12 @@ def sample_calling_cli(
         panel_info.df[panel_info.df["sample_hashing"] == "yes"].index.to_list()
     )
     samplesheet_df = pl.read_csv(samplesheet)
+    if "undetermined" in samplesheet_df["sample"].to_list():
+        raise ValueError(
+            f"The sample 'undetermined' is not allowed in the samplesheet as it "
+            "is reserved for undetermined components. Please edit your "
+            "samplesheet to use a different sample name."
+        )
     if undetermined_sample_name in samplesheet_df["sample"].to_list():
         raise ValueError(
             f"The sample '{undetermined_sample_name}' is not allowed in the samplesheet as it "

--- a/src/pixelator/pna/sample_calling/sample_calling.py
+++ b/src/pixelator/pna/sample_calling/sample_calling.py
@@ -267,7 +267,10 @@ def _apply_confidence_threshold_to_hash_info(
 
     """
     return hash_info.with_columns(
-        pl.when((pl.col("sample_confidence") < confidence_threshold))
+        pl.when(
+            (pl.col("sample_confidence") < confidence_threshold)
+            | (pl.col("called_sample") == "undetermined")
+        )
         .then(pl.lit(undetermined_sample_name))
         .otherwise(pl.col("called_sample"))
         .alias("called_sample")

--- a/src/pixelator/pna/sample_calling/sample_calling.py
+++ b/src/pixelator/pna/sample_calling/sample_calling.py
@@ -102,7 +102,12 @@ def collect_hash_info(
             pl.col("value").max().alias("max_value"),
             pl.col("value").sum().alias("total_value"),
         )
-        .with_columns(sample_confidence=pl.col("max_value") / pl.col("total_value"))
+        .with_columns(
+            pl.when(pl.col("total_value") == 0)
+            .then(pl.lit(0.0))
+            .otherwise(pl.col("max_value") / pl.col("total_value"))
+            .alias("sample_confidence")
+        )
         .with_columns(
             pl.when(pl.col("sample_confidence") < confidence_threshold)
             .then(pl.lit(undetermined_sample_name))

--- a/src/pixelator/pna/sample_calling/sample_calling.py
+++ b/src/pixelator/pna/sample_calling/sample_calling.py
@@ -31,7 +31,10 @@ logger = logging.getLogger(__name__)
 
 
 def collect_hash_info(
-    input_pxl_file: PNAPixelDataset, hashed_antibody_mapping: HashedAntibodyMapping
+    input_pxl_file: PNAPixelDataset,
+    hashed_antibody_mapping: HashedAntibodyMapping,
+    confidence_threshold: float,
+    undetermined_sample_name: str = "undetermined",
 ) -> pl.DataFrame:
     """Map components to samples in an sample-hashed dataset.
 
@@ -47,12 +50,14 @@ def collect_hash_info(
         input_pxl_file (PNAPixelDataset): The input pixel dataset.
         hashed_antibody_mapping (HashedAntibodyMapping): Mapping of sample names
             to hashed antibody names and the full list of hashing antibodies (from panel).
+        confidence_threshold (float): Confidence threshold.
+        undetermined_sample_name (str, optional): Name to use for undetermined components. Defaults to "undetermined".
 
     Returns:
         pl.DataFrame: A Polars DataFrame containing the following columns:
             - 'component': The component identifier.
             - '{sample}_hash_count': The summed hash count for each sample.
-            - 'undetermined_hash_count': The summed hash count for antibodies not mapped to any
+            - '{undetermined_sample_name}_hash_count': The summed hash count for antibodies not mapped to any
                 sample.
             - 'called_sample': The sample with the highest hash count for each component
                 (may be "undetermined").
@@ -63,9 +68,11 @@ def collect_hash_info(
     samples = hashed_antibody_mapping.keys()
     unmapped = hashed_antibody_mapping.unmapped_hashing_antibodies
     undetermined_col = (
-        pl.sum_horizontal(list(unmapped)).alias("undetermined_hash_count")
+        pl.sum_horizontal(list(unmapped)).alias(
+            f"{undetermined_sample_name}_hash_count"
+        )
         if unmapped
-        else pl.lit(0).alias("undetermined_hash_count")
+        else pl.lit(0).alias(f"{undetermined_sample_name}_hash_count")
     )
 
     hash_counts_per_sample = ab_count_data.select(
@@ -80,7 +87,7 @@ def collect_hash_info(
         undetermined_col,
     )
     unpivot_cols = [f"{sample}_hash_count" for sample in samples] + [
-        "undetermined_hash_count"
+        f"{undetermined_sample_name}_hash_count"
     ]
     called_sample = (
         hash_counts_per_sample.select(["component"] + unpivot_cols)
@@ -95,15 +102,27 @@ def collect_hash_info(
             pl.col("value").max().alias("max_value"),
             pl.col("value").sum().alias("total_value"),
         )
-    ).with_columns(sample_confidence=pl.col("max_value") / pl.col("total_value"))
+        .with_columns(sample_confidence=pl.col("max_value") / pl.col("total_value"))
+        .with_columns(
+            pl.when(pl.col("sample_confidence") < confidence_threshold)
+            .then(pl.lit(undetermined_sample_name))
+            .otherwise(pl.col("called_sample"))
+            .alias("called_sample")
+        )
+    )
 
     result = hash_counts_per_sample.join(
         called_sample, on="component", how="left"
     ).select(
         ["component"]
         + [pl.col(f"{sample}_hash_count") for sample in samples]
-        + ["undetermined_hash_count", "called_sample", "sample_confidence"]
+        + [
+            f"{undetermined_sample_name}_hash_count",
+            "called_sample",
+            "sample_confidence",
+        ]
     )
+
     return result.collect()
 
 
@@ -248,35 +267,6 @@ def _build_post_sample_calling_anndata(
     return new_adata
 
 
-def _apply_confidence_threshold_to_hash_info(
-    hash_info: pl.DataFrame,
-    confidence_threshold: float,
-    undetermined_sample_name: str = "undetermined",
-) -> pl.DataFrame:
-    """Apply confidence threshold to hash info and assign undetermined components.
-
-    Components with confidence below the threshold are assigned to undetermined.
-
-    Args:
-        hash_info (pl.DataFrame): Hash info dataframe.
-        confidence_threshold (float): Confidence threshold.
-        undetermined_sample_name (str, optional): Name to use for undetermined components. Defaults to "undetermined".
-
-    Returns:
-        pl.DataFrame: Hash info dataframe where confidence levels have been applied.
-
-    """
-    return hash_info.with_columns(
-        pl.when(
-            (pl.col("sample_confidence") < confidence_threshold)
-            | (pl.col("called_sample") == "undetermined")
-        )
-        .then(pl.lit(undetermined_sample_name))
-        .otherwise(pl.col("called_sample"))
-        .alias("called_sample")
-    )
-
-
 def _find_nodes_to_remove(
     hashing_antibody_mapping: HashedAntibodyMapping,
     remove_incompatible: bool,
@@ -332,14 +322,13 @@ def sample_calling(
     Returns: List of all output pxl files created.
 
     """
-    hash_info = collect_hash_info(input_pxl, hashing_antibody_mapping)
-    panel = PNAAntibodyPanel.from_pxl_dataset(input_pxl)
-
-    hash_info = _apply_confidence_threshold_to_hash_info(
-        hash_info,
+    hash_info = collect_hash_info(
+        input_pxl,
+        hashing_antibody_mapping,
         confidence_threshold,
-        undetermined_sample_name=undetermined_sample_name,
+        undetermined_sample_name,
     )
+    panel = PNAAntibodyPanel.from_pxl_dataset(input_pxl)
 
     dehashed = hash_info.group_by("called_sample")
     output_files: list[Path] = []

--- a/tests/pna/sample_calling/test_sample_calling.py
+++ b/tests/pna/sample_calling/test_sample_calling.py
@@ -269,7 +269,9 @@ def test_collect_hash_info(sample_hashed_pixel_files):
                 "B2M-3",
             ],
         ),
+        confidence_threshold=0.8,
     )
+
     comp_counts = cc.group_by("called_sample").len("count")
     assert comp_counts.shape[0] == 3
     assert all(comp_counts["count"] == 10)
@@ -294,24 +296,50 @@ def test_collect_hash_info_should_use_all_hashing_antibodies(sample_hashed_pixel
                 "B2M-3",
             ],
         ),
+        confidence_threshold=0.8,
+        undetermined_sample_name="test",
     )
-    # called_sample can be PBMC, Raji, or "undetermined" (when undetermined_hash_count wins),
+    # called_sample can be PBMC, Raji, or "test" (when undetermined_hash_count wins),
     # so we get 3 groups
     comp_counts = cc.group_by("called_sample").len("count")
+
     assert comp_counts.shape[0] == 3
-    assert "undetermined_hash_count" in cc.columns
+    assert "test_hash_count" in cc.columns
+    assert "undetermined_hash_count" not in cc.columns
     assert comp_counts["count"].sum() == 30  # all components assigned to one of the two
     assert set(comp_counts["called_sample"].to_list()) == {
         "PBMC",
         "Raji",
-        "undetermined",
+        "test",
     }
-    assert (
-        comp_counts.filter(pl.col("called_sample") == "undetermined")["count"].item()
-        == 10
+    assert comp_counts.filter(pl.col("called_sample") == "test")["count"].item() == 10
+
+
+def test_collect_hash_info_all_undetermined(sample_hashed_pixel_files):
+    """Test is undetermined when confidence is below threshold"""
+    pxl = read(sample_hashed_pixel_files)
+    cc = collect_hash_info(
+        pxl,
+        hashed_antibody_mapping=HashedAntibodyMapping(
+            mapping={
+                "PBMC": ["CD29-1", "B2M-1"],
+                "Raji": ["CD29-2", "B2M-2"],
+                "Jurkat": ["CD29-3", "B2M-3"],
+            },
+            all_hashing_antibodies=[
+                "CD29-1",
+                "CD29-2",
+                "CD29-3",
+                "B2M-1",
+                "B2M-2",
+                "B2M-3",
+            ],
+        ),
+        confidence_threshold=1.0,
+        undetermined_sample_name="test",
     )
 
-    # Check the sample calling confidence
+    assert all(cc["called_sample"] == "test")
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Ensure that all undetermined components are assigned the same called_sample name.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce it when relevant.

## PR checklist:

- [ ] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
