### PR TITLE
feat: add field archived to panel metadata 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--min-component-size-to-prune`, this new implementation uses a common
   threshold set by `--component-size-min-threshold`, or 8000 by default.
 - Dependency: `pixelgen-pixelator-core` (Python bindings for the native graph step).
-- Add new optional field archived to panel metadata.
+- Add new optional field `archived` to panel metadata.
   The parameter `--list-panels` now lists panels without the archived metadata field.
   Add new option `--list-panels-including-archived` to list all panels including archived ones.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [x.x.x] - TBD
 
 ### Added
-- Add the option to calculate proximity scores from edgelist using analytical expected join counts. 
+- Add the option to calculate proximity scores from edgelist using analytical expected join counts.
   `PNAPixelDataset.proximity(calculate_from_edgelist=True)` is used to compute these scores.
 
 - New implementation of `pixelator single-cell-pna graph`,
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--min-component-size-to-prune`, this new implementation uses a common
   threshold set by `--component-size-min-threshold`, or 8000 by default.
 - Dependency: `pixelgen-pixelator-core` (Python bindings for the native graph step).
+- Add new optional field archived to panel metadata.
+  The parameter `--list-panels` now lists panels without the archived metadata field.
+  Add new option `--list-panels-including-archived` to list all panels including archived ones.
 
 ### Changed
 - The previous implementation has been renamed and is available with `pixelator single-cell-pna graph_legacy`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   threshold set by `--component-size-min-threshold`, or 8000 by default.
 - Dependency: `pixelgen-pixelator-core` (Python bindings for the native graph step).
 - Add new optional field `archived` to panel metadata.
-  The parameter `--list-panels` now lists panels without the archived metadata field.
-  Add new option `--list-panels-including-archived` to list all panels including archived ones.
+- The parameter `--list-panels` now lists panels without the archived metadata field.
+- Add new option `--list-panels-including-archived` to list all panels including archived ones.
 
 ### Changed
 - The previous implementation has been renamed and is available with `pixelator single-cell-pna graph_legacy`.

--- a/src/pixelator/cli/main.py
+++ b/src/pixelator/cli/main.py
@@ -165,6 +165,7 @@ from pixelator.pna.cli.layout import layout
 from pixelator.pna.cli.misc import (
     list_single_cell_pna_designs,
     list_single_cell_pna_panels,
+    list_single_cell_pna_panels_including_archived,
 )
 from pixelator.pna.cli.report import report
 from pixelator.pna.cli.sample_calling import sample_calling_cli
@@ -180,6 +181,16 @@ from pixelator.pna.cli.sample_calling import sample_calling_cli
     required=False,
     callback=list_single_cell_pna_designs,
     help="List available designs and exit.",
+)
+@click.option(
+    "--list-panels-including-archived",
+    is_flag=True,
+    metavar="",
+    is_eager=True,
+    expose_value=False,
+    required=False,
+    callback=list_single_cell_pna_panels_including_archived,
+    help="List all panels, including panels marked as archived, and exit.",
 )
 @click.option(
     "--list-panels",

--- a/src/pixelator/common/config/panel.py
+++ b/src/pixelator/common/config/panel.py
@@ -30,6 +30,7 @@ class AntibodyPanelMetadata(pydantic.BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
     aliases: List[str] = []
+    archived: Optional[bool] = False
 
 
 class AntibodyPanel:

--- a/src/pixelator/pna/cli/misc.py
+++ b/src/pixelator/pna/cli/misc.py
@@ -30,7 +30,9 @@ def list_single_cell_pna_designs(ctx: click.Context, param: Any, value: Any) -> 
     ctx.exit()
 
 
-def list_single_cell_pna_panels(ctx: click.Context, param: Any, value: Any) -> None:
+def list_single_cell_pna_panels(
+    ctx: click.Context, param: Any, value: Any, include_archived: bool = False
+) -> None:
     """Return a list of single cell panels supported by the config.
 
     :param ctx: The click context
@@ -42,8 +44,22 @@ def list_single_cell_pna_panels(ctx: click.Context, param: Any, value: Any) -> N
     if not value or ctx.resilient_parsing:
         return
 
-    options = pna_config.list_panel_names(include_aliases=True)
+    options = pna_config.list_panel_names(
+        include_aliases=True, include_archived=include_archived
+    )
     for option in options:
         click_echo(option)
 
     ctx.exit()
+
+
+def list_single_cell_pna_panels_including_archived(
+    ctx: click.Context, param: Any, value: Any
+) -> None:
+    """Return a list of single cell panels supported by the config, including archived panels.
+
+    :param ctx: The click context
+    :param param: The click parameter
+    :param value: The click value
+    """
+    list_single_cell_pna_panels(ctx, param, value, include_archived=True)

--- a/src/pixelator/pna/config/config_class.py
+++ b/src/pixelator/pna/config/config_class.py
@@ -106,19 +106,26 @@ class PNAConfig:
         """Get an assay by name."""
         return self.assays.get(assay_name)
 
-    def list_panel_names(self, include_aliases: bool = False) -> List[str]:
+    def list_panel_names(
+        self, include_aliases: bool = False, include_archived: bool = False
+    ) -> List[str]:
         """Return a list of all panel names.
 
         :param include_aliases: Include panel aliases in the list
+        :param include_archived: Include archived panels in the list
         :returns: A list of panel names
         """
-        out = sorted(list(self.panels.keys()))
+        out = []
+        for panel in itertools.chain.from_iterable(self.panels.values()):
+            if not panel.archived or include_archived:
+                if panel.name in self.panels:
+                    out.append(panel.name)
+                if include_aliases:
+                    for alias in panel.aliases:
+                        if alias in self.panel_aliases:
+                            out.append(alias)
 
-        if not include_aliases:
-            return out
-
-        out += sorted(list(self.panel_aliases.keys()))
-        return out
+        return sorted(out)  # type: ignore[arg-type]
 
     def get_panel(
         self,

--- a/src/pixelator/pna/config/panel.py
+++ b/src/pixelator/pna/config/panel.py
@@ -172,6 +172,11 @@ class PNAAntibodyPanel:
         """Return the (optional) list of panel file aliases."""
         return self._metadata.aliases
 
+    @property
+    def archived(self) -> Optional[bool]:
+        """Return whether the panel is marked as archived."""
+        return self._metadata.archived
+
     @classmethod
     def _parse_header(cls, file: Path) -> AntibodyPanelMetadata:
         """Parse front-matter YAML from a file.


### PR DESCRIPTION
## Description

Add field archived to panel metadata.
Filter `--list-panels` output to only show non archived panels.
Add new option `--list-panels-including-archived` to list all panels including archived ones.

Fixes: PNA-2510

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
