### PR TITLE
Feature/pna 2633 enable ace denoising through CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "lxml",
     "cssselect>=1.4.0", # Required by lxml
     "typing_extensions",
-    "scipy>=1.0.0,<2.0.0",
+    "scipy>=1.11.0,<2.0.0",
     "pyarrow>=14",
     "semver>=3.0.0,<4",
     "ruamel-yaml>=0.17.21,<0.18",

--- a/src/pixelator/common/graph/adaptive_core_expansion.py
+++ b/src/pixelator/common/graph/adaptive_core_expansion.py
@@ -1,5 +1,8 @@
-import logging
-import warnings
+"""Adaptive Core Expansion (ACE) graph partitioning implementation.
+
+Copyright © 2026 Pixelgen Technologies AB
+"""
+
 from typing import Sequence
 
 import networkx as nx
@@ -8,8 +11,7 @@ import scipy.sparse as sp
 
 from pixelator.common.graph import Graph
 from pixelator.common.graph.backends.implementations._networkx import _mat_pow
-
-logger = logging.getLogger(__name__)
+from pixelator.common.utils import logger
 
 
 def normalize_counts(x):
@@ -25,37 +27,65 @@ def adaptive_core_expansion(
     cg: Graph,
     k: int = 3,
     max_k_core: int = 4,
-    binding_thresholds: Sequence[float] = (0.5, 0.475, 0.45, 0.425, 0.4, 0.375, 0.35, 0.325, 0.3),
+    binding_thresholds: Sequence[float] = (
+        0.5,
+        0.475,
+        0.45,
+        0.425,
+        0.4,
+        0.375,
+        0.35,
+        0.325,
+        0.3,
+    ),
     max_iter: int = 200,
     min_seed_pct: float = 0.1,
     nodes_to_move_threshold: int = 10,
     select_LCC: bool = True,
-    verbose: bool = True,
 ) -> Graph:
-    """Performs a topology-aware graph partitioning by identifying a high-density
-    k-core "seed" and iteratively expanding it.
+    """Perform Adaptive Core Expansion (ACE) graph partitioning.
 
-    The algorithm uses transition probabilities to recruit nodes from the periphery ("low" layer)
-    into the core ("high" layer) and selects the final partition that maximizes
-    phenotypic dissimilarity (Bray-Curtis) between the two groups.
+    Adaptive Core Expansion (ACE) is a topology-aware graph partitioning by
+    identifying a high-density k-core "seed" and iteratively expanding it.
+    The algorithm uses transition probabilities to recruit nodes from the
+    periphery ("low" layer) into the core ("high" layer) and selects the
+    final partition that maximizes phenotypic dissimilarity (Bray-Curtis)
+    between the two groups.
 
-    :param cg: A `Graph` object containing the cell graph and node counts.
-    :param k: The neighborhood radius (number of steps) used to calculate reachability
-    :param max_k_core: Integer to cap the maximum k-core layer used for seeding.
-    :param binding_thresholds: Sequence of thresholds for moving nodes from the low to high partition.
-    :param max_iter: Maximum iterations per binding threshold.
-    :param min_seed_pct: Minimum fraction of nodes required to form the initial seed partition.
-    :param nodes_to_move_threshold: Convergence limit; stops iteration if fewer nodes move.
-    :param select_LCC: Restricts the initial seed to the Largest Connected Component.
-    :param verbose: Whether to print progress alerts.
-    :return: The original graph object with an additional `partition` node attribute ("high" or "low").
+    Args:
+        cg: A `Graph` object containing the cell graph and node counts.
+        k: The neighborhood radius (number of steps) used to calculate reachability
+        max_k_core: Integer to cap the maximum k-core layer used for seeding.
+        binding_thresholds: Sequence of thresholds for moving nodes from the low to high partition.
+        max_iter: Maximum iterations per binding threshold.
+        min_seed_pct: Minimum fraction of nodes required to form the initial seed partition.
+        nodes_to_move_threshold: Convergence limit; stops iteration if fewer nodes move.
+        select_LCC: Restricts the initial seed to the Largest Connected Component.
+
+    Returns:
+        The original graph object with an additional `partition` node attribute ("high" or "low").
+
+    Raises:
+        ValueError: If the graph does not contain any k-core layers above 1.
+        ValueError: If no k-core layer meets the required 'min_seed_pct' threshold.
+        ValueError: If the Graph object does not contain count data.
+        ValueError: If the 'k' parameter is not between 1 and 6 inclusive.
+        ValueError: If the 'max_k_core' parameter is not between 2 and 10 inclusive.
+        ValueError: If the 'binding_thresholds' parameter is not a sequence of floats between 0 and 1.
+        ValueError: If the 'max_iter' parameter is not between 1 and 1000 inclusive.
+        ValueError: If the 'min_seed_pct' parameter is not between 0 and 1 inclusive.
+        ValueError: If the 'nodes_to_move_threshold' parameter is not between 0 and 1000 inclusive.
+        TypeError: If the 'binding_thresholds' parameter is not a sequence of floats between 0 and 1.
+
     """
-    assert 1 <= k <= 6
-    assert 2 <= max_k_core <= 10
-    assert all(0 <= t <= 1 for t in binding_thresholds)
-    assert 1 <= max_iter <= 1000
-    assert 0 <= min_seed_pct <= 1
-    assert 0 <= nodes_to_move_threshold <= 1000
+    _validate_ace_parameters(
+        k=k,
+        max_k_core=max_k_core,
+        binding_thresholds=binding_thresholds,
+        max_iter=max_iter,
+        min_seed_pct=min_seed_pct,
+        nodes_to_move_threshold=nodes_to_move_threshold,
+    )
 
     try:
         counts = cg.node_marker_counts
@@ -93,6 +123,10 @@ def adaptive_core_expansion(
 
     k_cores[k_cores > max_k] = max_k
 
+    logger.debug(
+        f"Seed 'high' core layer contains {np.mean(k_cores == max_k) * 100:.2f}% of all nodes."
+    )
+
     # Compute transition probability matrix P from the adjacency matrix
     A = cg.get_adjacency_sparse(node_ordering=node_list)
     A = A + sp.diags_array([1] * A.shape[0], format="csr", dtype=None)
@@ -101,30 +135,23 @@ def adaptive_core_expansion(
     D_inv = sp.diags_array(1 / row_sums, format="csr")
     P = D_inv @ A
 
-    min_weight = 0
+    min_weight = 1e-5  # To avoid having the sparse matrix grow too dense
     P_step = _mat_pow(P, k, prune_threshold=min_weight).T
 
-    # Set diagonal to 0
     P_step.setdiag(0)
 
     row_sums = np.ravel(P_step.sum(axis=1))
     D_inv = sp.diags_array(1 / row_sums, format="csr")
     P_step = D_inv @ P_step
 
-    if verbose:
-        logger.info(
-            f"Seed 'high' core layer contains {np.mean(k_cores == max_k)*100:.2f}% of all nodes."
-        )
-
     if select_LCC:
         seed_nodes = [node_list[i] for i, k_val in enumerate(k_cores) if k_val == max_k]
         subgraph = raw_graph.subgraph(seed_nodes)
         components = list(nx.connected_components(subgraph))
         if len(components) > 1:
-            if verbose:
-                logger.info(
-                    f"The high k-core layer has {len(components)} connected components. Selecting the largest connected component."
-                )
+            logger.debug(
+                f"The high k-core layer has {len(components)} connected components. Selecting the largest connected component."
+            )
             largest_comp = max(components, key=len)
             largest_comp_set = set(largest_comp)
             for i, n in enumerate(node_list):
@@ -137,10 +164,9 @@ def adaptive_core_expansion(
     sorted_thresholds = sorted(binding_thresholds, reverse=True)
 
     for binding_threshold in sorted_thresholds:
-        if verbose:
-            logger.info(
-                f"Finding partition seeded with k-core layer >= {max_k} and a binding threshold of {binding_threshold}."
-            )
+        logger.debug(
+            f"Finding partition seeded with k-core layer >= {max_k} and a binding threshold of {binding_threshold}."
+        )
 
         current_partition = _adaptive_core_expansion_inner(
             current_partition,
@@ -148,7 +174,6 @@ def adaptive_core_expansion(
             max_iter,
             nodes_to_move_threshold,
             binding_threshold,
-            verbose,
         )
 
         min_nodes_in_core = max(nodes_to_move_threshold, 10)
@@ -166,8 +191,7 @@ def adaptive_core_expansion(
 
             bc_score = float(np.sum(np.abs(x - y)) / np.sum(x + y))
 
-        if verbose:
-            logger.info("Completed")
+        logger.debug("Completed")
 
         partitions.append((current_partition.copy(), bc_score))
 
@@ -175,12 +199,11 @@ def adaptive_core_expansion(
     best_partition_vec, best_score = partitions[best_idx]
     best_binding_threshold = sorted_thresholds[best_idx]
 
-    if verbose:
-        logger.info(
-            f"Selected partition seeded with k-core layer >= {max_k} "
-            f"and a binding threshold of {best_binding_threshold}. "
-            f"Bray-Curtis dissimilarity score: {best_score:.4f}."
-        )
+    logger.debug(
+        f"Selected partition seeded with k-core layer >= {max_k} "
+        f"and a binding threshold of {best_binding_threshold}. "
+        f"Bray-Curtis dissimilarity score: {best_score:.4f}."
+    )
 
     pixel_type_dict = {
         node_list[i]: ("high" if best_partition_vec[i] == 1 else "low")
@@ -197,7 +220,6 @@ def _adaptive_core_expansion_inner(
     max_iter: int,
     nodes_to_move_threshold: int,
     binding_threshold: float,
-    verbose: bool
 ) -> np.ndarray:
     for i in range(max_iter):
         tp_total = P @ partition
@@ -206,13 +228,45 @@ def _adaptive_core_expansion_inner(
         num_to_move = to_move_mask.sum()
 
         if num_to_move < nodes_to_move_threshold:
-            if verbose:
-                logger.info(f"Convergence reached at iteration {i}.")
+            logger.debug(f"Convergence reached at iteration {i}.")
             break
 
         partition[to_move_mask] = 1
 
-    if verbose:
-        logger.info(f"Final 'high' core layer contains {partition.sum() / len(partition) * 100:.2f}% of all nodes.")
+    logger.debug(
+        f"Final 'high' core layer contains {partition.sum() / len(partition) * 100:.2f}% of all nodes."
+    )
 
     return partition
+
+
+def _validate_ace_parameters(
+    k, max_k_core, binding_thresholds, max_iter, min_seed_pct, nodes_to_move_threshold
+):
+    if not 1 <= k <= 6:
+        raise ValueError(f"'k' must be between 1 and 6 inclusive, got {k}.")
+    if not 2 <= max_k_core <= 10:
+        raise ValueError(
+            f"'max_k_core' must be between 2 and 10 inclusive, got {max_k_core}."
+        )
+    if not isinstance(binding_thresholds, Sequence):
+        raise TypeError(
+            "'binding_thresholds' must be a sequence of floats between 0 and 1."
+        )
+    if not all(0 <= t <= 1 for t in binding_thresholds):
+        raise ValueError(
+            "All values in 'binding_thresholds' must be between 0 and 1 inclusive."
+        )
+    if not 1 <= max_iter <= 1000:
+        raise ValueError(
+            f"'max_iter' must be between 1 and 1000 inclusive, got {max_iter}."
+        )
+    if not 0 <= min_seed_pct <= 1:
+        raise ValueError(
+            f"'min_seed_pct' must be between 0 and 1 inclusive, got {min_seed_pct}."
+        )
+    if not 0 <= nodes_to_move_threshold <= 1000:
+        raise ValueError(
+            f"'nodes_to_move_threshold' must be between 0 and 1000 inclusive, got {nodes_to_move_threshold}."
+        )
+    return True

--- a/src/pixelator/common/graph/adaptive_core_expansion.py
+++ b/src/pixelator/common/graph/adaptive_core_expansion.py
@@ -41,6 +41,7 @@ def adaptive_core_expansion(
     max_iter: int = 200,
     min_seed_pct: float = 0.1,
     nodes_to_move_threshold: int = 10,
+    select_LCC: bool = True,
 ) -> Graph:
     """Perform Adaptive Core Expansion (ACE) graph partitioning.
 
@@ -59,6 +60,7 @@ def adaptive_core_expansion(
         max_iter: Maximum iterations per binding threshold.
         min_seed_pct: Minimum fraction of nodes required to form the initial seed partition.
         nodes_to_move_threshold: Convergence limit; stops iteration if fewer nodes move.
+        select_LCC: Restricts the initial seed to the Largest Connected Component (LCC).
 
     Returns:
         The original graph object with an additional `partition` node attribute ("high" or "low").
@@ -141,6 +143,21 @@ def adaptive_core_expansion(
     row_sums = np.ravel(P_step.sum(axis=1))
     D_inv = sp.diags_array(1 / row_sums, format="csr")
     P_step = D_inv @ P_step
+
+    if select_LCC:
+        seed_nodes = [node_list[i] for i, k_val in enumerate(k_cores) if k_val == max_k]
+        subgraph = raw_graph.subgraph(seed_nodes)
+        components = list(nx.connected_components(subgraph))
+        if len(components) > 1:
+            logger.debug(
+                f"The high k-core layer has {len(components)} connected components. "
+                f"Selecting the largest connected component."
+            )
+            largest_comp = max(components, key=len)
+            largest_comp_set = set(largest_comp)
+            for i, k_val in enumerate(k_cores):
+                if k_val == max_k and node_list[i] not in largest_comp_set:
+                    k_cores[i] = max_k - 1
 
     partitions = []
     current_partition = (k_cores == max_k).astype(int)

--- a/src/pixelator/common/graph/adaptive_core_expansion.py
+++ b/src/pixelator/common/graph/adaptive_core_expansion.py
@@ -41,7 +41,6 @@ def adaptive_core_expansion(
     max_iter: int = 200,
     min_seed_pct: float = 0.1,
     nodes_to_move_threshold: int = 10,
-    select_LCC: bool = True,
 ) -> Graph:
     """Perform Adaptive Core Expansion (ACE) graph partitioning.
 
@@ -60,7 +59,6 @@ def adaptive_core_expansion(
         max_iter: Maximum iterations per binding threshold.
         min_seed_pct: Minimum fraction of nodes required to form the initial seed partition.
         nodes_to_move_threshold: Convergence limit; stops iteration if fewer nodes move.
-        select_LCC: Restricts the initial seed to the Largest Connected Component.
 
     Returns:
         The original graph object with an additional `partition` node attribute ("high" or "low").
@@ -143,20 +141,6 @@ def adaptive_core_expansion(
     row_sums = np.ravel(P_step.sum(axis=1))
     D_inv = sp.diags_array(1 / row_sums, format="csr")
     P_step = D_inv @ P_step
-
-    if select_LCC:
-        seed_nodes = [node_list[i] for i, k_val in enumerate(k_cores) if k_val == max_k]
-        subgraph = raw_graph.subgraph(seed_nodes)
-        components = list(nx.connected_components(subgraph))
-        if len(components) > 1:
-            logger.debug(
-                f"The high k-core layer has {len(components)} connected components. Selecting the largest connected component."
-            )
-            largest_comp = max(components, key=len)
-            largest_comp_set = set(largest_comp)
-            for i, n in enumerate(node_list):
-                if k_cores[i] == max_k and n not in largest_comp_set:
-                    k_cores[i] = max_k - 1
 
     partitions = []
     current_partition = (k_cores == max_k).astype(int)

--- a/src/pixelator/common/graph/node_pls.py
+++ b/src/pixelator/common/graph/node_pls.py
@@ -6,7 +6,7 @@ Copyright © 2025 Pixelgen Technologies AB.
 from __future__ import annotations
 
 import logging
-from typing import List, Literal, Optional, Sequence, Union
+from typing import List, Literal, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -188,7 +188,9 @@ def node_pls(
             for node_id in counts.index:
                 node_data = v_attr_dict.get(node_id)
                 if node_data is None or y not in node_data:
-                    raise ValueError(f"Variable '{y}' not found in counts or graph attributes for node {node_id}.")
+                    raise ValueError(
+                        f"Variable '{y}' not found in counts or graph attributes for node {node_id}."
+                    )
                 y_col.append(node_data[y])
             Y_data[y] = y_col
 
@@ -202,7 +204,9 @@ def node_pls(
     if x_vars is not None:
         missing_x = [x for x in x_vars if x not in X_expanded.columns]
         if missing_x:
-            raise ValueError(f"The following x_vars are not found: {', '.join(missing_x)}")
+            raise ValueError(
+                f"The following x_vars are not found: {', '.join(missing_x)}"
+            )
         X = X_expanded[x_vars].values
     else:
         X = X_expanded.values

--- a/src/pixelator/pna/analysis/denoise.py
+++ b/src/pixelator/pna/analysis/denoise.py
@@ -11,11 +11,9 @@ import tempfile
 from itertools import chain
 from pathlib import Path
 
-import duckdb
 import networkx as nx
 import numpy as np
 import pandas as pd
-import polars as pl
 from scipy.stats import fisher_exact
 
 from pixelator.common.annotate.aggregates import call_aggregates

--- a/src/pixelator/pna/analysis/denoise.py
+++ b/src/pixelator/pna/analysis/denoise.py
@@ -275,25 +275,23 @@ def denoise_pls(
 ) -> list:
     """PLS-on-coreness denoise: significant components, score gate, then largest connected set.
 
-    Fits PLS with neighborhood radius ``model_k`` (as in R ``node_pls``) and scores nodes
-    using radius ``pred_k``. Defaults match the R intracellular script (``ncomp=5``,
-    ``model_k=2``, ``pred_k=1``, weighted L1, no residualization, ``cor > 0``,
-    ``p < 0.01``, all retained scores ``> -3``).
+    Fits PLS with neighborhood radius ``model_k`` and scores nodes
+    using radius ``pred_k``.
 
-    Unlike the R script, filtering uses **all** nodes (not only ACE ``high``); removals
-    are returned for merging with other denoise methods like ACE and one-core.
+    Filtering uses **all** nodes (not only ACE ``high``); removals
+    are returned for merging with other denoise methods.
 
     Args:
         component: Component graph (mutates ``coreness`` on nodes temporarily).
         ncomp: Requested PLS components (capped by sample size and feature count).
-        model_k: Neighborhood steps for fitting X (R ``model_k``).
-        pred_k: Neighborhood steps for prediction / scores (R ``pred_k``).
-        use_weights: Use edge weights in neighborhood expansion (R ``weighted``).
-        normalization: Neighborhood matrix normalization (R ``normalization``).
+        model_k: Neighborhood steps for fitting X.
+        pred_k: Neighborhood steps for prediction / scores.
+        use_weights: Use edge weights in neighborhood expansion.
+        normalization: Neighborhood matrix normalization.
         residualize: If True, residualize X against a ``pixel_type`` design matrix.
-        pls_component_p_threshold: Per-component Pearson test vs coreness (R ``0.01``).
-        min_pls_coreness_correlation: Minimum positive correlation (R ``cor > 0``).
-        pls_score_threshold: All selected score columns must exceed this (R ``-3``).
+        pls_component_p_threshold: Per-component Pearson test vs coreness.
+        min_pls_coreness_correlation: Minimum positive correlation.
+        pls_score_threshold: All selected score columns must exceed this.
 
     Returns:
         Nodes to remove, ``[]`` if no PLS-based removal applies, or ``[None]`` if the

--- a/src/pixelator/pna/analysis/denoise.py
+++ b/src/pixelator/pna/analysis/denoise.py
@@ -437,6 +437,17 @@ class DenoiseACE(PerComponentTask):
         nodes_to_move_threshold: int = 10,
         select_LCC: bool = True,
     ):
+        """Initialize a DenoiseACE instance.
+
+        Args:
+            k: Neighborhood radius (steps) for the transition matrix in ACE.
+            max_k_core: Maximum k-core layer used for seeding in ACE.
+            max_iter: Maximum expansion iterations per binding threshold in ACE.
+            min_seed_pct: Minimum fraction of nodes required for the initial ACE seed.
+            nodes_to_move_threshold: ACE convergence threshold (nodes moved per iteration).
+            select_LCC: Whether to restrict the ACE seed to the largest k-core component.
+
+        """
         self.k = k
         self.max_k_core = max_k_core
         self.max_iter = max_iter

--- a/src/pixelator/pna/analysis/denoise.py
+++ b/src/pixelator/pna/analysis/denoise.py
@@ -298,6 +298,7 @@ def denoise_pls(
     Returns:
         Nodes to remove, ``[]`` if no PLS-based removal applies, or ``[None]`` if the
         component is disqualified (fit/scoring failed).
+
     """
     idx = component.node_marker_counts.index
     n_samples = len(idx)

--- a/src/pixelator/pna/analysis/denoise.py
+++ b/src/pixelator/pna/analysis/denoise.py
@@ -194,6 +194,7 @@ def denoise_ace(
     max_iter: int = 200,
     min_seed_pct: float = 0.1,
     nodes_to_move_threshold: int = 10,
+    select_lcc: bool = True,
 ) -> list:
     """Partition the graph with ACE and return nodes in the peripheral-like ("low") partition.
 
@@ -206,6 +207,7 @@ def denoise_ace(
         max_iter: Maximum expansion iterations per binding threshold in ACE.
         min_seed_pct: Minimum fraction of nodes required for the initial ACE seed.
         nodes_to_move_threshold: ACE convergence threshold (nodes moved per iteration).
+        select_lcc: If True, restrict the initial ACE seed to the largest connected component.
 
     Returns:
         List of node identifiers to remove, or ``[None]`` if the component is
@@ -220,6 +222,7 @@ def denoise_ace(
             max_iter=max_iter,
             min_seed_pct=min_seed_pct,
             nodes_to_move_threshold=nodes_to_move_threshold,
+            select_LCC=select_lcc,
         )
     except ValueError as exc:
         logger.debug("ACE denoising skipped for component: %s", exc)
@@ -463,6 +466,7 @@ class DenoiseGraph(PerComponentTask):
         max_iter: int = 200,
         min_seed_pct: float = 0.1,
         nodes_to_move_threshold: int = 10,
+        ace_select_lcc: bool = True,
         pls_ncomp: int = 5,
         pls_model_k: int = 2,
         pls_pred_k: int = 1,
@@ -489,6 +493,7 @@ class DenoiseGraph(PerComponentTask):
         self.max_iter = max_iter
         self.min_seed_pct = min_seed_pct
         self.nodes_to_move_threshold = nodes_to_move_threshold
+        self.ace_select_lcc = ace_select_lcc
         self.pls_ncomp = pls_ncomp
         self.pls_model_k = pls_model_k
         self.pls_pred_k = pls_pred_k
@@ -534,6 +539,7 @@ class DenoiseGraph(PerComponentTask):
                 max_iter=self.max_iter,
                 min_seed_pct=self.min_seed_pct,
                 nodes_to_move_threshold=self.nodes_to_move_threshold,
+                select_lcc=self.ace_select_lcc,
             )
             if ace_result == [None]:
                 disqualified = True

--- a/src/pixelator/pna/analysis/denoise.py
+++ b/src/pixelator/pna/analysis/denoise.py
@@ -189,7 +189,6 @@ def denoise_ace_layer(
     max_iter: int = 200,
     min_seed_pct: float = 0.1,
     nodes_to_move_threshold: int = 10,
-    select_LCC: bool = True,
 ) -> list:
     """Partition the graph with ACE and return nodes in the peripheral-like ("low") partition.
 
@@ -202,7 +201,6 @@ def denoise_ace_layer(
         max_iter: Maximum expansion iterations per binding threshold in ACE.
         min_seed_pct: Minimum fraction of nodes required for the initial ACE seed.
         nodes_to_move_threshold: ACE convergence threshold (nodes moved per iteration).
-        select_LCC: Whether to restrict the ACE seed to the largest k-core component.
 
     Returns:
         List of node identifiers to remove, or ``[None]`` if the component is
@@ -217,7 +215,6 @@ def denoise_ace_layer(
             max_iter=max_iter,
             min_seed_pct=min_seed_pct,
             nodes_to_move_threshold=nodes_to_move_threshold,
-            select_LCC=select_LCC,
         )
     except ValueError as exc:
         logger.debug("ACE denoising skipped for component: %s", exc)
@@ -234,13 +231,11 @@ def denoise_one_core_layer(
     inflate_factor: float = 1.5,
     one_core_ratio_threshold: float = 0.9,
 ) -> list:
-    """Identify and remove markers over-expressed in the one-core layer of a graph.
+    """Identify markers over-expressed in the one-core layer and sample nodes to remove.
 
     This function analyzes the one-core layer of a graph, identifies markers
     that are over-expressed using a statistical significance threshold, and
-    removes nodes associated with those markers. Additionally, it ensures
-    that stranded nodes (nodes disconnected from the graph due to removal)
-    are also removed.
+    samples nodes associated with those markers for removal (bleed-over candidates).
 
     Args:
         component (PNAGraph): The graph component to process, containing
@@ -253,7 +248,9 @@ def denoise_one_core_layer(
                                                    their one-core layer are not denoised.
 
     Returns:
-        list: A list of nodes to be removed from the one-core layer of the graph.
+        list: Node ids sampled for removal from the one-core layer (bleed-over
+        candidates). Does not include stranded nodes; callers merge with other
+        denoise steps and then call ``get_stranded_nodes`` once on the combined set.
 
     """
     node_marker_counts = component.node_marker_counts
@@ -272,8 +269,6 @@ def denoise_one_core_layer(
         ((node_core_numbers[node_marker_counts.index] == 1).values)
     ]
     nodes_to_remove = _sample_nodes_to_be_removed(one_core_layer, markers_to_remove)
-    stranded_nodes = get_stranded_nodes(component, nodes_to_remove)
-    nodes_to_remove += stranded_nodes
     return nodes_to_remove
 
 
@@ -307,189 +302,117 @@ def write_denoised_edgelist(
         )
 
 
-class DenoiseOneCore(PerComponentTask):
-    """Denoise bleed-over markers in parts of the component with low coreness."""
+class DenoiseGraph(PerComponentTask):
+    """Graph denoising: one-core and/or ACE on the full graph, then merged removal plus stranding."""
 
-    TASK_NAME = "denoise-one-core"
+    TASK_NAME = "denoise-graph"
 
     def __init__(
         self,
+        *,
+        run_one_core: bool = False,
+        run_ace: bool = False,
         pval_significance_threshold: float = 0.05,
         inflate_factor: float = 1.5,
         one_core_ratio_threshold: float = 0.9,
-    ):
-        """Initialize a DenoiseOneCore instance.
-
-        Args:
-            pval_significance_threshold (float): The p-value threshold for considering
-            a marker over-expressed in the one-core layer.
-            inflate_factor: A factor used to inflate the excess count of markers.
-            one_core_ratio_threshold: Components with higher nodes in their one-core
-                                      layer are not denoised.
-
-        """
-        self.pval_significance_threshold = pval_significance_threshold
-        self.inflate_factor = inflate_factor
-        self.one_core_ratio_threshold = one_core_ratio_threshold
-
-    def run_on_component_graph(
-        self, component: PNAGraph, component_id: str
-    ) -> pd.DataFrame:
-        """Execute one-core denoising on a given component graph and return nodes to remove.
-
-        This function performs denoising on the provided PNAGraph component by
-        identifying nodes to be removed based on a single core layer denoising
-        process. The resulting nodes are returned in a DataFrame along with
-        their associated component ID.
-
-        Args:
-            component (PNAGraph): The graph component to be denoised.
-            component_id (str): The identifier for the graph component.
-
-        Returns:
-            pd.DataFrame: A DataFrame containing the nodes to be removed with the following columns:
-                - "umi": The unique identifier of the node to be removed.
-                - "component": The ID of the component the node belongs to.
-
-        """
-        logger.debug(f"Running low-core denoising on component {component_id}")
-        nodes_to_remove = pd.DataFrame(
-            denoise_one_core_layer(
-                component,
-                pval_significance_threshold=self.pval_significance_threshold,
-                inflate_factor=self.inflate_factor,
-                one_core_ratio_threshold=self.one_core_ratio_threshold,
-            ),
-            columns=["umi"],
-        )
-        nodes_to_remove["component"] = component_id
-        return nodes_to_remove
-
-    def add_to_pixel_file(self, data: pd.DataFrame, pxl_file_target: PxlFile):
-        """Add denoised component to a pixel file by updating the edgelist and adata.
-
-        This function reads an existing pixel file, filters its edgelist
-        based on the provided data, and updates the file with the modified
-        edgelist and corresponding AnnData object.
-
-        Args:
-            data (pd.DataFrame): A DataFrame containing the data to be used
-                for filtering.
-            pxl_file_target (PxlFile): The target pixel file to which
-                the data will be added.
-
-        """
-        pxl = PNAPixelDataset.from_files(pxl_file_target)
-        old_adata = pxl.adata()
-        try:
-            panel = PNAAntibodyPanel.from_pxl_file(pxl_file_target.path)
-        except KeyError:
-            # If pxl file does not contain panel data, try to load it from
-            # the panel name.
-            # This will happen when old pxl files generated before v0.22.0
-            # are used.
-            panel_name = pxl.metadata().popitem()[1]["panel_name"]
-            panel = load_antibody_panel(pna_config, panel_name)
-        nodes_to_remove = (
-            data.loc[~data["umi"].isna(), "umi"].astype(np.uint64).tolist()
-        )
-
-        with tempfile.TemporaryDirectory() as temp_dir:
-            denoised_edgelist_path = temp_dir + "/denoised_edgelist.parquet"
-            write_denoised_edgelist(pxl, nodes_to_remove, denoised_edgelist_path)
-            with PixelFileWriter(pxl_file_target.path) as writer:
-                writer.write_edgelist(Path(denoised_edgelist_path))
-                adata = pna_edgelist_to_anndata(writer.get_connection(), panel)
-                call_aggregates(adata)
-                adata = add_missing_adata_info(adata, old_adata)
-                denoise_info = pd.DataFrame(index=adata.obs.index)
-                denoise_info["disqualified_for_denoising"] = False
-                denoise_info.loc[
-                    data.loc[data["umi"].isna(), "component"],
-                    "disqualified_for_denoising",
-                ] = True
-                n_umis_removed = (
-                    data.loc[~data["umi"].isna(), :].groupby("component").size()
-                )
-                denoise_info["number_of_nodes_removed_in_denoise"] = n_umis_removed
-                denoise_info["number_of_nodes_removed_in_denoise"] = denoise_info[
-                    "number_of_nodes_removed_in_denoise"
-                ].fillna(0)
-                adata.obs = adata.obs.join(denoise_info, how="left")
-
-                writer.write_adata(adata)
-
-
-class DenoiseACE(PerComponentTask):
-    """Remove peripheral-like nodes identified by adaptive core expansion (ACE)."""
-
-    TASK_NAME = "denoise-ace"
-
-    def __init__(
-        self,
         k: int = 3,
         max_k_core: int = 4,
         max_iter: int = 200,
         min_seed_pct: float = 0.1,
         nodes_to_move_threshold: int = 10,
-        select_LCC: bool = True,
     ):
-        """Initialize a DenoiseACE instance.
-
-        Args:
-            k: Neighborhood radius (steps) for the transition matrix in ACE.
-            max_k_core: Maximum k-core layer used for seeding in ACE.
-            max_iter: Maximum expansion iterations per binding threshold in ACE.
-            min_seed_pct: Minimum fraction of nodes required for the initial ACE seed.
-            nodes_to_move_threshold: ACE convergence threshold (nodes moved per iteration).
-            select_LCC: Whether to restrict the ACE seed to the largest k-core component.
-
-        """
+        """Configure which denoise steps run and their hyperparameters."""
+        if not run_one_core and not run_ace:
+            raise ValueError("At least one of run_one_core or run_ace must be True.")
+        self.run_one_core = run_one_core
+        self.run_ace = run_ace
+        self.pval_significance_threshold = pval_significance_threshold
+        self.inflate_factor = inflate_factor
+        self.one_core_ratio_threshold = one_core_ratio_threshold
         self.k = k
         self.max_k_core = max_k_core
         self.max_iter = max_iter
         self.min_seed_pct = min_seed_pct
         self.nodes_to_move_threshold = nodes_to_move_threshold
-        self.select_LCC = select_LCC
 
     def run_on_component_graph(
         self, component: PNAGraph, component_id: str
     ) -> pd.DataFrame:
-        """Execute ACE denoising on a given component graph and return nodes to remove.
+        """Return nodes to remove (including stranded) and per-method metadata columns.
 
-        This function performs denoising on the provided PNAGraph component by
-        identifying nodes to be removed based on a single core layer denoising
-        process. The resulting nodes are returned in a DataFrame along with
-        their associated component ID.
-
-        Args:
-            component (PNAGraph): The graph component to be denoised.
-            component_id (str): The identifier for the graph component.
-
-        Returns:
-            pd.DataFrame: A DataFrame containing the nodes to be removed with the following columns:
-                - "umi": The unique identifier of the node to be removed.
-                - "component": The ID of the component the node belongs to.
-
+        One-core and ACE each see the same full ``component`` graph; removals are
+        merged afterward so neither step is conditioned on the other's output.
         """
-        logger.debug("Running ACE denoising on component %s", component_id)
-        nodes_to_remove = pd.DataFrame(
-            denoise_ace_layer(
+        one_core_marked: list = []
+        ace_marked: list = []
+        disqualified = False
+
+        if self.run_one_core:
+            logger.debug("Running one-core denoising on component %s", component_id)
+            oc = denoise_one_core_layer(
+                component,
+                pval_significance_threshold=self.pval_significance_threshold,
+                inflate_factor=self.inflate_factor,
+                one_core_ratio_threshold=self.one_core_ratio_threshold,
+            )
+            if oc == [None]:
+                disqualified = True
+            else:
+                one_core_marked = oc
+
+        if self.run_ace:
+            logger.debug("Running ACE denoising on component %s", component_id)
+            ace_result = denoise_ace_layer(
                 component,
                 k=self.k,
                 max_k_core=self.max_k_core,
                 max_iter=self.max_iter,
                 min_seed_pct=self.min_seed_pct,
                 nodes_to_move_threshold=self.nodes_to_move_threshold,
-                select_LCC=self.select_LCC,
-            ),
-            columns=["umi"],
-        )
-        nodes_to_remove["component"] = component_id
-        return nodes_to_remove
+            )
+            if ace_result == [None]:
+                disqualified = True
+            else:
+                ace_marked = ace_result
+
+        combined: list = []
+        seen: set = set()
+        for n in one_core_marked + ace_marked:
+            if n not in seen:
+                seen.add(n)
+                combined.append(n)
+
+        if combined:
+            stranded = get_stranded_nodes(component, combined)
+            for n in stranded:
+                if n not in seen:
+                    seen.add(n)
+                    combined.append(n)
+
+        rows: list[dict] = []
+        ace_only_count = len(ace_marked)
+        for umi in combined:
+            rows.append(
+                {
+                    "umi": umi,
+                    "component": component_id,
+                    "ace_marked_count": ace_only_count,
+                }
+            )
+        if disqualified:
+            rows.append(
+                {
+                    "umi": np.nan,
+                    "component": component_id,
+                    "ace_marked_count": ace_only_count,
+                }
+            )
+        if not rows:
+            return pd.DataFrame(columns=["umi", "component", "ace_marked_count"])
+        return pd.DataFrame(rows)
 
     def add_to_pixel_file(self, data: pd.DataFrame, pxl_file_target: PxlFile):
-        """Update the pixel file by removing ACE ``low`` partition nodes and recording metrics."""
+        """Filter edgelist by removed nodes and write denoise metrics to AnnData."""
         pxl = PNAPixelDataset.from_files(pxl_file_target)
         old_adata = pxl.adata()
         try:
@@ -511,31 +434,27 @@ class DenoiseACE(PerComponentTask):
                 adata = add_missing_adata_info(adata, old_adata)
                 denoise_info = pd.DataFrame(index=adata.obs.index)
                 denoise_info["disqualified_for_denoising"] = False
-                denoise_info.loc[
-                    data.loc[data["umi"].isna(), "component"],
-                    "disqualified_for_denoising",
-                ] = True
-                n_ace_removed = (
+                disq_components = data.loc[data["umi"].isna(), "component"].unique()
+                denoise_info.loc[disq_components, "disqualified_for_denoising"] = True
+
+                n_total_removed = (
                     data.loc[~data["umi"].isna(), :].groupby("component").size()
                 )
-                denoise_info["number_of_nodes_removed_in_denoise_ace"] = n_ace_removed
-                denoise_info["number_of_nodes_removed_in_denoise_ace"] = denoise_info[
-                    "number_of_nodes_removed_in_denoise_ace"
-                ].fillna(0)
-                if "number_of_nodes_removed_in_denoise" in old_adata.obs.columns:
-                    prev = (
-                        old_adata.obs["number_of_nodes_removed_in_denoise"]
-                        .reindex(denoise_info.index)
-                        .fillna(0)
-                        .astype(int)
+                denoise_info["number_of_nodes_removed_in_denoise"] = (
+                    pd.to_numeric(
+                        n_total_removed.reindex(denoise_info.index), errors="coerce"
                     )
-                    denoise_info["number_of_nodes_removed_in_denoise"] = (
-                        prev + denoise_info["number_of_nodes_removed_in_denoise_ace"]
-                    )
-                else:
-                    denoise_info["number_of_nodes_removed_in_denoise"] = denoise_info[
-                        "number_of_nodes_removed_in_denoise_ace"
-                    ]
+                    .fillna(0)
+                    .astype("int64")
+                )
+
+                n_ace = data.groupby("component")["ace_marked_count"].first()
+                denoise_info["number_of_nodes_removed_in_denoise_ace"] = (
+                    pd.to_numeric(n_ace.reindex(denoise_info.index), errors="coerce")
+                    .fillna(0)
+                    .astype("int64")
+                )
+
                 if "disqualified_for_denoising" in old_adata.obs.columns:
                     denoise_info["disqualified_for_denoising"] = (
                         old_adata.obs["disqualified_for_denoising"]

--- a/src/pixelator/pna/analysis/denoise.py
+++ b/src/pixelator/pna/analysis/denoise.py
@@ -220,7 +220,6 @@ def denoise_ace_layer(
             min_seed_pct=min_seed_pct,
             nodes_to_move_threshold=nodes_to_move_threshold,
             select_LCC=select_LCC,
-            verbose=False,
         )
     except ValueError as exc:
         logger.debug("ACE denoising skipped for component: %s", exc)

--- a/src/pixelator/pna/analysis/denoise.py
+++ b/src/pixelator/pna/analysis/denoise.py
@@ -19,6 +19,7 @@ import polars as pl
 from scipy.stats import fisher_exact
 
 from pixelator.common.annotate.aggregates import call_aggregates
+from pixelator.common.graph.adaptive_core_expansion import adaptive_core_expansion
 from pixelator.pna.analysis_engine import PerComponentTask
 from pixelator.pna.anndata import add_missing_adata_info, pna_edgelist_to_anndata
 from pixelator.pna.config import pna_config
@@ -181,6 +182,53 @@ def get_stranded_nodes(component: PNAGraph, nodes_to_remove: list = []) -> list:
     connected_components = sorted(nx.connected_components(graph), key=len, reverse=True)
     stranded_nodes = list(chain.from_iterable(connected_components[1:]))
     return stranded_nodes
+
+
+def denoise_ace_layer(
+    component: PNAGraph,
+    k: int = 3,
+    max_k_core: int = 4,
+    max_iter: int = 200,
+    min_seed_pct: float = 0.1,
+    nodes_to_move_threshold: int = 10,
+    select_LCC: bool = True,
+) -> list:
+    """Partition the graph with ACE and return nodes in the peripheral-like ("low") partition.
+
+    Nodes in the ``low`` partition are candidates for removal to retain a denser core-like graph.
+
+    Args:
+        component: The graph component to process.
+        k: Neighborhood radius (steps) for the transition matrix in ACE.
+        max_k_core: Maximum k-core layer used for seeding in ACE.
+        max_iter: Maximum expansion iterations per binding threshold in ACE.
+        min_seed_pct: Minimum fraction of nodes required for the initial ACE seed.
+        nodes_to_move_threshold: ACE convergence threshold (nodes moved per iteration).
+        select_LCC: Whether to restrict the ACE seed to the largest k-core component.
+
+    Returns:
+        List of node identifiers to remove, or ``[None]`` if the component is
+        disqualified (ACE cannot be applied).
+
+    """
+    try:
+        adaptive_core_expansion(
+            component,
+            k=k,
+            max_k_core=max_k_core,
+            max_iter=max_iter,
+            min_seed_pct=min_seed_pct,
+            nodes_to_move_threshold=nodes_to_move_threshold,
+            select_LCC=select_LCC,
+            verbose=False,
+        )
+    except ValueError as exc:
+        logger.debug("ACE denoising skipped for component: %s", exc)
+        return [None]
+
+    partitions = nx.get_node_attributes(component.raw, "partition")
+    low_nodes = [n for n, part in partitions.items() if part == "low"]
+    return low_nodes
 
 
 def denoise_one_core_layer(
@@ -370,6 +418,113 @@ class DenoiseOneCore(PerComponentTask):
                 denoise_info["number_of_nodes_removed_in_denoise"] = denoise_info[
                     "number_of_nodes_removed_in_denoise"
                 ].fillna(0)
+                adata.obs = adata.obs.join(denoise_info, how="left")
+
+                writer.write_adata(adata)
+
+
+class DenoiseACE(PerComponentTask):
+    """Remove peripheral-like nodes identified by adaptive core expansion (ACE)."""
+
+    TASK_NAME = "denoise-ace"
+
+    def __init__(
+        self,
+        k: int = 3,
+        max_k_core: int = 4,
+        max_iter: int = 200,
+        min_seed_pct: float = 0.1,
+        nodes_to_move_threshold: int = 10,
+        select_LCC: bool = True,
+    ):
+        self.k = k
+        self.max_k_core = max_k_core
+        self.max_iter = max_iter
+        self.min_seed_pct = min_seed_pct
+        self.nodes_to_move_threshold = nodes_to_move_threshold
+        self.select_LCC = select_LCC
+
+    def run_on_component_graph(
+        self, component: PNAGraph, component_id: str
+    ) -> pd.DataFrame:
+        logger.debug("Running ACE denoising on component %s", component_id)
+        nodes_to_remove = pd.DataFrame(
+            denoise_ace_layer(
+                component,
+                k=self.k,
+                max_k_core=self.max_k_core,
+                max_iter=self.max_iter,
+                min_seed_pct=self.min_seed_pct,
+                nodes_to_move_threshold=self.nodes_to_move_threshold,
+                select_LCC=self.select_LCC,
+            ),
+            columns=["umi"],
+        )
+        nodes_to_remove["component"] = component_id
+        return nodes_to_remove
+
+    def add_to_pixel_file(self, data: pd.DataFrame, pxl_file_target: PxlFile):
+        """Update the pixel file by removing ACE ``low`` partition nodes and recording metrics."""
+        pxl = PNAPixelDataset.from_files(pxl_file_target)
+        old_adata = pxl.adata()
+        try:
+            panel = PNAAntibodyPanel.from_pxl_file(pxl_file_target.path)
+        except KeyError:
+            panel_name = pxl.metadata().popitem()[1]["panel_name"]
+            panel = load_antibody_panel(pna_config, panel_name)
+        nodes_to_remove = (
+            data.loc[~data["umi"].isna(), "umi"].astype(np.uint64).tolist()
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            denoised_edgelist_path = temp_dir + "/denoised_edgelist.parquet"
+            write_denoised_edgelist(pxl, nodes_to_remove, denoised_edgelist_path)
+            with PixelFileWriter(pxl_file_target.path) as writer:
+                writer.write_edgelist(Path(denoised_edgelist_path))
+                adata = pna_edgelist_to_anndata(writer.get_connection(), panel)
+                call_aggregates(adata)
+                adata = add_missing_adata_info(adata, old_adata)
+                denoise_info = pd.DataFrame(index=adata.obs.index)
+                denoise_info["disqualified_for_denoising"] = False
+                denoise_info.loc[
+                    data.loc[data["umi"].isna(), "component"],
+                    "disqualified_for_denoising",
+                ] = True
+                n_ace_removed = (
+                    data.loc[~data["umi"].isna(), :].groupby("component").size()
+                )
+                denoise_info["number_of_nodes_removed_in_denoise_ace"] = n_ace_removed
+                denoise_info["number_of_nodes_removed_in_denoise_ace"] = denoise_info[
+                    "number_of_nodes_removed_in_denoise_ace"
+                ].fillna(0)
+                if "number_of_nodes_removed_in_denoise" in old_adata.obs.columns:
+                    prev = (
+                        old_adata.obs["number_of_nodes_removed_in_denoise"]
+                        .reindex(denoise_info.index)
+                        .fillna(0)
+                        .astype(int)
+                    )
+                    denoise_info["number_of_nodes_removed_in_denoise"] = (
+                        prev + denoise_info["number_of_nodes_removed_in_denoise_ace"]
+                    )
+                else:
+                    denoise_info["number_of_nodes_removed_in_denoise"] = denoise_info[
+                        "number_of_nodes_removed_in_denoise_ace"
+                    ]
+                if "disqualified_for_denoising" in old_adata.obs.columns:
+                    denoise_info["disqualified_for_denoising"] = (
+                        old_adata.obs["disqualified_for_denoising"]
+                        .reindex(denoise_info.index)
+                        .fillna(False)
+                        | denoise_info["disqualified_for_denoising"]
+                    )
+                for col in (
+                    "disqualified_for_denoising",
+                    "number_of_nodes_removed_in_denoise",
+                    "number_of_nodes_removed_in_denoise_ace",
+                ):
+                    if col in adata.obs.columns:
+                        adata.obs = adata.obs.drop(columns=[col])
                 adata.obs = adata.obs.join(denoise_info, how="left")
 
                 writer.write_adata(adata)

--- a/src/pixelator/pna/analysis/denoise.py
+++ b/src/pixelator/pna/analysis/denoise.py
@@ -10,14 +10,19 @@ import random
 import tempfile
 from itertools import chain
 from pathlib import Path
+from typing import Literal, Optional
 
 import networkx as nx
 import numpy as np
 import pandas as pd
-from scipy.stats import fisher_exact
+from scipy.stats import fisher_exact, pearsonr
 
 from pixelator.common.annotate.aggregates import call_aggregates
 from pixelator.common.graph.adaptive_core_expansion import adaptive_core_expansion
+from pixelator.common.graph.node_pls import (
+    _create_node_neighborhood_abundance_matrix,
+    node_pls,
+)
 from pixelator.pna.analysis_engine import PerComponentTask
 from pixelator.pna.anndata import add_missing_adata_info, pna_edgelist_to_anndata
 from pixelator.pna.config import pna_config
@@ -182,7 +187,7 @@ def get_stranded_nodes(component: PNAGraph, nodes_to_remove: list = []) -> list:
     return stranded_nodes
 
 
-def denoise_ace_layer(
+def denoise_ace(
     component: PNAGraph,
     k: int = 3,
     max_k_core: int = 4,
@@ -223,6 +228,144 @@ def denoise_ace_layer(
     partitions = nx.get_node_attributes(component.raw, "partition")
     low_nodes = [n for n, part in partitions.items() if part == "low"]
     return low_nodes
+
+
+def _pixel_type_design_matrix(component: PNAGraph, node_index: pd.Index) -> np.ndarray:
+    """Build a 2-column design matrix [intercept, B-side dummy] matching R treatment coding.
+
+    PNA graphs store bipartite side in the ``pixel_type`` node attribute (``A`` / ``B``).
+    """
+    pixel_type = nx.get_node_attributes(component.raw, "pixel_type")
+    n = len(node_index)
+    mat = np.zeros((n, 2), dtype=np.float64)
+    mat[:, 0] = 1.0
+    for i, node_id in enumerate(node_index):
+        mat[i, 1] = 1.0 if pixel_type.get(node_id) == "B" else 0.0
+    return mat
+
+
+def _nodes_outside_largest_cc_after_pls_scores(
+    raw: nx.Graph,
+    node_index: pd.Index,
+    passing_mask: np.ndarray,
+) -> list:
+    """Return nodes to drop: fail score filter or lie outside the largest CC among passers."""
+    keep_candidates = [node_index[i] for i in range(len(node_index)) if passing_mask[i]]
+    if not keep_candidates:
+        return list(raw.nodes)
+
+    sub = raw.subgraph(keep_candidates)
+    largest = max(nx.connected_components(sub), key=len)
+    largest_set = set(largest)
+    return [n for n in raw.nodes if n not in largest_set]
+
+
+def denoise_pls(
+    component: PNAGraph,
+    *,
+    ncomp: int = 5,
+    model_k: int = 2,
+    pred_k: int = 1,
+    use_weights: bool = True,
+    normalization: Literal["L1", "CLR", "LogNormalize", "none"] = "L1",
+    residualize: bool = False,
+    pls_component_p_threshold: float = 0.01,
+    min_pls_coreness_correlation: float = 0.0,
+    pls_score_threshold: float = -3.0,
+) -> list:
+    """PLS-on-coreness denoise: significant components, score gate, then largest connected set.
+
+    Fits PLS with neighborhood radius ``model_k`` (as in R ``node_pls``) and scores nodes
+    using radius ``pred_k``. Defaults match the R intracellular script (``ncomp=5``,
+    ``model_k=2``, ``pred_k=1``, weighted L1, no residualization, ``cor > 0``,
+    ``p < 0.01``, all retained scores ``> -3``).
+
+    Unlike the R script, filtering uses **all** nodes (not only ACE ``high``); removals
+    are returned for merging with other denoise methods like ACE and one-core.
+
+    Args:
+        component: Component graph (mutates ``coreness`` on nodes temporarily).
+        ncomp: Requested PLS components (capped by sample size and feature count).
+        model_k: Neighborhood steps for fitting X (R ``model_k``).
+        pred_k: Neighborhood steps for prediction / scores (R ``pred_k``).
+        use_weights: Use edge weights in neighborhood expansion (R ``weighted``).
+        normalization: Neighborhood matrix normalization (R ``normalization``).
+        residualize: If True, residualize X against a ``pixel_type`` design matrix.
+        pls_component_p_threshold: Per-component Pearson test vs coreness (R ``0.01``).
+        min_pls_coreness_correlation: Minimum positive correlation (R ``cor > 0``).
+        pls_score_threshold: All selected score columns must exceed this (R ``-3``).
+
+    Returns:
+        Nodes to remove, ``[]`` if no PLS-based removal applies, or ``[None]`` if the
+        component is disqualified (fit/scoring failed).
+    """
+    idx = component.node_marker_counts.index
+    n_samples = len(idx)
+    n_features = component.node_marker_counts.shape[1]
+    max_comp = min(ncomp, n_features, max(1, n_samples - 1))
+    if max_comp < 1:
+        logger.debug("PLS denoising skipped: insufficient samples or features.")
+        return [None]
+
+    coreness_series = pd.Series(nx.core_number(component.raw)).reindex(idx)
+    if coreness_series.isna().any():
+        logger.debug("PLS denoising skipped: missing coreness for some nodes.")
+        return [None]
+
+    nx.set_node_attributes(component.raw, coreness_series.to_dict(), "coreness")
+    model_mat: Optional[np.ndarray] = None
+    if residualize:
+        model_mat = _pixel_type_design_matrix(component, idx)
+
+    def _cleanup_coreness() -> None:
+        for n in list(component.raw.nodes):
+            data = component.raw.nodes[n]
+            if isinstance(data, dict) and "coreness" in data:
+                del data["coreness"]
+
+    try:
+        pls_model = node_pls(
+            component,
+            y_vars="coreness",
+            k=model_k,
+            use_weights=use_weights,
+            ncomp=max_comp,
+            normalization=normalization,
+            model_mat=model_mat,
+        )
+        X_pred = _create_node_neighborhood_abundance_matrix(
+            component,
+            k=pred_k,
+            use_weights=use_weights,
+            normalization=normalization,
+            model_mat=model_mat,
+        )
+        scores = pls_model.transform(X_pred.values)
+    except (ValueError, np.linalg.LinAlgError) as exc:
+        logger.debug("PLS denoising skipped for component: %s", exc)
+        _cleanup_coreness()
+        return [None]
+
+    _cleanup_coreness()
+
+    n_scores = scores.shape[1]
+    coreness_arr = coreness_series.astype(float).values
+    comps_to_use: list[int] = []
+    for j in range(n_scores):
+        r, p = pearsonr(coreness_arr, scores[:, j])
+        if np.isnan(p) or np.isnan(r):
+            continue
+        if r > min_pls_coreness_correlation and p < pls_component_p_threshold:
+            comps_to_use.append(j)
+
+    if not comps_to_use:
+        return []
+
+    passing = np.ones(n_samples, dtype=bool)
+    for j in comps_to_use:
+        passing &= scores[:, j] > pls_score_threshold
+
+    return _nodes_outside_largest_cc_after_pls_scores(component.raw, idx, passing)
 
 
 def denoise_one_core_layer(
@@ -303,7 +446,7 @@ def write_denoised_edgelist(
 
 
 class DenoiseGraph(PerComponentTask):
-    """Graph denoising: one-core and/or ACE on the full graph, then merged removal plus stranding."""
+    """Graph denoising: one-core, ACE, and/or PLS on the full graph, merged removal plus stranding."""
 
     TASK_NAME = "denoise-graph"
 
@@ -312,6 +455,7 @@ class DenoiseGraph(PerComponentTask):
         *,
         run_one_core: bool = False,
         run_ace: bool = False,
+        run_pls: bool = False,
         pval_significance_threshold: float = 0.05,
         inflate_factor: float = 1.5,
         one_core_ratio_threshold: float = 0.9,
@@ -320,12 +464,24 @@ class DenoiseGraph(PerComponentTask):
         max_iter: int = 200,
         min_seed_pct: float = 0.1,
         nodes_to_move_threshold: int = 10,
+        pls_ncomp: int = 5,
+        pls_model_k: int = 2,
+        pls_pred_k: int = 1,
+        pls_use_weights: bool = True,
+        pls_normalization: Literal["L1", "CLR", "LogNormalize", "none"] = "L1",
+        pls_residualize: bool = False,
+        pls_component_p_threshold: float = 0.01,
+        min_pls_coreness_correlation: float = 0.0,
+        pls_score_threshold: float = -3.0,
     ):
         """Configure which denoise steps run and their hyperparameters."""
-        if not run_one_core and not run_ace:
-            raise ValueError("At least one of run_one_core or run_ace must be True.")
+        if not run_one_core and not run_ace and not run_pls:
+            raise ValueError(
+                "At least one of run_one_core, run_ace, or run_pls must be True."
+            )
         self.run_one_core = run_one_core
         self.run_ace = run_ace
+        self.run_pls = run_pls
         self.pval_significance_threshold = pval_significance_threshold
         self.inflate_factor = inflate_factor
         self.one_core_ratio_threshold = one_core_ratio_threshold
@@ -334,17 +490,27 @@ class DenoiseGraph(PerComponentTask):
         self.max_iter = max_iter
         self.min_seed_pct = min_seed_pct
         self.nodes_to_move_threshold = nodes_to_move_threshold
+        self.pls_ncomp = pls_ncomp
+        self.pls_model_k = pls_model_k
+        self.pls_pred_k = pls_pred_k
+        self.pls_use_weights = pls_use_weights
+        self.pls_normalization = pls_normalization
+        self.pls_residualize = pls_residualize
+        self.pls_component_p_threshold = pls_component_p_threshold
+        self.min_pls_coreness_correlation = min_pls_coreness_correlation
+        self.pls_score_threshold = pls_score_threshold
 
     def run_on_component_graph(
         self, component: PNAGraph, component_id: str
     ) -> pd.DataFrame:
         """Return nodes to remove (including stranded) and per-method metadata columns.
 
-        One-core and ACE each see the same full ``component`` graph; removals are
-        merged afterward so neither step is conditioned on the other's output.
+        One-core, ACE, and PLS each see the same full ``component`` graph; removals are
+        merged afterward so no step is conditioned on another's output.
         """
         one_core_marked: list = []
         ace_marked: list = []
+        pls_marked: list = []
         disqualified = False
 
         if self.run_one_core:
@@ -362,7 +528,7 @@ class DenoiseGraph(PerComponentTask):
 
         if self.run_ace:
             logger.debug("Running ACE denoising on component %s", component_id)
-            ace_result = denoise_ace_layer(
+            ace_result = denoise_ace(
                 component,
                 k=self.k,
                 max_k_core=self.max_k_core,
@@ -375,9 +541,28 @@ class DenoiseGraph(PerComponentTask):
             else:
                 ace_marked = ace_result
 
+        if self.run_pls:
+            logger.debug("Running PLS denoising on component %s", component_id)
+            pls_result = denoise_pls(
+                component,
+                ncomp=self.pls_ncomp,
+                model_k=self.pls_model_k,
+                pred_k=self.pls_pred_k,
+                use_weights=self.pls_use_weights,
+                normalization=self.pls_normalization,
+                residualize=self.pls_residualize,
+                pls_component_p_threshold=self.pls_component_p_threshold,
+                min_pls_coreness_correlation=self.min_pls_coreness_correlation,
+                pls_score_threshold=self.pls_score_threshold,
+            )
+            if pls_result == [None]:
+                disqualified = True
+            else:
+                pls_marked = pls_result
+
         combined: list = []
         seen: set = set()
-        for n in one_core_marked + ace_marked:
+        for n in one_core_marked + ace_marked + pls_marked:
             if n not in seen:
                 seen.add(n)
                 combined.append(n)
@@ -391,12 +576,14 @@ class DenoiseGraph(PerComponentTask):
 
         rows: list[dict] = []
         ace_only_count = len(ace_marked)
+        pls_only_count = len(pls_marked)
         for umi in combined:
             rows.append(
                 {
                     "umi": umi,
                     "component": component_id,
                     "ace_marked_count": ace_only_count,
+                    "pls_marked_count": pls_only_count,
                 }
             )
         if disqualified:
@@ -405,10 +592,18 @@ class DenoiseGraph(PerComponentTask):
                     "umi": np.nan,
                     "component": component_id,
                     "ace_marked_count": ace_only_count,
+                    "pls_marked_count": pls_only_count,
                 }
             )
         if not rows:
-            return pd.DataFrame(columns=["umi", "component", "ace_marked_count"])
+            return pd.DataFrame(
+                columns=[
+                    "umi",
+                    "component",
+                    "ace_marked_count",
+                    "pls_marked_count",
+                ]
+            )
         return pd.DataFrame(rows)
 
     def add_to_pixel_file(self, data: pd.DataFrame, pxl_file_target: PxlFile):
@@ -455,6 +650,18 @@ class DenoiseGraph(PerComponentTask):
                     .astype("int64")
                 )
 
+                if "pls_marked_count" in data.columns:
+                    n_pls = data.groupby("component")["pls_marked_count"].first()
+                    denoise_info["number_of_nodes_removed_in_denoise_pls"] = (
+                        pd.to_numeric(
+                            n_pls.reindex(denoise_info.index), errors="coerce"
+                        )
+                        .fillna(0)
+                        .astype("int64")
+                    )
+                else:
+                    denoise_info["number_of_nodes_removed_in_denoise_pls"] = 0
+
                 if "disqualified_for_denoising" in old_adata.obs.columns:
                     denoise_info["disqualified_for_denoising"] = (
                         old_adata.obs["disqualified_for_denoising"]
@@ -466,6 +673,7 @@ class DenoiseGraph(PerComponentTask):
                     "disqualified_for_denoising",
                     "number_of_nodes_removed_in_denoise",
                     "number_of_nodes_removed_in_denoise_ace",
+                    "number_of_nodes_removed_in_denoise_pls",
                 ):
                     if col in adata.obs.columns:
                         adata.obs = adata.obs.drop(columns=[col])

--- a/src/pixelator/pna/analysis/denoise.py
+++ b/src/pixelator/pna/analysis/denoise.py
@@ -458,6 +458,23 @@ class DenoiseACE(PerComponentTask):
     def run_on_component_graph(
         self, component: PNAGraph, component_id: str
     ) -> pd.DataFrame:
+        """Execute ACE denoising on a given component graph and return nodes to remove.
+
+        This function performs denoising on the provided PNAGraph component by
+        identifying nodes to be removed based on a single core layer denoising
+        process. The resulting nodes are returned in a DataFrame along with
+        their associated component ID.
+
+        Args:
+            component (PNAGraph): The graph component to be denoised.
+            component_id (str): The identifier for the graph component.
+
+        Returns:
+            pd.DataFrame: A DataFrame containing the nodes to be removed with the following columns:
+                - "umi": The unique identifier of the node to be removed.
+                - "component": The ID of the component the node belongs to.
+
+        """
         logger.debug("Running ACE denoising on component %s", component_id)
         nodes_to_remove = pd.DataFrame(
             denoise_ace_layer(

--- a/src/pixelator/pna/cli/denoise.py
+++ b/src/pixelator/pna/cli/denoise.py
@@ -109,7 +109,7 @@ logger = logging.getLogger(__name__)
     is_flag=True,
     help=(
         "PLS-on-coreness denoise: retain the largest connected component after filtering nodes "
-        "by significant PLS score components (defaults match the R intracellular script). "
+        "by significant PLS score components. "
         "Uses the full graph like ACE and one-core; removals are merged with other methods."
     ),
 )

--- a/src/pixelator/pna/cli/denoise.py
+++ b/src/pixelator/pna/cli/denoise.py
@@ -17,7 +17,7 @@ from pixelator.common.utils import (
     write_parameters_file,
 )
 from pixelator.pna import read
-from pixelator.pna.analysis.denoise import DenoiseACE, DenoiseOneCore
+from pixelator.pna.analysis.denoise import DenoiseGraph
 from pixelator.pna.analysis.report import DenoiseSampleReport
 from pixelator.pna.analysis_engine import AnalysisManager, LoggingSetup
 from pixelator.pna.cli.common import output_option
@@ -49,7 +49,8 @@ logger = logging.getLogger(__name__)
     is_flag=True,
     help=(
         "Remove nodes in the peripheral-like ('low') partition from adaptive core expansion (ACE). "
-        "Can be combined with --run-one-core-graph-denoising (one-core runs first, then ACE)."
+        "Can be combined with --run-one-core-graph-denoising: both use the full component graph; "
+        "marked nodes are merged and stranded nodes are removed once at the end."
     ),
 )
 @click.option(
@@ -160,13 +161,17 @@ def denoise(
         report.write_json_file(metrics, indent=4)
         return
 
-    analysis_to_run = []
-    if run_one_core_graph_denoising:
-        analysis_to_run.append(
-            DenoiseOneCore(pval_threshold, inflate_factor, one_core_ratio_threshold)
+    analysis_to_run = [
+        DenoiseGraph(
+            run_one_core=run_one_core_graph_denoising,
+            run_ace=run_ace_denoising,
+            pval_significance_threshold=pval_threshold,
+            inflate_factor=inflate_factor,
+            one_core_ratio_threshold=one_core_ratio_threshold,
+            k=ace_k,
+            max_k_core=ace_max_k_core,
         )
-    if run_ace_denoising:
-        analysis_to_run.append(DenoiseACE(k=ace_k, max_k_core=ace_max_k_core))
+    ]
     logging_setup = LoggingSetup.from_logger(ctx.obj.get("LOGGER"))
     manager = AnalysisManager(analysis_to_run, logging_setup=logging_setup)
     pxl_dataset = read(pxl_file.path)

--- a/src/pixelator/pna/cli/denoise.py
+++ b/src/pixelator/pna/cli/denoise.py
@@ -68,6 +68,15 @@ logger = logging.getLogger(__name__)
     help="Maximum k-core layer used for ACE seeding when --run-ace-denoising is set.",
 )
 @click.option(
+    "--ace-no-select-lcc",
+    is_flag=True,
+    default=False,
+    help=(
+        "When --run-ace-denoising is set, do not restrict the ACE initial seed to the "
+        "largest connected component (default: seed uses the LCC)."
+    ),
+)
+@click.option(
     "--one-core-ratio-threshold",
     default=0.9,
     required=False,
@@ -186,6 +195,7 @@ def denoise(
     run_ace_denoising,
     ace_k,
     ace_max_k_core,
+    ace_no_select_lcc,
     one_core_ratio_threshold,
     pval_threshold,
     inflate_factor,
@@ -211,6 +221,7 @@ def denoise(
         run_pls_denoising=run_pls_denoising,
         ace_k=ace_k,
         ace_max_k_core=ace_max_k_core,
+        ace_select_lcc=not ace_no_select_lcc,
         one_core_ratio_threshold=one_core_ratio_threshold,
         pval_threshold=pval_threshold,
         inflate_factor=inflate_factor,
@@ -268,6 +279,7 @@ def denoise(
             one_core_ratio_threshold=one_core_ratio_threshold,
             k=ace_k,
             max_k_core=ace_max_k_core,
+            ace_select_lcc=not ace_no_select_lcc,
             pls_ncomp=pls_ncomp,
             pls_model_k=pls_model_k,
             pls_pred_k=pls_pred_k,

--- a/src/pixelator/pna/cli/denoise.py
+++ b/src/pixelator/pna/cli/denoise.py
@@ -17,7 +17,7 @@ from pixelator.common.utils import (
     write_parameters_file,
 )
 from pixelator.pna import read
-from pixelator.pna.analysis.denoise import DenoiseOneCore
+from pixelator.pna.analysis.denoise import DenoiseACE, DenoiseOneCore
 from pixelator.pna.analysis.report import DenoiseSampleReport
 from pixelator.pna.analysis_engine import AnalysisManager, LoggingSetup
 from pixelator.pna.cli.common import output_option
@@ -42,6 +42,29 @@ logger = logging.getLogger(__name__)
     required=False,
     is_flag=True,
     help="Run the denoise step to remove markers that are over-expressed in the one-core layer of a component.",
+)
+@click.option(
+    "--run-ace-denoising",
+    required=False,
+    is_flag=True,
+    help=(
+        "Remove nodes in the peripheral-like ('low') partition from adaptive core expansion (ACE). "
+        "Can be combined with --run-one-core-graph-denoising (one-core runs first, then ACE)."
+    ),
+)
+@click.option(
+    "--ace-k",
+    default=3,
+    type=click.IntRange(1, 6),
+    show_default=True,
+    help="Neighborhood radius (steps) for ACE when --run-ace-denoising is set.",
+)
+@click.option(
+    "--ace-max-k-core",
+    default=4,
+    type=click.IntRange(2, 10),
+    show_default=True,
+    help="Maximum k-core layer used for ACE seeding when --run-ace-denoising is set.",
 )
 @click.option(
     "--one-core-ratio-threshold",
@@ -86,6 +109,9 @@ def denoise(
     ctx,
     pxl_file,
     run_one_core_graph_denoising,
+    run_ace_denoising,
+    ace_k,
+    ace_max_k_core,
     one_core_ratio_threshold,
     pval_threshold,
     inflate_factor,
@@ -97,6 +123,9 @@ def denoise(
         "denoise",
         input_files=input_files,
         run_one_core_graph_denoising=run_one_core_graph_denoising,
+        run_ace_denoising=run_ace_denoising,
+        ace_k=ace_k,
+        ace_max_k_core=ace_max_k_core,
         one_core_ratio_threshold=one_core_ratio_threshold,
         pval_threshold=pval_threshold,
         inflate_factor=inflate_factor,
@@ -119,7 +148,7 @@ def denoise(
     )
     metrics = denoise_output / f"{sample_name}.report.json"
 
-    if not run_one_core_graph_denoising:
+    if not run_one_core_graph_denoising and not run_ace_denoising:
         report = DenoiseSampleReport(
             sample_id=sample_name,
             product_id="single-cell-pna",
@@ -131,9 +160,13 @@ def denoise(
         report.write_json_file(metrics, indent=4)
         return
 
-    analysis_to_run = [
-        DenoiseOneCore(pval_threshold, inflate_factor, one_core_ratio_threshold)
-    ]
+    analysis_to_run = []
+    if run_one_core_graph_denoising:
+        analysis_to_run.append(
+            DenoiseOneCore(pval_threshold, inflate_factor, one_core_ratio_threshold)
+        )
+    if run_ace_denoising:
+        analysis_to_run.append(DenoiseACE(k=ace_k, max_k_core=ace_max_k_core))
     logging_setup = LoggingSetup.from_logger(ctx.obj.get("LOGGER"))
     manager = AnalysisManager(analysis_to_run, logging_setup=logging_setup)
     pxl_dataset = read(pxl_file.path)

--- a/src/pixelator/pna/cli/denoise.py
+++ b/src/pixelator/pna/cli/denoise.py
@@ -103,6 +103,79 @@ logger = logging.getLogger(__name__)
     show_default=True,
     help="How much to inflate number of noise markers in the one-core layer to remove.",
 )
+@click.option(
+    "--run-pls-denoising",
+    required=False,
+    is_flag=True,
+    help=(
+        "PLS-on-coreness denoise: retain the largest connected component after filtering nodes "
+        "by significant PLS score components (defaults match the R intracellular script). "
+        "Uses the full graph like ACE and one-core; removals are merged with other methods."
+    ),
+)
+@click.option(
+    "--pls-ncomp",
+    default=5,
+    type=click.IntRange(1, 50),
+    show_default=True,
+    help="Requested PLS components when --run-pls-denoising is set (capped per component).",
+)
+@click.option(
+    "--pls-model-k",
+    default=2,
+    type=click.IntRange(0, 6),
+    show_default=True,
+    help="Neighborhood steps for fitting the PLS X matrix when --run-pls-denoising is set.",
+)
+@click.option(
+    "--pls-pred-k",
+    default=1,
+    type=click.IntRange(0, 6),
+    show_default=True,
+    help="Neighborhood steps for PLS scores (prediction X) when --run-pls-denoising is set.",
+)
+@click.option(
+    "--pls-use-weights/--pls-no-weights",
+    default=True,
+    show_default=True,
+    help="Use edge weights in PLS neighborhood expansion when --run-pls-denoising is set.",
+)
+@click.option(
+    "--pls-normalization",
+    default="L1",
+    type=click.Choice(["L1", "CLR", "LogNormalize", "none"], case_sensitive=True),
+    show_default=True,
+    help="Normalization for the PLS neighborhood matrix when --run-pls-denoising is set.",
+)
+@click.option(
+    "--pls-residualize",
+    is_flag=True,
+    help=(
+        "Residualize the PLS neighborhood matrix against pixel_type (A/B) when "
+        "--run-pls-denoising is set."
+    ),
+)
+@click.option(
+    "--pls-component-p-threshold",
+    default=0.01,
+    type=click.FloatRange(0.0, 1.0, min_open=True),
+    show_default=True,
+    help="Pearson vs coreness: keep PLS components with p-value below this when --run-pls-denoising is set.",
+)
+@click.option(
+    "--pls-min-coreness-correlation",
+    default=0.0,
+    type=click.FloatRange(-1.0, 1.0),
+    show_default=True,
+    help="Keep PLS components whose Pearson correlation with coreness exceeds this.",
+)
+@click.option(
+    "--pls-score-threshold",
+    default=-3.0,
+    type=float,
+    show_default=True,
+    help="All retained PLS score columns must exceed this value when --run-pls-denoising is set.",
+)
 @output_option
 @click.pass_context
 @timer
@@ -116,6 +189,16 @@ def denoise(
     one_core_ratio_threshold,
     pval_threshold,
     inflate_factor,
+    run_pls_denoising,
+    pls_ncomp,
+    pls_model_k,
+    pls_pred_k,
+    pls_use_weights,
+    pls_normalization,
+    pls_residualize,
+    pls_component_p_threshold,
+    pls_min_coreness_correlation,
+    pls_score_threshold,
     output,
 ):
     """Denoise components of a PXL file."""
@@ -125,11 +208,21 @@ def denoise(
         input_files=input_files,
         run_one_core_graph_denoising=run_one_core_graph_denoising,
         run_ace_denoising=run_ace_denoising,
+        run_pls_denoising=run_pls_denoising,
         ace_k=ace_k,
         ace_max_k_core=ace_max_k_core,
         one_core_ratio_threshold=one_core_ratio_threshold,
         pval_threshold=pval_threshold,
         inflate_factor=inflate_factor,
+        pls_ncomp=pls_ncomp,
+        pls_model_k=pls_model_k,
+        pls_pred_k=pls_pred_k,
+        pls_use_weights=pls_use_weights,
+        pls_normalization=pls_normalization,
+        pls_residualize=pls_residualize,
+        pls_component_p_threshold=pls_component_p_threshold,
+        pls_min_coreness_correlation=pls_min_coreness_correlation,
+        pls_score_threshold=pls_score_threshold,
         output=output,
     )
 
@@ -149,7 +242,11 @@ def denoise(
     )
     metrics = denoise_output / f"{sample_name}.report.json"
 
-    if not run_one_core_graph_denoising and not run_ace_denoising:
+    if (
+        not run_one_core_graph_denoising
+        and not run_ace_denoising
+        and not run_pls_denoising
+    ):
         report = DenoiseSampleReport(
             sample_id=sample_name,
             product_id="single-cell-pna",
@@ -165,11 +262,21 @@ def denoise(
         DenoiseGraph(
             run_one_core=run_one_core_graph_denoising,
             run_ace=run_ace_denoising,
+            run_pls=run_pls_denoising,
             pval_significance_threshold=pval_threshold,
             inflate_factor=inflate_factor,
             one_core_ratio_threshold=one_core_ratio_threshold,
             k=ace_k,
             max_k_core=ace_max_k_core,
+            pls_ncomp=pls_ncomp,
+            pls_model_k=pls_model_k,
+            pls_pred_k=pls_pred_k,
+            pls_use_weights=pls_use_weights,
+            pls_normalization=pls_normalization,
+            pls_residualize=pls_residualize,
+            pls_component_p_threshold=pls_component_p_threshold,
+            min_pls_coreness_correlation=pls_min_coreness_correlation,
+            pls_score_threshold=pls_score_threshold,
         )
     ]
     logging_setup = LoggingSetup.from_logger(ctx.obj.get("LOGGER"))

--- a/tests/common/test_adaptive_core_expansion.py
+++ b/tests/common/test_adaptive_core_expansion.py
@@ -14,7 +14,11 @@ from pixelator import read_pna as read
 from pixelator.common.graph.adaptive_core_expansion import adaptive_core_expansion
 
 PXL_FILE = (
-    Path(__file__).parents[2] / "tests" / "pna" / "data" / "PNA055_Sample07_S7.layout.pxl"
+    Path(__file__).parents[2]
+    / "tests"
+    / "pna"
+    / "data"
+    / "PNA055_Sample07_S7.layout.pxl"
 )
 COMPONENT_ID = "0a45497c6bfbfb22"
 

--- a/tests/common/test_adaptive_core_expansion.py
+++ b/tests/common/test_adaptive_core_expansion.py
@@ -35,7 +35,7 @@ def graph_from_pxl():
 def test_adaptive_core_expansion_works_as_expected(graph_from_pxl):
     """Test that adaptive_core_expansion works for various valid inputs."""
     # Basic execution and exact count check
-    res = adaptive_core_expansion(graph_from_pxl, verbose=False)
+    res = adaptive_core_expansion(graph_from_pxl)
     partitions = list(nx.get_node_attributes(res.raw, "partition").values())
     partition_counts = {
         "high": partitions.count("high"),
@@ -45,11 +45,11 @@ def test_adaptive_core_expansion_works_as_expected(graph_from_pxl):
     assert partition_counts == {"high": 43144, "low": 399}
 
     # Test with different valid parameter combinations (expect no errors)
-    adaptive_core_expansion(graph_from_pxl, k=2, verbose=False)
-    adaptive_core_expansion(graph_from_pxl, max_iter=10, verbose=False)
-    adaptive_core_expansion(graph_from_pxl, min_seed_pct=0.2, verbose=False)
-    adaptive_core_expansion(graph_from_pxl, nodes_to_move_threshold=100, verbose=False)
-    adaptive_core_expansion(graph_from_pxl, select_LCC=False, verbose=False)
+    adaptive_core_expansion(graph_from_pxl, k=2)
+    adaptive_core_expansion(graph_from_pxl, max_iter=10)
+    adaptive_core_expansion(graph_from_pxl, min_seed_pct=0.2)
+    adaptive_core_expansion(graph_from_pxl, nodes_to_move_threshold=100)
+    adaptive_core_expansion(graph_from_pxl, select_LCC=False)
 
 
 def test_adaptive_core_expansion_fails_with_invalid_input(graph_from_pxl):
@@ -72,14 +72,14 @@ def test_adaptive_core_expansion_fails_with_invalid_input(graph_from_pxl):
         adaptive_core_expansion(graph_from_pxl, nodes_to_move_threshold="Invalid")
 
     # Out of bounds numerical values
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         adaptive_core_expansion(graph_from_pxl, max_iter=0)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         adaptive_core_expansion(graph_from_pxl, max_iter=1001)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         adaptive_core_expansion(graph_from_pxl, min_seed_pct=2.0)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         adaptive_core_expansion(graph_from_pxl, nodes_to_move_threshold=-1)

--- a/tests/common/test_adaptive_core_expansion.py
+++ b/tests/common/test_adaptive_core_expansion.py
@@ -49,7 +49,6 @@ def test_adaptive_core_expansion_works_as_expected(graph_from_pxl):
     adaptive_core_expansion(graph_from_pxl, max_iter=10)
     adaptive_core_expansion(graph_from_pxl, min_seed_pct=0.2)
     adaptive_core_expansion(graph_from_pxl, nodes_to_move_threshold=100)
-    adaptive_core_expansion(graph_from_pxl, select_LCC=False)
 
 
 def test_adaptive_core_expansion_fails_with_invalid_input(graph_from_pxl):

--- a/tests/common/test_node_pls.py
+++ b/tests/common/test_node_pls.py
@@ -6,7 +6,6 @@ Copyright © 2025 Pixelgen Technologies AB.
 import numpy as np
 import pandas as pd
 import pytest
-import scipy.sparse as sp
 from sklearn.cross_decomposition import PLSRegression
 
 from pixelator.common.graph import Graph
@@ -20,7 +19,7 @@ from pixelator.common.graph.node_pls import (
 @pytest.fixture
 def mock_graph():
     """Create a simple mock graph for testing.
-    
+
     Nodes: 0, 1, 2
     Edges: (0, 1), (1, 2)
     Markers: A, B
@@ -33,13 +32,13 @@ def mock_graph():
             "marker": ["A", "B"],  # Dummy markers for edgelist creation
         }
     )
-    
+
     # Create graph
     # We use a custom way to add marker counts since from_edgelist adds them from the edgelist itself
     g = Graph.from_edgelist(
         edgelist, add_marker_counts=True, simplify=True, use_full_bipartite=True
     )
-    
+
     # Mock node_marker_counts
     # Graph.from_edgelist with add_marker_counts=True will have some counts.
     # But let's verify what they are or overwrite if needed.
@@ -53,7 +52,7 @@ def test_residualize_matrix():
     res = _residualize_matrix(X, model_mat)
     # Residuals should be near zero
     assert np.allclose(res, 0.0)
-    
+
     # Non-correlated
     X = np.array([[1.0], [0.0], [1.0]])
     model_mat = np.array([[0.0], [1.0], [0.0]])
@@ -65,14 +64,18 @@ def test_create_node_neighborhood_abundance_matrix(mock_graph):
     # Set custom counts for the mock graph
     # node_marker_counts returns a DataFrame, but it's computed from the backend.
     # To test this unit properly, we need a graph with known counts.
-    
+
     # Let's just check if it runs without error first
-    X_exp = _create_node_neighborhood_abundance_matrix(mock_graph, k=1, normalization="none", scale=False)
+    X_exp = _create_node_neighborhood_abundance_matrix(
+        mock_graph, k=1, normalization="none", scale=False
+    )
     assert isinstance(X_exp, pd.DataFrame)
     assert X_exp.shape[0] == mock_graph.vcount()
-    
+
     # Check L1 normalization
-    X_l1 = _create_node_neighborhood_abundance_matrix(mock_graph, k=0, normalization="L1", scale=False)
+    X_l1 = _create_node_neighborhood_abundance_matrix(
+        mock_graph, k=0, normalization="L1", scale=False
+    )
     row_sums = X_l1.sum(axis=1)
     # Nodes with 0 counts will have row_sum 0 or 1 depending on implementation
     # But for nodes with counts, it should be 1.
@@ -84,13 +87,16 @@ def test_create_node_neighborhood_abundance_matrix(mock_graph):
 def test_node_pls_basic(mock_graph):
     # Add a node attribute to the raw networkx graph for testing y_not_in_counts
     import networkx as nx
-    nx.set_node_attributes(mock_graph.raw, {n: i for i, n in enumerate(mock_graph.raw.nodes)}, "my_attr")
-    
+
+    nx.set_node_attributes(
+        mock_graph.raw, {n: i for i, n in enumerate(mock_graph.raw.nodes)}, "my_attr"
+    )
+
     # Run node_pls using a marker as Y
     marker_name = mock_graph.node_marker_counts.columns[0]
     model = node_pls(mock_graph, y_vars=marker_name, k=1, ncomp=1)
     assert isinstance(model, PLSRegression)
-    
+
     # Run node_pls using a graph attribute as Y
     model2 = node_pls(mock_graph, y_vars="my_attr", k=1, ncomp=1)
     assert isinstance(model2, PLSRegression)
@@ -99,4 +105,3 @@ def test_node_pls_basic(mock_graph):
 def test_node_pls_invalid_y(mock_graph):
     with pytest.raises(ValueError, match="not found in counts or graph attributes"):
         node_pls(mock_graph, y_vars="non_existent_var")
-

--- a/tests/pna/denoise/test_denoise.py
+++ b/tests/pna/denoise/test_denoise.py
@@ -13,7 +13,9 @@ import pytest
 from pandas.testing import assert_frame_equal, assert_series_equal
 
 from pixelator.pna.analysis.denoise import (
+    DenoiseACE,
     DenoiseOneCore,
+    denoise_ace_layer,
     denoise_one_core_layer,
     get_overexpressed_markers_in_one_core,
     get_stranded_nodes,
@@ -314,3 +316,66 @@ def test_denoise_one_core_analysis(pna_pxl_dataset, tmp_path):
             denoised_node_core_numbers[denoised_node_core_numbers > 1],
             check_like=True,
         )
+
+
+REFERENCE_ACE_COMPONENT = "0a45497c6bfbfb22"
+REFERENCE_ACE_LOW_NODE_COUNT = 399
+
+
+@pytest.mark.slow
+def test_denoise_ace_layer_reference_component(pna_pxl_dataset):
+    """ACE layer removal list matches peripheral partition on reference component."""
+    comp_graph = PNAGraph.from_edgelist(
+        pna_pxl_dataset.filter(components=[REFERENCE_ACE_COMPONENT])
+        .edgelist()
+        .to_polars()
+        .lazy()
+    )
+    removed = denoise_ace_layer(comp_graph)
+    assert removed != [None]
+    assert len(removed) == REFERENCE_ACE_LOW_NODE_COUNT
+    partitions = nx.get_node_attributes(comp_graph.raw, "partition")
+    low_ids = {n for n, p in partitions.items() if p == "low"}
+    assert set(removed) == low_ids
+
+
+@pytest.mark.slow
+def test_denoise_ace_analysis(pna_pxl_dataset, tmp_path):
+    """DenoiseACE analysis writes fewer nodes and records ACE removal counts."""
+    pxl_file_target = PixelDatasetSaver(pxl_dataset=pna_pxl_dataset).save(
+        "PNA055_Sample07_S7", Path(tmp_path) / "layout.pxl"
+    )
+    with mock.patch(
+        "pixelator.pna.analysis.denoise.load_antibody_panel"
+    ) as mock_load_panel:
+
+        def f(*args, **kwargs):
+            return load_antibody_panel(pna_config, "proxiome-immuno-155-v2")
+
+        mock_load_panel.side_effect = f
+
+        manager = AnalysisManager([DenoiseACE()])
+        denoised_dataset = manager.execute(pna_pxl_dataset, pxl_file_target)
+
+    obs = denoised_dataset.adata().obs
+    assert "number_of_nodes_removed_in_denoise_ace" in obs.columns
+    assert int(obs.loc[REFERENCE_ACE_COMPONENT, "number_of_nodes_removed_in_denoise_ace"]) == (
+        REFERENCE_ACE_LOW_NODE_COUNT
+    )
+    assert int(obs.loc[REFERENCE_ACE_COMPONENT, "number_of_nodes_removed_in_denoise"]) == (
+        REFERENCE_ACE_LOW_NODE_COUNT
+    )
+
+    orig_graph = PNAGraph.from_edgelist(
+        pna_pxl_dataset.filter(components=[REFERENCE_ACE_COMPONENT])
+        .edgelist()
+        .to_polars()
+        .lazy()
+    )
+    denoised_graph = PNAGraph.from_edgelist(
+        denoised_dataset.filter(components=[REFERENCE_ACE_COMPONENT])
+        .edgelist()
+        .to_polars()
+        .lazy()
+    )
+    assert denoised_graph.vcount() == orig_graph.vcount() - REFERENCE_ACE_LOW_NODE_COUNT

--- a/tests/pna/denoise/test_denoise.py
+++ b/tests/pna/denoise/test_denoise.py
@@ -13,8 +13,7 @@ import pytest
 from pandas.testing import assert_frame_equal, assert_series_equal
 
 from pixelator.pna.analysis.denoise import (
-    DenoiseACE,
-    DenoiseOneCore,
+    DenoiseGraph,
     denoise_ace_layer,
     denoise_one_core_layer,
     get_overexpressed_markers_in_one_core,
@@ -265,17 +264,22 @@ def test_denoise_one_core_layer(pna_pxl_dataset):
             pna_pxl_dataset.filter(components=[comp]).edgelist().to_polars().lazy()
         )
         nodes_to_be_removed = denoise_one_core_layer(comp_graph)
+        if nodes_to_be_removed == [None]:
+            continue
         node_core_numbers = pd.Series(nx.core_number(comp_graph.raw))
         assert all(node_core_numbers[nodes_to_be_removed] == 1)
 
+        with_stranded = nodes_to_be_removed + get_stranded_nodes(
+            comp_graph, nodes_to_be_removed
+        )
         denoised_graph = comp_graph.raw.copy()
-        denoised_graph.remove_nodes_from(nodes_to_be_removed)
+        denoised_graph.remove_nodes_from(with_stranded)
         assert nx.is_connected(denoised_graph)
 
 
 @pytest.mark.slow
 def test_denoise_one_core_analysis(pna_pxl_dataset, tmp_path):
-    """Test the DenoiseOneCore analysis."""
+    """Test graph denoising with one-core only."""
     pxl_file_target = PixelDatasetSaver(pxl_dataset=pna_pxl_dataset).save(
         "PNA055_Sample07_S7", Path(tmp_path) / "layout.pxl"
     )
@@ -289,7 +293,7 @@ def test_denoise_one_core_analysis(pna_pxl_dataset, tmp_path):
 
         mock_load_panel.side_effect = f
 
-        manager = AnalysisManager([DenoiseOneCore()])
+        manager = AnalysisManager([DenoiseGraph(run_one_core=True, run_ace=False)])
         denoised_dataset = manager.execute(pna_pxl_dataset, pxl_file_target)
 
     assert "tau_type" in denoised_dataset.adata().obs.columns
@@ -341,7 +345,7 @@ def test_denoise_ace_layer_reference_component(pna_pxl_dataset):
 
 @pytest.mark.slow
 def test_denoise_ace_analysis(pna_pxl_dataset, tmp_path):
-    """DenoiseACE analysis writes fewer nodes and records ACE removal counts."""
+    """ACE-only graph denoising records ACE removal counts."""
     pxl_file_target = PixelDatasetSaver(pxl_dataset=pna_pxl_dataset).save(
         "PNA055_Sample07_S7", Path(tmp_path) / "layout.pxl"
     )
@@ -354,7 +358,7 @@ def test_denoise_ace_analysis(pna_pxl_dataset, tmp_path):
 
         mock_load_panel.side_effect = f
 
-        manager = AnalysisManager([DenoiseACE()])
+        manager = AnalysisManager([DenoiseGraph(run_one_core=False, run_ace=True)])
         denoised_dataset = manager.execute(pna_pxl_dataset, pxl_file_target)
 
     obs = denoised_dataset.adata().obs

--- a/tests/pna/denoise/test_denoise.py
+++ b/tests/pna/denoise/test_denoise.py
@@ -359,12 +359,12 @@ def test_denoise_ace_analysis(pna_pxl_dataset, tmp_path):
 
     obs = denoised_dataset.adata().obs
     assert "number_of_nodes_removed_in_denoise_ace" in obs.columns
-    assert int(obs.loc[REFERENCE_ACE_COMPONENT, "number_of_nodes_removed_in_denoise_ace"]) == (
-        REFERENCE_ACE_LOW_NODE_COUNT
-    )
-    assert int(obs.loc[REFERENCE_ACE_COMPONENT, "number_of_nodes_removed_in_denoise"]) == (
-        REFERENCE_ACE_LOW_NODE_COUNT
-    )
+    assert int(
+        obs.loc[REFERENCE_ACE_COMPONENT, "number_of_nodes_removed_in_denoise_ace"]
+    ) == (REFERENCE_ACE_LOW_NODE_COUNT)
+    assert int(
+        obs.loc[REFERENCE_ACE_COMPONENT, "number_of_nodes_removed_in_denoise"]
+    ) == (REFERENCE_ACE_LOW_NODE_COUNT)
 
     orig_graph = PNAGraph.from_edgelist(
         pna_pxl_dataset.filter(components=[REFERENCE_ACE_COMPONENT])

--- a/tests/pna/denoise/test_denoise.py
+++ b/tests/pna/denoise/test_denoise.py
@@ -14,7 +14,7 @@ from pandas.testing import assert_frame_equal, assert_series_equal
 
 from pixelator.pna.analysis.denoise import (
     DenoiseGraph,
-    denoise_ace_layer,
+    denoise_ace,
     denoise_one_core_layer,
     get_overexpressed_markers_in_one_core,
     get_stranded_nodes,
@@ -327,7 +327,7 @@ REFERENCE_ACE_LOW_NODE_COUNT = 399
 
 
 @pytest.mark.slow
-def test_denoise_ace_layer_reference_component(pna_pxl_dataset):
+def test_denoise_ace_reference_component(pna_pxl_dataset):
     """ACE layer removal list matches peripheral partition on reference component."""
     comp_graph = PNAGraph.from_edgelist(
         pna_pxl_dataset.filter(components=[REFERENCE_ACE_COMPONENT])
@@ -335,7 +335,7 @@ def test_denoise_ace_layer_reference_component(pna_pxl_dataset):
         .to_polars()
         .lazy()
     )
-    removed = denoise_ace_layer(comp_graph)
+    removed = denoise_ace(comp_graph)
     assert removed != [None]
     assert len(removed) == REFERENCE_ACE_LOW_NODE_COUNT
     partitions = nx.get_node_attributes(comp_graph.raw, "partition")

--- a/tests/pna/denoise/test_denoise_cli.py
+++ b/tests/pna/denoise/test_denoise_cli.py
@@ -2,12 +2,18 @@
 
 import tempfile
 from pathlib import Path
+from unittest import mock
 
 import pytest
 from click.testing import CliRunner
 
 from pixelator import cli
+from pixelator.pna.config import pna_config
+from pixelator.pna.config.panel import load_antibody_panel
 from pixelator.pna.pixeldataset import read
+
+REFERENCE_COMPONENT = "0a45497c6bfbfb22"
+ACE_LOW_NODE_COUNT = 399
 
 
 @pytest.mark.slow
@@ -35,3 +41,78 @@ def test_denoise_runs_ok(pxl_file):
 
         result = read(Path(output_dir) / "denoise" / "file.denoised_graph.pxl")
         assert not result.adata().obs["disqualified_for_denoising"].any()
+
+
+def _patch_denoise_panel_loader():
+    """Layout test PXLs may lack ``panel_metadata``; mirror ``test_denoise_one_core_analysis``."""
+
+    def _load(*args, **kwargs):
+        return load_antibody_panel(pna_config, "proxiome-immuno-155-v2")
+
+    return mock.patch(
+        "pixelator.pna.analysis.denoise.load_antibody_panel", side_effect=_load
+    )
+
+
+@pytest.mark.slow
+def test_denoise_ace_cli_runs_ok(pna_pxl_file):
+    """ACE-only denoise completes and records ACE-specific removal counts."""
+    runner = CliRunner()
+    with tempfile.TemporaryDirectory() as output_dir, _patch_denoise_panel_loader():
+        args = [
+            "--cores",
+            "1",
+            "single-cell-pna",
+            "denoise",
+            str(pna_pxl_file),
+            "--output",
+            output_dir,
+            "--run-ace-denoising",
+            "--ace-k",
+            "3",
+            "--ace-max-k-core",
+            "4",
+        ]
+        cmd = runner.invoke(cli.main_cli, args)
+        assert cmd.exit_code == 0, cmd.output
+
+        out_pxl = Path(output_dir) / "denoise" / "PNA055_Sample07_S7.denoised_graph.pxl"
+        result = read(out_pxl)
+        obs = result.adata().obs
+        assert "number_of_nodes_removed_in_denoise_ace" in obs.columns
+        assert int(obs.loc[REFERENCE_COMPONENT, "number_of_nodes_removed_in_denoise_ace"]) == ACE_LOW_NODE_COUNT
+        assert int(obs.loc[REFERENCE_COMPONENT, "number_of_nodes_removed_in_denoise"]) == ACE_LOW_NODE_COUNT
+
+
+@pytest.mark.slow
+def test_denoise_one_core_and_ace_cli_runs_ok(pna_pxl_file):
+    """One-core then ACE (CLI order) produces cumulative removal stats."""
+    runner = CliRunner()
+    with tempfile.TemporaryDirectory() as output_dir, _patch_denoise_panel_loader():
+        args = [
+            "--cores",
+            "1",
+            "single-cell-pna",
+            "denoise",
+            str(pna_pxl_file),
+            "--output",
+            output_dir,
+            "--run-one-core-graph-denoising",
+            "--run-ace-denoising",
+            "--pval-threshold",
+            "0.05",
+            "--inflate-factor",
+            "1.5",
+        ]
+        cmd = runner.invoke(cli.main_cli, args)
+        assert cmd.exit_code == 0, cmd.output
+
+        out_pxl = Path(output_dir) / "denoise" / "PNA055_Sample07_S7.denoised_graph.pxl"
+        result = read(out_pxl)
+        obs = result.adata().obs
+        assert "number_of_nodes_removed_in_denoise_ace" in obs.columns
+        ace_removed = int(obs.loc[REFERENCE_COMPONENT, "number_of_nodes_removed_in_denoise_ace"])
+        total_removed = int(obs.loc[REFERENCE_COMPONENT, "number_of_nodes_removed_in_denoise"])
+        assert ace_removed == ACE_LOW_NODE_COUNT
+        assert total_removed >= ace_removed
+        assert total_removed > 0

--- a/tests/pna/denoise/test_denoise_cli.py
+++ b/tests/pna/denoise/test_denoise_cli.py
@@ -80,8 +80,14 @@ def test_denoise_ace_cli_runs_ok(pna_pxl_file):
         result = read(out_pxl)
         obs = result.adata().obs
         assert "number_of_nodes_removed_in_denoise_ace" in obs.columns
-        assert int(obs.loc[REFERENCE_COMPONENT, "number_of_nodes_removed_in_denoise_ace"]) == ACE_LOW_NODE_COUNT
-        assert int(obs.loc[REFERENCE_COMPONENT, "number_of_nodes_removed_in_denoise"]) == ACE_LOW_NODE_COUNT
+        assert (
+            int(obs.loc[REFERENCE_COMPONENT, "number_of_nodes_removed_in_denoise_ace"])
+            == ACE_LOW_NODE_COUNT
+        )
+        assert (
+            int(obs.loc[REFERENCE_COMPONENT, "number_of_nodes_removed_in_denoise"])
+            == ACE_LOW_NODE_COUNT
+        )
 
 
 @pytest.mark.slow
@@ -111,8 +117,12 @@ def test_denoise_one_core_and_ace_cli_runs_ok(pna_pxl_file):
         result = read(out_pxl)
         obs = result.adata().obs
         assert "number_of_nodes_removed_in_denoise_ace" in obs.columns
-        ace_removed = int(obs.loc[REFERENCE_COMPONENT, "number_of_nodes_removed_in_denoise_ace"])
-        total_removed = int(obs.loc[REFERENCE_COMPONENT, "number_of_nodes_removed_in_denoise"])
+        ace_removed = int(
+            obs.loc[REFERENCE_COMPONENT, "number_of_nodes_removed_in_denoise_ace"]
+        )
+        total_removed = int(
+            obs.loc[REFERENCE_COMPONENT, "number_of_nodes_removed_in_denoise"]
+        )
         assert ace_removed == ACE_LOW_NODE_COUNT
         assert total_removed >= ace_removed
         assert total_removed > 0

--- a/tests/pna/denoise/test_denoise_cli.py
+++ b/tests/pna/denoise/test_denoise_cli.py
@@ -92,7 +92,7 @@ def test_denoise_ace_cli_runs_ok(pna_pxl_file):
 
 @pytest.mark.slow
 def test_denoise_one_core_and_ace_cli_runs_ok(pna_pxl_file):
-    """One-core then ACE (CLI order) produces cumulative removal stats."""
+    """One-core plus ACE: ACE counts match full-graph ACE; total includes one-core and stranding."""
     runner = CliRunner()
     with tempfile.TemporaryDirectory() as output_dir, _patch_denoise_panel_loader():
         args = [

--- a/tests/pna/denoise/test_denoise_pls.py
+++ b/tests/pna/denoise/test_denoise_pls.py
@@ -1,0 +1,135 @@
+"""Tests for PLS-based graph denoising.
+
+Copyright © 2026 Pixelgen Technologies AB.
+"""
+
+from unittest import mock
+
+import networkx as nx
+import numpy as np
+import pandas as pd
+import polars as pl
+import pytest
+
+import pixelator.common.graph.node_pls as node_pls_mod
+from pixelator.pna.analysis import denoise as denoise_mod
+from pixelator.pna.analysis.denoise import (
+    DenoiseGraph,
+    _nodes_outside_largest_cc_after_pls_scores,
+    _pixel_type_design_matrix,
+    denoise_pls,
+)
+from pixelator.pna.graph import PNAGraph
+
+
+def _dense_bipartite_edgelist() -> pl.LazyFrame:
+    """Build a connected bipartite edgelist with enough markers for PLS."""
+    rows = []
+    umis_a = [f"a{i}" for i in range(10)]
+    umis_b = [f"b{i}" for i in range(10)]
+    markers = [f"M{k}" for k in range(8)]
+    for i, a in enumerate(umis_a):
+        for j, b in enumerate(umis_b):
+            if (i + j) % 3 != 0:
+                continue
+            rows.append(
+                {
+                    "umi1": a,
+                    "umi2": b,
+                    "marker_1": markers[(i + j) % 8],
+                    "marker_2": markers[(i + j + 2) % 8],
+                    "read_count": 1,
+                }
+            )
+    return pl.DataFrame(rows).lazy()
+
+
+@pytest.fixture
+def pls_sized_pna_graph() -> PNAGraph:
+    return PNAGraph.from_edgelist(_dense_bipartite_edgelist())
+
+
+def test_nodes_outside_largest_cc_after_pls_scores_path():
+    raw = nx.path_graph(4)
+    idx = pd.Index(list(raw.nodes))
+    passing = np.array([True, True, False, False])
+    removed = _nodes_outside_largest_cc_after_pls_scores(raw, idx, passing)
+    assert set(removed) == {2, 3}
+
+
+def test_nodes_outside_largest_cc_all_passing_returns_empty():
+    raw = nx.cycle_graph(5)
+    idx = pd.Index(list(raw.nodes))
+    passing = np.ones(len(idx), dtype=bool)
+    removed = _nodes_outside_largest_cc_after_pls_scores(raw, idx, passing)
+    assert removed == []
+
+
+def test_nodes_outside_largest_cc_no_passers_removes_all():
+    raw = nx.star_graph(4)
+    idx = pd.Index(list(raw.nodes))
+    passing = np.zeros(len(idx), dtype=bool)
+    removed = _nodes_outside_largest_cc_after_pls_scores(raw, idx, passing)
+    assert set(removed) == set(raw.nodes)
+
+
+def test_pixel_type_design_matrix_matches_node_order(pls_sized_pna_graph):
+    idx = pls_sized_pna_graph.node_marker_counts.index
+    mat = _pixel_type_design_matrix(pls_sized_pna_graph, idx)
+    assert mat.shape == (len(idx), 2)
+    assert np.all(mat[:, 0] == 1.0)
+    pt = nx.get_node_attributes(pls_sized_pna_graph.raw, "pixel_type")
+    for i, node_id in enumerate(idx):
+        assert mat[i, 1] == (1.0 if pt.get(node_id) == "B" else 0.0)
+
+
+def test_denoise_pls_no_removals_when_no_components_selected(pls_sized_pna_graph):
+    with mock.patch.object(denoise_mod, "pearsonr", return_value=(0.0, 0.5)):
+        out = denoise_pls(
+            pls_sized_pna_graph,
+            min_pls_coreness_correlation=0.0,
+            pls_component_p_threshold=0.01,
+        )
+    assert out == []
+
+
+def test_denoise_pls_create_matrix_uses_model_k_and_pred_k(pls_sized_pna_graph):
+    ks: list[int] = []
+    _create_real = node_pls_mod._create_node_neighborhood_abundance_matrix
+
+    def _capture(cg, k, *args, **kwargs):
+        ks.append(k)
+        return _create_real(cg, k, *args, **kwargs)
+
+    with (
+        mock.patch.object(
+            node_pls_mod,
+            "_create_node_neighborhood_abundance_matrix",
+            side_effect=_capture,
+        ),
+        mock.patch.object(
+            denoise_mod,
+            "_create_node_neighborhood_abundance_matrix",
+            side_effect=_capture,
+        ),
+    ):
+        denoise_pls(
+            pls_sized_pna_graph,
+            model_k=2,
+            pred_k=1,
+            pls_component_p_threshold=1e-9,
+            min_pls_coreness_correlation=-1.0,
+            pls_score_threshold=-1e9,
+        )
+    assert 2 in ks and 1 in ks
+    assert ks.index(2) < ks.index(1)
+
+
+def test_denoise_graph_accepts_pls_only():
+    g = DenoiseGraph(run_one_core=False, run_ace=False, run_pls=True)
+    assert g.run_pls and not g.run_one_core and not g.run_ace
+
+
+def test_denoise_graph_requires_at_least_one_mode():
+    with pytest.raises(ValueError, match="At least one"):
+        DenoiseGraph(run_one_core=False, run_ace=False, run_pls=False)

--- a/uv.lock
+++ b/uv.lock
@@ -2038,7 +2038,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.5" },
     { name = "ruamel-yaml", specifier = ">=0.17.21,<0.18" },
     { name = "scanpy" },
-    { name = "scipy", specifier = ">=1.0.0,<2.0.0" },
+    { name = "scipy", specifier = ">=1.11.0,<2.0.0" },
     { name = "semver", specifier = ">=3.0.0,<4" },
     { name = "types-requests", specifier = ">=2.32.4.20260107" },
     { name = "typing-extensions" },


### PR DESCRIPTION
This PR enables adaptive core expansion (ACE) as method for removing potentially noisy nodes in the peripheral regions of a component through the denoise CLI. --run-ace-denoising will activate this method in "pixelator single-cell-pna denoise" command.

Fixes: PNA-2644

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce it when relevant.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
