### PR TITLE
fix: add archived panels to validate_panel panel_options

### DIFF
--- a/src/pixelator/pna/cli/common.py
+++ b/src/pixelator/pna/cli/common.py
@@ -115,7 +115,9 @@ def validate_panel(ctx, param, value):
     else:
         from pixelator.pna.config import pna_config
 
-        panel_options = list(pna_config.list_panel_names(include_aliases=True))
+        panel_options = list(
+            pna_config.list_panel_names(include_aliases=True, include_archived=True)
+        )
 
         if value not in panel_options:
             raise click.UsageError(


### PR DESCRIPTION
## Description
fix: add archived panels to validate_panel panel_options

validate_panel used in the panel_option click decorator need `include_archived=True` to allow to run with archived panels

Fixes: #(issue number)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce it when relevant.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
