### PR TITLE
feat: auto bump panel patch version when reading anndata

### DIFF
--- a/src/pixelator/pna/analysis/denoise.py
+++ b/src/pixelator/pna/analysis/denoise.py
@@ -24,7 +24,7 @@ from pixelator.pna.anndata import add_missing_adata_info, pna_edgelist_to_anndat
 from pixelator.pna.config import pna_config
 from pixelator.pna.config.panel import PNAAntibodyPanel, load_antibody_panel
 from pixelator.pna.graph import PNAGraph
-from pixelator.pna.pixeldataset import PNAPixelDataset
+from pixelator.pna.pixeldataset import PNAPixelDataset, read
 from pixelator.pna.pixeldataset.io import PixelFileWriter, PxlFile
 
 logger = logging.getLogger(__name__)
@@ -337,7 +337,7 @@ class DenoiseOneCore(PerComponentTask):
         pxl = PNAPixelDataset.from_files(pxl_file_target)
         old_adata = pxl.adata()
         try:
-            panel = PNAAntibodyPanel.from_pxl_file(pxl_file_target.path)
+            panel = PNAAntibodyPanel.from_pxl_dataset(read(pxl_file_target.path))
         except KeyError:
             # If pxl file does not contain panel data, try to load it from
             # the panel name.

--- a/src/pixelator/pna/anndata.py
+++ b/src/pixelator/pna/anndata.py
@@ -28,13 +28,8 @@ def add_panel_information(adata: AnnData, panel: PNAAntibodyPanel) -> AnnData:
     """Add panel data to var."""
     adata.var = adata.var.join(panel.df, how="left")
 
-    adata.uns["panel_metadata"] = {
-        "name": panel.name,
-        "aliases": panel.aliases,
-        "description": panel.description,
-        "version": panel.version,
-        "panel_columns": list(panel.df.columns),
-    }
+    adata.uns["panel_metadata"] = panel.metadata.model_dump()
+    adata.uns["panel_metadata"]["panel_columns"] = list(panel.df.columns)
 
     return adata
 

--- a/src/pixelator/pna/cli/common.py
+++ b/src/pixelator/pna/cli/common.py
@@ -115,7 +115,9 @@ def validate_panel(ctx, param, value):
     else:
         from pixelator.pna.config import pna_config
 
-        panel_options = list(pna_config.list_panel_names(include_aliases=True))
+        panel_options = list(
+            pna_config.list_panel_names(include_aliases=True, include_archived=True)
+        )
 
         if value not in panel_options:
             raise click.UsageError(

--- a/src/pixelator/pna/cli/sample_calling.py
+++ b/src/pixelator/pna/cli/sample_calling.py
@@ -98,7 +98,7 @@ def sample_calling_cli(
     pool_name = Path(input_pxl_file).name.split(".")[0]
     undetermined_sample_name = f"{pool_name}_undetermined"
 
-    panel_info = PNAAntibodyPanel.from_pxl_file(input_pxl_file)
+    panel_info = PNAAntibodyPanel.from_pxl_dataset(read(input_pxl_file))
     hashing_antibodies_in_panel = set(
         panel_info.df[panel_info.df["sample_hashing"] == "yes"].index.to_list()
     )

--- a/src/pixelator/pna/config/panel.py
+++ b/src/pixelator/pna/config/panel.py
@@ -10,6 +10,8 @@ from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional
 
+from anndata import AnnData
+
 try:
     from typing import Self
 except ImportError:
@@ -21,7 +23,6 @@ import pandas as pd
 import polars as pl
 import ruamel.yaml as yaml
 
-from pixelator import read_pna
 from pixelator.common.config import AntibodyPanelMetadata
 from pixelator.common.types import PathType
 from pixelator.common.utils import logger
@@ -104,27 +105,6 @@ class PNAAntibodyPanel:
         return cls(df, metadata, file_name=panel_file.name)
 
     @classmethod
-    def from_pxl_file(cls, filename: PathType) -> Self:
-        """Create an AntibodyPanel from a pxl file.
-
-        :param filename: The path to the pxl file.
-        :returns: The AntibodyPanel object.
-        :raises AssertionError: exception if panel file is missing,
-        :rtype: AntibodyPanel
-        """
-        pxl_file = Path(filename)
-
-        if not pxl_file.is_file() or pxl_file.suffix != ".pxl":
-            raise AssertionError(
-                f"Pixel file {filename} not found or has an incorrect format"
-            )
-
-        logger.debug("Creating Antibody panel from file %s", filename)
-
-        pxl_data = read_pna(pxl_file)
-        return cls.from_pxl_dataset(pxl_data, file_name=pxl_file.name)
-
-    @classmethod
     def from_pxl_dataset(
         cls, pxl_data: PNAPixelDataset, file_name: Optional[str] = None
     ) -> Self:
@@ -139,19 +119,40 @@ class PNAAntibodyPanel:
         """
         logger.debug("Creating Antibody panel from PNAPixelDataset object")
         adata = pxl_data.adata()
+        panel = cls.from_adata(adata, file_name=file_name)
+        logger.debug("Antibody panel from PNAPixelDataset created")
+        return panel
+
+    @classmethod
+    def from_adata(cls, adata: AnnData, file_name: Optional[str] = None) -> Self:
+        """Create an AntibodyPanel from an AnnData object.
+
+        :param adata: An AnnData object containing panel information.
+        :param file_name: The optional name of the file from which
+            the AnnData object was loaded.
+        :returns: The AntibodyPanel object.
+        :raises KeyError: exception if panel information is missing in the AnnData object.
+        :rtype: AntibodyPanel
+        """
+        logger.debug("Creating Antibody panel from AnnData object")
         try:
             panel_metadata = adata.uns["panel_metadata"]
         except KeyError as err:
             logger.error(  # pylint: disable=logging-not-lazy
-                f"The provided PNAPixelDataset does not contain {err}. "
+                f"The provided AnnData object does not contain {err}. "
                 + "Please, regenerate your data with the most recent version of pixelator."
             )
             raise
-        panel_columns = panel_metadata.pop("panel_columns")
+        panel_columns = panel_metadata.get("panel_columns")
+        if not panel_columns:
+            raise KeyError(
+                "The provided AnnData object does not contain panel columns information in the metadata. "
+                + "Please, regenerate your data with the most recent version of pixelator."
+            )
         df = adata.var[panel_columns]
         metadata = AntibodyPanelMetadata.model_validate(panel_metadata)
 
-        logger.debug("Antibody panel from PNAPixelDataset created")
+        logger.debug("Antibody panel from AnnData object created")
         return cls(df, metadata, file_name=file_name)
 
     @property

--- a/src/pixelator/pna/config/panel.py
+++ b/src/pixelator/pna/config/panel.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import warnings
 from functools import cached_property
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Set
 
 from anndata import AnnData
 
@@ -382,6 +382,16 @@ class PNAAntibodyPanel:
 
         return errors
 
+    def to_polars(self) -> pl.DataFrame:
+        """Convert the panel to a Polars DataFrame."""
+        return pl.from_pandas(self.df, include_index=True)
+
+    def __eq__(self, other: object) -> bool:
+        """Check if two panels are equal based on their dataframes and metadata."""
+        if not isinstance(other, PNAAntibodyPanel):
+            raise ValueError("Can only compare with another PNAAntibodyPanel")
+        return self.df.equals(other.df) and self.metadata == other.metadata
+
 
 def load_antibody_panel(config: PNAConfig, panel: PathType) -> PNAAntibodyPanel:
     """Load an antibody panel from a file or from the config file.
@@ -402,3 +412,137 @@ def load_antibody_panel(config: PNAConfig, panel: PathType) -> PNAAntibodyPanel:
 
     panel_obj = PNAAntibodyPanel.from_csv(panel)
     return panel_obj
+
+
+class PNAAntibodyPanelDiff:
+    """Class representing the differences between two PNAAntibodyPanel objects."""
+
+    join_on_columns: list[str] = ["sequence_1", "sequence_2"]
+
+    def __init__(self, panel_1: PNAAntibodyPanel, panel_2: PNAAntibodyPanel) -> None:
+        """Initialize the PNAAntibodyPanelDiff object.
+
+        :param panel_1: The first panel to compare.
+        :param panel_2: The second panel to compare.
+        """
+        self.panel_1 = panel_1
+        self.panel_2 = panel_2
+
+        self.joined = self.panel_1.to_polars().join(
+            self.panel_2.to_polars(),
+            on=self.join_on_columns,
+            how="full",
+            suffix="_panel_2",
+            # coalesce=True,
+        )
+
+        self._identical_columns: List[str] | None = None
+        self._changed_columns: List[str] | None = None
+        self._removed_columns: Set[str] | None = None
+        self._added_columns: Set[str] | None = None
+
+    @property
+    def identical_columns(self) -> List[str]:
+        """Return a list of columns that are identical between the two panels."""
+        if self._identical_columns is None:
+            self._identical_columns = [
+                col_name
+                for col_name in set(self.panel_1.to_polars().columns).union(
+                    set(self.panel_2.to_polars().columns)
+                )
+                if col_name in self.joined
+                and col_name + "_panel_2" in self.joined
+                and self.joined[col_name]
+                .eq_missing(self.joined[col_name + "_panel_2"])
+                .all()
+            ]
+        return self._identical_columns
+
+    @property
+    def changed_columns(self) -> List[str]:
+        """Return a list of columns that are different between the two panels."""
+        if self._changed_columns is None:
+            self._changed_columns = [
+                col_name
+                for col_name in set(self.panel_1.to_polars().columns).union(
+                    set(self.panel_2.to_polars().columns)
+                )
+                if col_name in self.joined
+                and col_name + "_panel_2" in self.joined
+                and not self.joined[col_name]
+                .eq_missing(self.joined[col_name + "_panel_2"])
+                .all()
+            ]
+            for col_name in self.changed_columns:
+                diff_count = self.joined.filter(
+                    pl.col(col_name).ne_missing(pl.col(col_name + "_panel_2"))
+                ).shape[0]
+                logger.info(
+                    f"Column {col_name} is different between the two panels {self.panel_1.name} and {self.panel_2.name} ({diff_count} differing entries)."
+                )
+        return self._changed_columns
+
+    @property
+    def removed_columns(self) -> List[str]:
+        """Return a list of columns that are present in panel 1 but not in panel 2."""
+        if self._removed_columns is None:
+            self._removed_columns = set(self.panel_1.to_polars().columns).difference(
+                set(self.panel_2.to_polars().columns)
+            )
+            for col_name in self.removed_columns:
+                logger.info(
+                    f"Column {col_name} is present in panel {self.panel_1.name} but not in panel {self.panel_2.name}."
+                )
+        return sorted(self._removed_columns)
+
+    @property
+    def added_columns(self) -> List[str]:
+        """Return a list of columns that are present in panel 2 but not in panel 1."""
+        if self._added_columns is None:
+            self._added_columns = set(self.panel_2.to_polars().columns).difference(
+                set(self.panel_1.to_polars().columns)
+            )
+            for col_name in self.added_columns:
+                logger.info(
+                    f"Column {col_name} is present in panel {self.panel_2.name} but not in panel {self.panel_1.name}."
+                )
+        return sorted(self._added_columns)
+
+    @property
+    def added_clones(self) -> pl.DataFrame:
+        """Return a dataframe with the clones that are present in panel 2 but not in panel 1."""
+        return (
+            self.joined.filter(
+                pl.any_horizontal(
+                    pl.col(col_name).is_null()
+                    & pl.col(col_name + "_panel_2").is_not_null()
+                    for col_name in self.join_on_columns
+                )
+            )
+            .drop([col_name for col_name in self.panel_1.to_polars().columns])
+            .rename(
+                {
+                    col_name + "_panel_2": col_name
+                    for col_name in self.panel_2.to_polars().columns
+                    if col_name + "_panel_2" in self.joined.columns
+                }
+            )
+        )
+
+    @property
+    def removed_clones(self) -> pl.DataFrame:
+        """Return a dataframe with the clones that are present in panel 1 but not in panel 2."""
+        return self.joined.filter(
+            pl.any_horizontal(
+                pl.col(col_name).is_not_null() & pl.col(col_name + "_panel_2").is_null()
+                for col_name in self.join_on_columns
+            )
+        ).drop(
+            [
+                col_name + "_panel_2"
+                if col_name in self.joined.columns
+                and col_name not in self.added_columns
+                else col_name
+                for col_name in self.panel_2.to_polars().columns
+            ]
+        )

--- a/src/pixelator/pna/config/panel.py
+++ b/src/pixelator/pna/config/panel.py
@@ -425,12 +425,19 @@ class PNAAntibodyPanelDiff:
         self.panel_1 = panel_1
         self.panel_2 = panel_2
 
+        logger.debug(
+            "Comparing panels %s v%s and %s v%s",
+            panel_1.name,
+            panel_1.version,
+            panel_2.name,
+            panel_2.version,
+        )
+
         self.joined = self.panel_1.to_polars().join(
             self.panel_2.to_polars(),
             on=self.join_on_columns,
             how="full",
             suffix="_panel_2",
-            # coalesce=True,
         )
 
         self._identical_columns: List[str] | None = None
@@ -439,71 +446,79 @@ class PNAAntibodyPanelDiff:
         self._added_columns: Set[str] | None = None
 
     @property
-    def identical_columns(self) -> List[str]:
-        """Return a list of columns that are identical between the two panels."""
-        if self._identical_columns is None:
-            self._identical_columns = [
-                col_name
-                for col_name in set(self.panel_1.to_polars().columns).union(
-                    set(self.panel_2.to_polars().columns)
-                )
-                if col_name in self.joined
-                and col_name + "_panel_2" in self.joined
-                and self.joined[col_name]
-                .eq_missing(self.joined[col_name + "_panel_2"])
-                .all()
-            ]
-        return self._identical_columns
-
-    @property
-    def changed_columns(self) -> List[str]:
-        """Return a list of columns that are different between the two panels."""
-        if self._changed_columns is None:
-            self._changed_columns = [
-                col_name
-                for col_name in set(self.panel_1.to_polars().columns).union(
-                    set(self.panel_2.to_polars().columns)
-                )
-                if col_name in self.joined
-                and col_name + "_panel_2" in self.joined
-                and not self.joined[col_name]
-                .eq_missing(self.joined[col_name + "_panel_2"])
-                .all()
-            ]
-            for col_name in self.changed_columns:
-                diff_count = self.joined.filter(
-                    pl.col(col_name).ne_missing(pl.col(col_name + "_panel_2"))
-                ).shape[0]
-                logger.info(
-                    f"Column {col_name} is different between the two panels {self.panel_1.name} and {self.panel_2.name} ({diff_count} differing entries)."
-                )
-        return self._changed_columns
-
-    @property
-    def removed_columns(self) -> List[str]:
-        """Return a list of columns that are present in panel 1 but not in panel 2."""
-        if self._removed_columns is None:
-            self._removed_columns = set(self.panel_1.to_polars().columns).difference(
+    def col_names_in_both_panels(self) -> List[str]:
+        """Return a list of column names that are present in both panels."""
+        return list(
+            set(self.panel_1.to_polars().columns).intersection(
                 set(self.panel_2.to_polars().columns)
             )
-            for col_name in self.removed_columns:
-                logger.info(
-                    f"Column {col_name} is present in panel {self.panel_1.name} but not in panel {self.panel_2.name}."
-                )
-        return sorted(self._removed_columns)
+        )
 
     @property
+    def identical_columns(self) -> List[str]:
+        """Return a list of columns that are identical between the two panels."""
+        return [
+            col_name
+            for col_name in self.col_names_in_both_panels
+            if self.joined[col_name]
+            .eq_missing(self.joined[col_name + "_panel_2"])
+            .all()
+        ]
+
+    @cached_property
+    def changed_columns(self) -> List[str]:
+        """Return a list of columns that are different between the two panels."""
+        changed_columns = [
+            col_name
+            for col_name in set(self.col_names_in_both_panels).difference(
+                set(self.join_on_columns)
+            )
+            if not self.joined[col_name]
+            .eq_missing(self.joined[col_name + "_panel_2"])
+            .all()
+        ]
+        for col_name in changed_columns:
+            diff_count = self.joined.filter(
+                pl.col(col_name).ne_missing(pl.col(col_name + "_panel_2"))
+            ).shape[0]
+            logger.debug(
+                "Column %s is different between the two panels %s and %s (%d differing entries).",
+                col_name,
+                self.panel_1.name,
+                self.panel_2.name,
+                diff_count,
+            )
+        return changed_columns
+
+    @cached_property
+    def removed_columns(self) -> List[str]:
+        """Return a list of columns that are present in panel 1 but not in panel 2."""
+        removed_columns = set(self.panel_1.to_polars().columns).difference(
+            set(self.panel_2.to_polars().columns)
+        )
+        for col_name in removed_columns:
+            logger.debug(
+                "Column %s is present in panel %s but not in panel %s.",
+                col_name,
+                self.panel_1.name,
+                self.panel_2.name,
+            )
+        return sorted(removed_columns)
+
+    @cached_property
     def added_columns(self) -> List[str]:
         """Return a list of columns that are present in panel 2 but not in panel 1."""
-        if self._added_columns is None:
-            self._added_columns = set(self.panel_2.to_polars().columns).difference(
-                set(self.panel_1.to_polars().columns)
+        added_columns = set(self.panel_2.to_polars().columns).difference(
+            set(self.panel_1.to_polars().columns)
+        )
+        for col_name in added_columns:
+            logger.debug(
+                "Column %s is present in panel %s but not in panel %s.",
+                col_name,
+                self.panel_2.name,
+                self.panel_1.name,
             )
-            for col_name in self.added_columns:
-                logger.info(
-                    f"Column {col_name} is present in panel {self.panel_2.name} but not in panel {self.panel_1.name}."
-                )
-        return sorted(self._added_columns)
+        return sorted(added_columns)
 
     @property
     def added_clones(self) -> pl.DataFrame:

--- a/src/pixelator/pna/config/panel.py
+++ b/src/pixelator/pna/config/panel.py
@@ -546,3 +546,37 @@ class PNAAntibodyPanelDiff:
                 for col_name in self.panel_2.to_polars().columns
             ]
         )
+
+    def upgrade_adata(self, adata: AnnData) -> AnnData:
+        """Upgrade an AnnData object with the changes between the two panels."""
+        adata_panel = PNAAntibodyPanel.from_adata(adata)
+        if self.panel_1 != adata_panel:
+            raise ValueError(
+                "The provided AnnData object does not match the panel. Cannot upgrade."
+                f"Expected panel {self.panel_2.name} v{self.panel_2.version}, but got panel {adata_panel.name} v{adata_panel.version}."
+            )
+
+        adata.var = (
+            self.joined.select(
+                list(
+                    set(
+                        self.join_on_columns
+                        + self.identical_columns
+                        + [f"{col}_panel_2" for col in self.changed_columns]
+                        + self.added_columns
+                    )
+                )
+            )
+            .rename({f"{col}_panel_2": col for col in self.changed_columns})
+            # keep order and append new to the end
+            .select(
+                ["marker_id"]  # index not in panel_metadata panel_columns below
+                + adata.uns["panel_metadata"]["panel_columns"]
+                + self.added_columns
+            )
+            .to_pandas()
+            .set_index("marker_id")
+        )
+        adata.uns["panel_metadata"] = self.panel_2.metadata.model_dump()
+        adata.uns["panel_metadata"]["panel_columns"] = adata.var.columns.tolist()
+        return adata

--- a/src/pixelator/pna/config/panel.py
+++ b/src/pixelator/pna/config/panel.py
@@ -67,7 +67,7 @@ class PNAAntibodyPanel:
                                 invalid or with incorrect format
         """
         self._filename = file_name
-        self._metadata = metadata
+        self.metadata = metadata
         self._df = df
 
         # validate the panel
@@ -162,7 +162,7 @@ class PNAAntibodyPanel:
             The panel name.
 
         """
-        return self._metadata.name
+        return self.metadata.name
 
     @property
     def product(self) -> Optional[str]:
@@ -172,7 +172,7 @@ class PNAAntibodyPanel:
             Product name, or None when not provided in panel metadata.
 
         """
-        return self._metadata.product
+        return self.metadata.product
 
     @property
     def version(self) -> str:
@@ -182,22 +182,22 @@ class PNAAntibodyPanel:
             Semantic version string for this panel.
 
         """
-        return self._metadata.version
+        return self.metadata.version
 
     @property
     def description(self) -> Optional[str]:
         """Return the panel file description."""
-        return self._metadata.description
+        return self.metadata.description
 
     @property
     def aliases(self) -> list[str]:
         """Return the (optional) list of panel file aliases."""
-        return self._metadata.aliases
+        return self.metadata.aliases
 
     @property
     def archived(self) -> Optional[bool]:
         """Return whether the panel is marked as archived."""
-        return self._metadata.archived
+        return self.metadata.archived
 
     @classmethod
     def _parse_header(cls, file: Path) -> AntibodyPanelMetadata:

--- a/src/pixelator/pna/config/panel.py
+++ b/src/pixelator/pna/config/panel.py
@@ -45,10 +45,7 @@ class PNAAntibodyPanel:
     }
 
     # and these should have unique values
-    _UNIQUE_COLUMNS = [
-        "sequence_1",
-        "sequence_2",
-    ]
+    _UNIQUE_COLUMNS = ["sequence_1", "sequence_2"]
 
     def __init__(
         self,
@@ -556,6 +553,14 @@ class PNAAntibodyPanelDiff:
                 f"Expected panel {self.panel_2.name} v{self.panel_2.version}, but got panel {adata_panel.name} v{adata_panel.version}."
             )
 
+        non_panel_columns = adata.var.copy()[
+            [
+                col
+                for col in adata.var.columns
+                if col not in adata.uns["panel_metadata"]["panel_columns"]
+            ]
+            + self.join_on_columns
+        ]
         adata.var = (
             self.joined.select(
                 list(
@@ -577,6 +582,15 @@ class PNAAntibodyPanelDiff:
             .to_pandas()
             .set_index("marker_id")
         )
+        if adata.var.shape[0] != non_panel_columns.shape[0]:
+            raise ValueError(
+                "Row count mismatch in automatic patch panel patch version bump."
+            )
+        adata.var = adata.var.join(
+            non_panel_columns.set_index(self.join_on_columns),
+            how="outer",
+            on=self.join_on_columns,
+        )
         adata.uns["panel_metadata"] = self.panel_2.metadata.model_dump()
-        adata.uns["panel_metadata"]["panel_columns"] = adata.var.columns.tolist()
+        adata.uns["panel_metadata"]["panel_columns"] = self.panel_2.df.columns.tolist()
         return adata

--- a/src/pixelator/pna/pixeldataset/io/anndata_helper.py
+++ b/src/pixelator/pna/pixeldataset/io/anndata_helper.py
@@ -11,10 +11,13 @@ from functools import cache
 from typing import Literal
 
 import polars as pl
+import semver
 from anndata import AnnData, ImplicitModificationWarning
 from anndata import concat as anndata_concat
 
 from pixelator.common.statistics import clr_transformation, log1p_transformation
+from pixelator.common.utils import logger
+from pixelator.pna.config.panel import PNAAntibodyPanel, PNAAntibodyPanelDiff
 from pixelator.pna.pixeldataset.utils import update_metrics_anndata
 from pixelator.pna.utils import normalize_input_to_list, normalize_input_to_set
 
@@ -58,6 +61,8 @@ class AnnDataHelper:
                 )
                 adatas.append(adata)
 
+        self._try_bump_adata_panel_version(adatas)
+
         if not adatas:
             return AnnData()
 
@@ -71,6 +76,43 @@ class AnnDataHelper:
         concatenated.uns = adatas[0].uns
         update_metrics_anndata(concatenated, inplace=True)
         return concatenated
+
+    def _try_bump_adata_panel_version(
+        self,
+        adatas: list[AnnData],
+    ) -> list[AnnData]:
+        """Try to bump the panel version of the given AnnData.
+
+        Only try to upgrade to the latest version available in the view,
+        if the panels differ in patch version and have the same product.
+        """
+        panel_versions = [
+            semver.Version.parse(adata.uns["panel_metadata"]["version"])
+            for adata in adatas
+        ]
+        panel_products = [
+            adata.uns["panel_metadata"].get("product") for adata in adatas
+        ]
+        latest_panel_version = max(panel_versions)
+        if (
+            all(ver.major == latest_panel_version.major for ver in panel_versions)
+            and all(ver.minor == latest_panel_version.minor for ver in panel_versions)
+            and len(set(panel_products)) == 1
+            and panel_products[0] is not None
+        ):
+            logger.info(
+                "Multiple panel patch versions for same product detected across samples. "
+                + "Attempting to upgrade to the latest."
+            )
+            latest_panel = PNAAntibodyPanel.from_adata(
+                adatas[panel_versions.index(latest_panel_version)]
+            )
+            for i, adata in enumerate(adatas):
+                panel = PNAAntibodyPanel.from_adata(adata)
+                if panel.version != latest_panel.version:
+                    diff = PNAAntibodyPanelDiff(panel, latest_panel)
+                    adatas[i] = diff.upgrade_adata(adata)
+        return adatas
 
     def _read_adata_from_sample(
         self,

--- a/src/pixelator/pna/pixeldataset/io/anndata_helper.py
+++ b/src/pixelator/pna/pixeldataset/io/anndata_helper.py
@@ -86,6 +86,12 @@ class AnnDataHelper:
         Only try to upgrade to the latest version available in the view,
         if the panels differ in patch version and have the same product.
         """
+        if any("panel_metadata" not in adata.uns for adata in adatas):
+            logger.debug(
+                "Missing panel metadata in one or more samples, "
+                + "skipping automatic panel version upgrade."
+            )
+            return adatas
         panel_versions = [
             semver.Version.parse(adata.uns["panel_metadata"]["version"])
             for adata in adatas

--- a/tests/pna/config/test_config.py
+++ b/tests/pna/config/test_config.py
@@ -152,7 +152,10 @@ def test_loading_multiple_major_version(config_with_multiple_versions):
     panel_name = "test-pna-panel>=0.0.1"
     with pytest.raises(
         ValueError,
-        match=f"Multiple major versions found for panel {panel_name}. Please specify the major and minor version in the panel name or alias to disambiguate.",
+        match=(
+            f"Multiple major versions found for panel {panel_name}. Please specify the major and "
+            + "minor version in the panel name or alias to disambiguate."
+        ),
     ):
         config_with_multiple_versions.get_panel(panel_name)
 
@@ -185,6 +188,14 @@ def test_loading_panel_from_config_specific_version(config_with_multiple_version
     panel = config_with_multiple_versions.get_panel("test-pna-panel", version="2.0.0")
     assert panel.name == "test-pna-panel"
     assert panel.version == "2.0.0"
+
+    panel = config_with_multiple_versions.get_panel("test-pna-panel==1.1.0")
+    assert panel.name == "test-pna-panel"
+    assert panel.version == "1.1.0"
+
+    panel = config_with_multiple_versions.get_panel("test-pna-panel==1.0.0")
+    assert panel.name == "test-pna-panel"
+    assert panel.version == "1.0.0"
 
 
 def test_loading_panel_from_config_product_and_specific_version(

--- a/tests/pna/config/test_panel.py
+++ b/tests/pna/config/test_panel.py
@@ -6,6 +6,7 @@ from pandas.testing import assert_frame_equal
 
 from pixelator.common.config import AntibodyPanelMetadata
 from pixelator.pna.config.panel import PNAAntibodyPanel
+from pixelator.pna.pixeldataset import read
 
 
 @pytest.fixture
@@ -92,7 +93,7 @@ def test_panel_validation_ok_uniprotid_empty(panel_df):
 
 
 def test_panel_from_pxl(pxl_file):
-    panel = PNAAntibodyPanel.from_pxl_file(pxl_file)
+    panel = PNAAntibodyPanel.from_pxl_dataset(read(pxl_file))
     assert panel.name == "test-pna-panel"
     assert panel.version == "0.1.0"
     assert panel.description == "Test R&D panel for RNA"

--- a/tests/pna/graph_legacy/conftest.py
+++ b/tests/pna/graph_legacy/conftest.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from pixelator.common.config.panel import AntibodyPanelMetadata
 from pixelator.pna.config import PNAAntibodyPanel
 
 
@@ -37,10 +38,18 @@ def mock_panel_fixture(request):
     if version.startswith("2"):
         mock_antibody_panel.df.drop(columns=["nuclear"], inplace=True)
 
-    mock_antibody_panel.name = "mock-panel"
-    mock_antibody_panel.version = version
-    mock_antibody_panel.description = "Dummy panel data"
-    mock_antibody_panel.aliases = ["mock_alias"]
+    mock_antibody_panel.metadata = AntibodyPanelMetadata.model_validate(
+        {
+            "name": "mock-panel",
+            "version": version,
+            "description": "Dummy panel data",
+            "aliases": ["mock_alias"],
+        }
+    )
+    mock_antibody_panel.name = mock_antibody_panel.metadata.name
+    mock_antibody_panel.version = mock_antibody_panel.metadata.version
+    mock_antibody_panel.aliases = mock_antibody_panel.metadata.aliases
+    mock_antibody_panel.description = mock_antibody_panel.metadata.description
     return mock_antibody_panel
 
 

--- a/tests/pna/graph_legacy/test_connected_components.py
+++ b/tests/pna/graph_legacy/test_connected_components.py
@@ -517,10 +517,7 @@ def test_build_pxl_file_with_components(lazy_edgelist_karate_graph, mock_panel, 
 
     adata = result.adata()
     assert adata.uns["panel_metadata"] == {
-        "name": mock_panel.name,
-        "description": mock_panel.description,
-        "aliases": mock_panel.aliases,
-        "version": mock_panel.version,
+        **mock_panel.metadata.model_dump(),
         "panel_columns": expected_columns,
     }
     reconstructed_panel = adata.var[adata.uns["panel_metadata"]["panel_columns"]]

--- a/tests/pna/pixeldataset/test_anndata_helper.py
+++ b/tests/pna/pixeldataset/test_anndata_helper.py
@@ -183,7 +183,7 @@ class TestTryBumpAdataPanelVersion:
                 session=session, sample="sample_new"
             )
 
-        # allso test non panel columns are kept as is during the bump
+        # Also test non panel columns are kept as is during the bump
         positive_cells_count = np.random.randint(0, 100, adata_old.var.shape[0])
         adata_old.var["positive_cells_count"] = positive_cells_count
 

--- a/tests/pna/pixeldataset/test_anndata_helper.py
+++ b/tests/pna/pixeldataset/test_anndata_helper.py
@@ -22,12 +22,15 @@ def _panel_with_version_product_and_uniprot(
     version: str,
     product: str | None,
     marker_a_uniprot: str,
+    marker_a_new_name: str | None = None,
     added_column_name: str | None = None,
     added_column_value: str | None = None,
 ) -> PNAAntibodyPanel:
     """Clone a panel while tweaking version/product and marker metadata for tests."""
     panel_df = panel.df.copy()
     panel_df.loc["MarkerA", "uniprot_id"] = marker_a_uniprot
+    if marker_a_new_name is not None:
+        panel_df = panel_df.rename(index={"MarkerA": marker_a_new_name})
     if added_column_name is not None and added_column_value is not None:
         panel_df[added_column_name] = added_column_value
     metadata = panel.metadata.model_copy(
@@ -164,6 +167,7 @@ class TestTryBumpAdataPanelVersion:
             version="0.1.1",
             product="test-product",
             marker_a_uniprot="Q9UPN0",
+            marker_a_new_name="MarkerANew",
             added_column_name="target_class",
             added_column_value="new-value",
         )
@@ -188,19 +192,19 @@ class TestTryBumpAdataPanelVersion:
         adata_old.var["positive_cells_count"] = positive_cells_count
 
         assert adata_old.var.loc["MarkerA", "uniprot_id"] == "P12345"
-        assert adata_new.var.loc["MarkerA", "uniprot_id"] == "Q9UPN0"
+        assert adata_new.var.loc["MarkerANew", "uniprot_id"] == "Q9UPN0"
         assert "target_class" not in adata_old.var.columns
         assert "target_class" in adata_new.var.columns
 
         bumped = helper._try_bump_adata_panel_version([adata_old, adata_new])
 
         assert "target_class" in bumped[0].var.columns
-        assert bumped[0].var.loc["MarkerA", "target_class"] == "new-value"
-        assert bumped[0].var.loc["MarkerA", "uniprot_id"] == "Q9UPN0"
+        assert bumped[0].var.loc["MarkerANew", "target_class"] == "new-value"
+        assert bumped[0].var.loc["MarkerANew", "uniprot_id"] == "Q9UPN0"
 
         assert "target_class" in bumped[1].var.columns
-        assert bumped[1].var.loc["MarkerA", "uniprot_id"] == "Q9UPN0"
-        assert bumped[1].var.loc["MarkerA", "target_class"] == "new-value"
+        assert bumped[1].var.loc["MarkerANew", "uniprot_id"] == "Q9UPN0"
+        assert bumped[1].var.loc["MarkerANew", "target_class"] == "new-value"
 
         assert "positive_cells_count" in bumped[0].var.columns
         assert "positive_cells_count" not in bumped[1].var.columns

--- a/tests/pna/pixeldataset/test_anndata_helper.py
+++ b/tests/pna/pixeldataset/test_anndata_helper.py
@@ -5,6 +5,7 @@ Copyright © 2025 Pixelgen Technologies AB.
 
 from pathlib import Path
 
+import numpy as np
 import polars as pl
 import pytest
 
@@ -182,6 +183,10 @@ class TestTryBumpAdataPanelVersion:
                 session=session, sample="sample_new"
             )
 
+        # allso test non panel columns are kept as is during the bump
+        positive_cells_count = np.random.randint(0, 100, adata_old.var.shape[0])
+        adata_old.var["positive_cells_count"] = positive_cells_count
+
         assert adata_old.var.loc["MarkerA", "uniprot_id"] == "P12345"
         assert adata_new.var.loc["MarkerA", "uniprot_id"] == "Q9UPN0"
         assert "target_class" not in adata_old.var.columns
@@ -191,8 +196,21 @@ class TestTryBumpAdataPanelVersion:
 
         assert "target_class" in bumped[0].var.columns
         assert bumped[0].var.loc["MarkerA", "target_class"] == "new-value"
+        assert bumped[0].var.loc["MarkerA", "uniprot_id"] == "Q9UPN0"
+
         assert "target_class" in bumped[1].var.columns
+        assert bumped[1].var.loc["MarkerA", "uniprot_id"] == "Q9UPN0"
         assert bumped[1].var.loc["MarkerA", "target_class"] == "new-value"
+
+        assert "positive_cells_count" in bumped[0].var.columns
+        assert "positive_cells_count" not in bumped[1].var.columns
+        assert (
+            adata_old.var["positive_cells_count"]
+            == bumped[0].var["positive_cells_count"]
+        ).all()
+
+        assert (adata_old[:, "MarkerC"].X == bumped[0][:, "MarkerC"].X).all()
+        assert (adata_new[:, "MarkerC"].X == bumped[1][:, "MarkerC"].X).all()
 
     @pytest.mark.parametrize(
         "new_version,new_product",
@@ -244,3 +262,6 @@ class TestTryBumpAdataPanelVersion:
         not_bumped = helper._try_bump_adata_panel_version([adata_old, adata_new])
 
         assert "target_class" not in not_bumped[0].var.columns
+
+        assert (adata_old[:, "MarkerC"].X == not_bumped[0][:, "MarkerC"].X).all()
+        assert (adata_new[:, "MarkerC"].X == not_bumped[1][:, "MarkerC"].X).all()

--- a/tests/pna/pixeldataset/test_anndata_helper.py
+++ b/tests/pna/pixeldataset/test_anndata_helper.py
@@ -3,10 +3,81 @@
 Copyright © 2025 Pixelgen Technologies AB.
 """
 
+from pathlib import Path
+
+import polars as pl
 import pytest
 
 from pixelator.common.utils.testing import adata_assert_equal
+from pixelator.pna.config.panel import PNAAntibodyPanel
+from pixelator.pna.pixeldataset import PNAPixelDataset
 from pixelator.pna.pixeldataset.io.anndata_helper import AnnDataHelper
+from tests.pna.conftest import create_pxl_file
+
+
+def _panel_with_version_product_and_uniprot(
+    panel: PNAAntibodyPanel,
+    *,
+    version: str,
+    product: str | None,
+    marker_a_uniprot: str,
+    added_column_name: str | None = None,
+    added_column_value: str | None = None,
+) -> PNAAntibodyPanel:
+    """Clone a panel while tweaking version/product and marker metadata for tests."""
+    panel_df = panel.df.copy()
+    panel_df.loc["MarkerA", "uniprot_id"] = marker_a_uniprot
+    if added_column_name is not None and added_column_value is not None:
+        panel_df[added_column_name] = added_column_value
+    metadata = panel.metadata.model_copy(
+        update={"version": version, "product": product}
+    )
+    return PNAAntibodyPanel(df=panel_df, metadata=metadata)
+
+
+def _write_component_suffix_parquet(source: Path, target: Path, suffix: str) -> None:
+    """Write a parquet copy where `component` values are suffixed to avoid overlap."""
+    (
+        pl.scan_parquet(source)
+        .with_columns((pl.col("component") + suffix).alias("component"))
+        .sink_parquet(target)
+    )
+
+
+def _build_two_sample_dataset_with_panels(
+    *,
+    tmp_path: Path,
+    edgelist_parquet_path: Path,
+    panel_old: PNAAntibodyPanel,
+    panel_new: PNAAntibodyPanel,
+) -> PNAPixelDataset:
+    """Create two on-disk PXL samples with distinct panels for bumping patch version tests."""
+    sample_old = create_pxl_file(
+        target=tmp_path / "sample_old.pxl",
+        sample_name="sample_old",
+        edgelist_parquet_path=edgelist_parquet_path,
+        proximity_parquet_path=None,
+        layout_parquet_path=None,
+        panel=panel_old,
+    )
+
+    sample_new_edgelist = tmp_path / "sample_new_edgelist.parquet"
+
+    _write_component_suffix_parquet(
+        source=edgelist_parquet_path,
+        target=sample_new_edgelist,
+        suffix="_sample_new",
+    )
+
+    sample_new = create_pxl_file(
+        target=tmp_path / "sample_new.pxl",
+        sample_name="sample_new",
+        edgelist_parquet_path=sample_new_edgelist,
+        proximity_parquet_path=None,
+        layout_parquet_path=None,
+        panel=panel_new,
+    )
+    return PNAPixelDataset.from_pxl_files([sample_old, sample_new])
 
 
 class TestAnnDataHelper:
@@ -69,3 +140,107 @@ def test_anndata_helper_basic_smoke(pxl_dataset, components, markers):
     res = helper.read_adata(add_clr_transform=False, add_log1p_transform=False)
     assert res.n_obs >= 0
     assert res.n_vars >= 0
+
+
+class TestTryBumpAdataPanelVersion:
+    """Coverage for automatic panel patch bump behavior in AnnDataHelper."""
+
+    def test_bumps_to_latest_patch_when_prerequisites_are_met(
+        self,
+        tmp_path: Path,
+        edgelist_parquet_path: Path,
+        panel: PNAAntibodyPanel,
+    ):
+        """Bump to latest patch when major/minor/product prerequisites are satisfied."""
+        panel_old = _panel_with_version_product_and_uniprot(
+            panel,
+            version="0.1.0",
+            product="test-product",
+            marker_a_uniprot="P12345",
+        )
+        panel_new = _panel_with_version_product_and_uniprot(
+            panel,
+            version="0.1.1",
+            product="test-product",
+            marker_a_uniprot="Q9UPN0",
+            added_column_name="target_class",
+            added_column_value="new-value",
+        )
+        dataset = _build_two_sample_dataset_with_panels(
+            tmp_path=tmp_path,
+            edgelist_parquet_path=edgelist_parquet_path,
+            panel_old=panel_old,
+            panel_new=panel_new,
+        )
+        helper = AnnDataHelper(dataset.view)
+
+        with dataset.view.open() as session:
+            adata_old = helper._read_adata_from_sample(
+                session=session, sample="sample_old"
+            )
+            adata_new = helper._read_adata_from_sample(
+                session=session, sample="sample_new"
+            )
+
+        assert adata_old.var.loc["MarkerA", "uniprot_id"] == "P12345"
+        assert adata_new.var.loc["MarkerA", "uniprot_id"] == "Q9UPN0"
+        assert "target_class" not in adata_old.var.columns
+        assert "target_class" in adata_new.var.columns
+
+        bumped = helper._try_bump_adata_panel_version([adata_old, adata_new])
+
+        assert "target_class" in bumped[0].var.columns
+        assert bumped[0].var.loc["MarkerA", "target_class"] == "new-value"
+        assert "target_class" in bumped[1].var.columns
+        assert bumped[1].var.loc["MarkerA", "target_class"] == "new-value"
+
+    @pytest.mark.parametrize(
+        "new_version,new_product",
+        [
+            ("0.2.0", "test-product"),
+            ("0.1.1", "different-product"),
+            ("0.1.1", None),  # product is None
+        ],
+    )
+    def test_skips_bump_when_prerequisites_are_not_met(
+        self,
+        tmp_path: Path,
+        edgelist_parquet_path: Path,
+        panel: PNAAntibodyPanel,
+        new_version: str,
+        new_product: str | None,
+    ):
+        """Skip bump when version compatibility or product prerequisites are not met."""
+        panel_old = _panel_with_version_product_and_uniprot(
+            panel,
+            version="0.1.0",
+            product="test-product",
+            marker_a_uniprot="P12345",
+        )
+        panel_new = _panel_with_version_product_and_uniprot(
+            panel,
+            version=new_version,
+            product=new_product,
+            marker_a_uniprot="Q9UPN0",
+            added_column_name="target_class",
+            added_column_value="new-version",
+        )
+        dataset = _build_two_sample_dataset_with_panels(
+            tmp_path=tmp_path,
+            edgelist_parquet_path=edgelist_parquet_path,
+            panel_old=panel_old,
+            panel_new=panel_new,
+        )
+        helper = AnnDataHelper(dataset.view)
+
+        with dataset.view.open() as session:
+            adata_old = helper._read_adata_from_sample(
+                session=session, sample="sample_old"
+            )
+            adata_new = helper._read_adata_from_sample(
+                session=session, sample="sample_new"
+            )
+
+        not_bumped = helper._try_bump_adata_panel_version([adata_old, adata_new])
+
+        assert "target_class" not in not_bumped[0].var.columns

--- a/tests/pna/test_anndata.py
+++ b/tests/pna/test_anndata.py
@@ -9,11 +9,13 @@ import polars as pl
 import pytest
 from pandas.testing import assert_frame_equal
 
+from pixelator.common.config import AntibodyPanelMetadata
 from pixelator.pna.anndata import pna_edgelist_to_anndata
 from pixelator.pna.config import PNAAntibodyPanel, load_antibody_panel
 from pixelator.pna.pixeldataset.io import PixelFileWriter
 
 mock_antibody_panel = create_autospec(PNAAntibodyPanel)
+mock_antibody_panel.metadata = create_autospec(AntibodyPanelMetadata)
 mock_antibody_panel.markers = ["A", "B", "C"]
 # Each marker is duplicated in the panel,
 # on these parameters so this accounts for that.


### PR DESCRIPTION
## Description
Attempt to automaticalluy bump panel patch version to latest available when reading anndata from multiple pxl datasets.

Leaves the edgelist, proximity and layout tables as is even if marker names changed in panel.

Fixes: PNA-2627

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce it when relevant.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)

## AI generated summary of changes to facilitate review
### Main production changes
- Added automatic panel patch-version upgrade logic when reading multiple samples in `AnnDataHelper`.
- New `_try_bump_adata_panel_version` in `src/pixelator/pna/pixeldataset/io/anndata_helper.py`:
  - Parses panel versions with `semver`.
  - Requires same major/minor and same non-null `product` across samples.
  - Uses `PNAAntibodyPanelDiff(...).upgrade_adata(...)` to upgrade older patch versions to latest.
- Added logging import/use in `anndata_helper.py` for upgrade/skip paths.
- `add_panel_information` in `src/pixelator/pna/anndata.py` now writes full panel metadata via `panel.metadata.model_dump()` and appends `panel_columns`.
- `PNAAntibodyPanel`/panel handling updates in `src/pixelator/pna/config/panel.py`:
  - Added `from_adata(...)` constructor (mostly a split from `from_pxl_dataset`).
  - Removed direct `from_pxl_file(...)` constructor usage pattern from updated callsites (use `from_pxl_dataset` together with `pixelator.pna.pixeldataset.read` instead).
  - Moved/standardized metadata usage to `self.metadata` accessors.
  - Added `to_polars()` and equality implementation.
  - Added `PNAAntibodyPanelDiff` class (panel comparison + `upgrade_adata` support).
- Callsite updates to load panel info from dataset objects instead of direct PXL-file constructor:
  - `src/pixelator/pna/analysis/denoise.py`
  - `src/pixelator/pna/cli/sample_calling.py`
- CLI panel validation in `src/pixelator/pna/cli/common.py` now includes archived panel names in valid options (`include_archived=True`). Not effective right now but needed for validation when archived panel exists and would be used.

### Test changes
- Added substantial coverage for automatic panel version bumping in `tests/pna/pixeldataset/test_anndata_helper.py`:
  - Creates on-disk temporary datasets with different panel patch versions.
  - Verifies successful bump when prerequisites are met.
  - Verifies skip behavior when prerequisites are not met.
  - Verifies non-panel columns and matrix values are preserved.
- Updated tests for new panel-loading/metadata behavior:
  - `tests/pna/test_anndata.py`
  - `tests/pna/config/test_panel.py`
  - `tests/pna/config/test_config.py`
- Updated graph legacy fixtures/assertions to use concrete metadata-backed values and full metadata dumps:
  - `tests/pna/graph_legacy/conftest.py`
  - `tests/pna/graph_legacy/test_connected_components.py`

### Behavior impact summary
- Multi-sample pxl dataset reads can now normalize patch-level panel differences automatically when safe.
- Panel metadata persisted into AnnData/PXL is more complete and consistent.
- Codepaths that reconstruct panel objects now rely on dataset/AnnData metadata extraction.
- CLI panel validation accepts archived panels where applicable.

### Validation notes
- Targeted slow test for connected-components PXL build passes after fixture/assertion updates:
  - `tests/pna/graph_legacy/test_connected_components.py::test_build_pxl_file_with_components`
