### PR TITLE
Warn, not crash on trailing commas in panel files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [x.x.x] - 2026-MM-DD
+
+### Changed
+- When parsing panel files, trailing commas in the header will now give a warning and ignore the trailing commas,
+  instead of raising an error.
+
 ## [0.26.0] - 2026-05-04
 
 ### Important changes

--- a/src/pixelator/common/config/panel.py
+++ b/src/pixelator/common/config/panel.py
@@ -5,6 +5,7 @@ Copyright © 2022 Pixelgen Technologies AB.
 
 from __future__ import annotations
 
+import re
 import warnings
 from functools import cached_property
 from pathlib import Path
@@ -51,6 +52,61 @@ class AntibodyPanelMetadata(pydantic.BaseModel):
         """
         Version(v)  # will raise if not a valid version string
         return v
+
+
+def _strip_trailing_commas(metadata: str) -> tuple[str, bool]:
+    """Remove line-end commas from header YAML.
+
+    This keeps recovery narrow to the malformed pattern we want to tolerate.
+    """
+    normalized = re.sub(r",(\s*(?:\n|$))", r"\1", metadata)
+    return normalized, normalized != metadata
+
+
+def _load_header_frontmatter(metadata: str) -> AntibodyPanelMetadata:
+    """Load and validate first YAML document from panel metadata text."""
+    yaml_loader = yaml.YAML(typ="safe")
+    raw_config = list(yaml_loader.load_all(metadata))
+
+    if len(raw_config) == 0:
+        raise ValueError("No header / metadata found in panel file")
+
+    frontmatter = raw_config[0]
+    return AntibodyPanelMetadata.model_validate(frontmatter)
+
+
+def parse_panel_header_metadata(file: Path) -> AntibodyPanelMetadata:
+    """Parse panel front-matter metadata and recover from trailing commas."""
+    metadata_lines = []
+    with open(str(file), "r") as handle:
+        for line in handle:
+            if line.startswith("# "):
+                metadata_lines.append(line[2:])
+            else:
+                break
+
+    metadata = "".join(metadata_lines)
+    try:
+        return _load_header_frontmatter(metadata)
+    except (yaml.YAMLError, pydantic.ValidationError, ValueError):
+        normalized_metadata, changed = _strip_trailing_commas(metadata)
+        if not changed:
+            if metadata.strip() == "":
+                raise ValueError(f"No header / metadata found in panel file {file}")
+            raise
+
+        try:
+            parsed = _load_header_frontmatter(normalized_metadata)
+        except (yaml.YAMLError, pydantic.ValidationError, ValueError):
+            if metadata.strip() == "":
+                raise ValueError(f"No header / metadata found in panel file {file}")
+            raise
+
+        logger.warning(
+            "Panel header in %s contains trailing comma(s); parsing with commas ignored.",
+            file,
+        )
+        return parsed
 
 
 class AntibodyPanel:
@@ -249,24 +305,7 @@ class AntibodyPanel:
             ValueError: If no metadata header is present in the file.
 
         """
-        yaml_loader = yaml.YAML(typ="safe")
-
-        metadata_lines = []
-        with open(str(file), "r") as f:
-            for line in f:
-                if line.startswith("# "):
-                    metadata_lines.append(line[2:])
-                else:
-                    break
-
-        metadata = "".join(metadata_lines)
-        raw_config = list(yaml_loader.load_all(metadata))
-
-        if len(raw_config) == 0:
-            raise ValueError(f"No header / metadata found in panel file {file}")
-
-        frontmatter = raw_config[0]
-        return AntibodyPanelMetadata.model_validate(frontmatter)
+        return parse_panel_header_metadata(file)
 
     @cached_property
     def markers_control(self) -> List[str]:

--- a/src/pixelator/pna/config/panel.py
+++ b/src/pixelator/pna/config/panel.py
@@ -21,9 +21,11 @@ import re
 
 import pandas as pd
 import polars as pl
-import ruamel.yaml as yaml
 
-from pixelator.common.config import AntibodyPanelMetadata
+from pixelator.common.config.panel import (
+    AntibodyPanelMetadata,
+    parse_panel_header_metadata,
+)
 from pixelator.common.types import PathType
 from pixelator.common.utils import logger
 
@@ -211,24 +213,7 @@ class PNAAntibodyPanel:
             ValueError: If no metadata header is present in the file.
 
         """
-        yaml_loader = yaml.YAML(typ="safe")
-
-        metadata_lines = []
-        with open(str(file), "r") as f:
-            for line in f:
-                if line.startswith("# "):
-                    metadata_lines.append(line[2:])
-                else:
-                    break
-
-        metadata = "".join(metadata_lines)
-        raw_config = list(yaml_loader.load_all(metadata))
-
-        if len(raw_config) == 0:
-            raise ValueError(f"No header / metadata found in panel file {file}")
-
-        frontmatter = raw_config[0]
-        return AntibodyPanelMetadata.model_validate(frontmatter)
+        return parse_panel_header_metadata(file)
 
     @classmethod
     def _parse_panel(cls, panel_file: Path) -> pd.DataFrame:

--- a/tests/mpx/resources/test_panel.py
+++ b/tests/mpx/resources/test_panel.py
@@ -8,6 +8,7 @@ from tempfile import NamedTemporaryFile
 
 import pandas as pd
 import pytest
+import ruamel.yaml as yaml
 
 from pixelator.common.config import AntibodyPanel
 
@@ -70,4 +71,42 @@ def test_panel_raise_when_there_is_issue(panel: pd.DataFrame):
         duplicated_panel.to_csv(tmp_file.name)
 
         with pytest.raises(AssertionError):
+            AntibodyPanel.from_csv(tmp_file.name)
+
+
+def test_panel_header_trailing_commas_warns_and_recovers(caplog):
+    panel_content = """# ---
+# name: test panel,
+# description: test description,
+# version: 0.1.0,
+# ---
+marker_id,control,nuclear,sequence,conj_id
+CD45,no,no,TCCCTTGCGATTTAC,test001
+"""
+    with NamedTemporaryFile(suffix=".csv", mode="w", encoding="utf-8") as tmp_file:
+        tmp_file.write(panel_content)
+        tmp_file.flush()
+
+        with caplog.at_level("WARNING"):
+            panel = AntibodyPanel.from_csv(tmp_file.name)
+
+    assert panel.name == "test panel"
+    assert panel.version == "0.1.0"
+    assert "trailing comma" in caplog.text.lower()
+
+
+def test_panel_header_non_recoverable_yaml_still_fails():
+    panel_content = """# ---
+# name: test panel
+# aliases: [test-alias
+# version: 0.1.0
+# ---
+marker_id,control,nuclear,sequence,conj_id
+CD45,no,no,TCCCTTGCGATTTAC,test001
+"""
+    with NamedTemporaryFile(suffix=".csv", mode="w", encoding="utf-8") as tmp_file:
+        tmp_file.write(panel_content)
+        tmp_file.flush()
+
+        with pytest.raises(yaml.YAMLError):
             AntibodyPanel.from_csv(tmp_file.name)

--- a/tests/pna/config/test_panel.py
+++ b/tests/pna/config/test_panel.py
@@ -1,7 +1,10 @@
 """Copyright © 2025 Pixelgen Technologies AB."""
 
+from tempfile import NamedTemporaryFile
+
 import pandas as pd
 import pytest
+import ruamel.yaml as yaml
 from pandas.testing import assert_frame_equal
 
 from pixelator.common.config import AntibodyPanelMetadata
@@ -108,3 +111,44 @@ def test_panel_from_pxl(pxl_file):
     }
     expected_df = pd.DataFrame(expected_data).set_index("marker_id")
     assert_frame_equal(panel.df, expected_df)
+
+
+def test_panel_header_trailing_commas_warns_and_recovers(caplog):
+    panel_content = """# ---
+# name: test-pna-panel,
+# product: test-product,
+# aliases:
+#   - test-pna
+# description: Test R&D panel for PNA,
+# version: 1.0.0,
+# ---
+marker_id,control,sequence_1,sequence_2
+MarkerA,no,ACTTCCTAGG,ACTTCCTAGG
+"""
+    with NamedTemporaryFile(suffix=".csv", mode="w", encoding="utf-8") as tmp_file:
+        tmp_file.write(panel_content)
+        tmp_file.flush()
+
+        with caplog.at_level("WARNING"):
+            panel = PNAAntibodyPanel.from_csv(tmp_file.name)
+
+    assert panel.name == "test-pna-panel"
+    assert panel.version == "1.0.0"
+    assert "trailing comma" in caplog.text.lower()
+
+
+def test_panel_header_non_recoverable_yaml_still_fails():
+    panel_content = """# ---
+# name: test panel
+# aliases: [test-alias
+# version: 0.1.0
+# ---
+marker_id,control,nuclear,sequence,conj_id
+CD45,no,no,TCCCTTGCGATTTAC,test001
+"""
+    with NamedTemporaryFile(suffix=".csv", mode="w", encoding="utf-8") as tmp_file:
+        tmp_file.write(panel_content)
+        tmp_file.flush()
+
+        with pytest.raises(yaml.YAMLError):
+            PNAAntibodyPanel.from_csv(tmp_file.name)


### PR DESCRIPTION
## Description

Warn instead of crashing when there are trailing commas in the panel file header, which is quite common when working with the panel files in spreadsheet editors.

Fixes: pna-2771

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added new tests.

## PR checklist:

- [ ] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
