### PR TITLE
Use uv.lock in docker container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [M.mm.pp] - yyyy-mm-dd
+
+### Fixed
+
+- Follow uv.lock when building docker containers
+
 ## [0.27.0] - 2026-05-22
 
 ### Added

--- a/containers/base.Dockerfile
+++ b/containers/base.Dockerfile
@@ -116,7 +116,7 @@ WORKDIR /pixelator
 COPY . /pixelator
 COPY .git /pixelator/.git
 
-ENV UV_PROJECT_ENVIRONMENT="/usr/local/"
+ENV UV_PROJECT_ENVIRONMENT="/usr/"
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$VERSION_OVERRIDE
 
 RUN if [ ! -z "${VERSION_OVERRIDE}" ]; then \

--- a/containers/base.Dockerfile
+++ b/containers/base.Dockerfile
@@ -117,7 +117,6 @@ COPY . /pixelator
 COPY .git /pixelator/.git
 
 ENV UV_PROJECT_ENVIRONMENT="/usr/"
-ENV SETUPTOOLS_SCM_PRETEND_VERSION=$VERSION_OVERRIDE
 
 RUN if [ ! -z "${VERSION_OVERRIDE}" ]; then \
     echo "Overriding version to ${VERSION_OVERRIDE}"; \

--- a/containers/base.Dockerfile
+++ b/containers/base.Dockerfile
@@ -116,10 +116,13 @@ WORKDIR /pixelator
 COPY . /pixelator
 COPY .git /pixelator/.git
 
+ENV UV_PROJECT_ENVIRONMENT="/usr/local/"
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=$VERSION_OVERRIDE
+
 RUN if [ ! -z "${VERSION_OVERRIDE}" ]; then \
     echo "Overriding version to ${VERSION_OVERRIDE}"; \
-    SETUPTOOLS_SCM_PRETEND_VERSION="${VERSION_OVERRIDE}" uv sync --system --reinstall-package pixelator ; \
-    else uv sync --system --reinstall-package pixelator ; \
+    SETUPTOOLS_SCM_PRETEND_VERSION="${VERSION_OVERRIDE}" uv sync --no-editable --no-dev --reinstall-package pixelator ; \
+    else uv sync --no-editable --no-dev --reinstall-package pixelator ; \
     fi
 
 # ------------------------------------------

--- a/containers/base.Dockerfile
+++ b/containers/base.Dockerfile
@@ -118,8 +118,8 @@ COPY .git /pixelator/.git
 
 RUN if [ ! -z "${VERSION_OVERRIDE}" ]; then \
     echo "Overriding version to ${VERSION_OVERRIDE}"; \
-    SETUPTOOLS_SCM_PRETEND_VERSION="${VERSION_OVERRIDE}" uv pip install --system . ; \
-    else uv pip install --system . ; \
+    SETUPTOOLS_SCM_PRETEND_VERSION="${VERSION_OVERRIDE}" uv sync --system --reinstall-package pixelator ; \
+    else uv sync --system --reinstall-package pixelator ; \
     fi
 
 # ------------------------------------------


### PR DESCRIPTION
## Description

`uv pip install` emulates pip and ignores `uv.lock`. This results in some dependencies being updated on build, even without any changes to `uv.lock`.

This PR addresses this issue by using `uv sync` instead.

Fixes: PNA-2804

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Build and inspect container to make sure duckdb's version is 1.5.2 in the container, as specified in uv.lock.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
