### PR TITLE
fix: propagate demux mismatches arg to correct_marker_barcodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [xx.xx.xx] - 2026-MM-DD
+
+### Fixed
+ - Propagate the demux --mismatches cli argument to correct_marker_barcodes (was using default i.e. 1)
+
 ## [0.27.0] - 2026-05-22
 
 ### Added

--- a/src/pixelator/pna/cli/demux.py
+++ b/src/pixelator/pna/cli/demux.py
@@ -154,6 +154,7 @@ def demux(
         output=demux_output,
         save_failed=True,
         threads=threads,
+        mismatches=mismatches,
     )
 
     # Store intermediate parquet files before deduplication and sorting


### PR DESCRIPTION
<!--

Please fill in the appropriate checklist below (delete whatever is not relevant).

Learn more about contributing: [CONTRIBUTING.md](https://github.com/PixelgenTechnologies/pixelator/blob/main/CONTRIBUTING.md)
-->

## Description

propagate demux mismatches arg to correct_marker_barcodes

Fixes: PNA-2791

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce it when relevant.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
