### PR TITLE
Pna 2810

### DIFF
--- a/src/pixelator/pna/cli/demux.py
+++ b/src/pixelator/pna/cli/demux.py
@@ -153,6 +153,7 @@ def demux(
         panel=panel,
         output=demux_output,
         save_failed=True,
+        mismatches=mismatches,
         threads=threads,
     )
 

--- a/tests/pna/demux/test_demux_cli.py
+++ b/tests/pna/demux/test_demux_cli.py
@@ -67,3 +67,32 @@ def test_demux_custom_panel(tmp_path, testdata_amplicon_fastq, pna_data_root):
     cmd = runner.invoke(cli.main_cli, args)
 
     assert cmd.exit_code == 0
+
+
+@pytest.mark.slow
+def test_demux_mismatches(tmp_path, testdata_amplicon_fastq, mocker):
+    import pixelator.pna.cli.demux
+    spy = mocker.spy(pixelator.pna.cli.demux, "correct_marker_barcodes")
+
+    runner = CliRunner()
+    args = [
+        "single-cell-pna",
+        "demux",
+        str(testdata_amplicon_fastq),
+        "--output",
+        str(tmp_path),
+        "--design",
+        "proxiome-v1",
+        "--panel",
+        "proxiome-v1-immuno-155-v1.0",
+        "--mismatches",
+        "2",
+    ]
+    cmd = runner.invoke(cli.main_cli, args)
+
+    assert cmd.exit_code == 0
+    # Check that correct_marker_barcodes was called with mismatches=2
+    spy.assert_called_once()
+    kwargs = spy.call_args.kwargs
+    assert kwargs.get("mismatches") == 2
+


### PR DESCRIPTION
## Description

This PR fixes a bug in demux where the `--mismatches` command line option was only parsed but never sent to `correct_marker_barcodes` downstream.

Fixes: PNA-2810

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Added a small test to verify that the mismatches option is passed.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
