### PR TITLE
switch to enrichment based sample calling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [] - Unreleased
 
-## Added
+### Added
 - `annotate_cells` method to determine cell-types using another given set of pre-annotated cells.
+
+
+### Changed
+- Switch sample calling evaluation metric to hash enrichment factor instead of hash purity.
 
 ## [0.28.0] - 2026-06-03
 
-## Added
+### Added
 - `coarsened_pmds_layout` method for more performant cell layout computation.
 
 ### Fixed

--- a/src/pixelator/pna/cli/sample_calling.py
+++ b/src/pixelator/pna/cli/sample_calling.py
@@ -65,8 +65,8 @@ from pixelator.pna.sample_calling.report import (
     type=float,
     default=10.0,
     help="Hash enrichment threshold for sample calling. "
-    "Components with a hash enrichment factor (highest hash count divided by second highest) "
-    "below this threshold will be considered undetermined. "
+    "Components with a hash enrichment factor below this threshold will be considered undetermined. "
+    "Hash enrichment is calculated as the ration between highest hash count and the second highest hash count."
     "Default is 10.0.",
 )
 @output_option

--- a/src/pixelator/pna/cli/sample_calling.py
+++ b/src/pixelator/pna/cli/sample_calling.py
@@ -63,11 +63,11 @@ from pixelator.pna.sample_calling.report import (
     "--enrichment-threshold",
     required=False,
     type=float,
-    default=2.0,
+    default=10.0,
     help="Hash enrichment threshold for sample calling. "
     "Components with a hash enrichment factor (highest hash count divided by second highest) "
     "below this threshold will be considered undetermined. "
-    "Default is 2.0.",
+    "Default is 10.0.",
 )
 @output_option
 @click.pass_context

--- a/src/pixelator/pna/cli/sample_calling.py
+++ b/src/pixelator/pna/cli/sample_calling.py
@@ -22,7 +22,7 @@ from pixelator.pna.config.panel import PNAAntibodyPanel
 from pixelator.pna.sample_calling import (
     create_final_report,
     sample_calling,
-    warn_if_undetermined_has_high_confidence,
+    warn_if_undetermined_has_high_enrichment,
 )
 from pixelator.pna.sample_calling.hash_antibodies import HashedAntibodyMapping
 from pixelator.pna.sample_calling.report import (
@@ -60,13 +60,14 @@ from pixelator.pna.sample_calling.report import (
     help="Save components that could not be confidently assigned to any sample.",
 )
 @click.option(
-    "--confidence-threshold",
+    "--enrichment-threshold",
     required=False,
     type=float,
-    default=0.9,
-    help="Confidence threshold for sample calling. "
-    "Components with a sample confidence below this threshold will be considered undetermined. "
-    "Default is 0.9.",
+    default=2.0,
+    help="Hash enrichment threshold for sample calling. "
+    "Components with a hash enrichment factor (highest hash count divided by second highest) "
+    "below this threshold will be considered undetermined. "
+    "Default is 2.0.",
 )
 @output_option
 @click.pass_context
@@ -77,7 +78,7 @@ def sample_calling_cli(
     samplesheet: str,
     remove_incompatible: bool,
     save_undetermined: bool,
-    confidence_threshold: float,
+    enrichment_threshold: float,
     output,
 ):
     """Map components to samples in sample-hashed datasets.
@@ -88,7 +89,7 @@ def sample_calling_cli(
         samplesheet: Path to a samplesheet file with a hash_index column.
         remove_incompatible: Remove antibodies that are incompatible with their component.
         save_undetermined: Save components that could not be confidently assigned to any sample.
-        confidence_threshold: Confidence threshold for sample calling.
+        enrichment_threshold: Hash enrichment threshold for sample calling.
         output: The path where the results will be placed (it is created if it does not exist).
     """
     log_step_start(
@@ -98,7 +99,7 @@ def sample_calling_cli(
         output=output,
         remove_incompatible=remove_incompatible,
         save_undetermined=save_undetermined,
-        confidence_threshold=confidence_threshold,
+        enrichment_threshold=enrichment_threshold,
     )
     # some basic sanity check on the input files
     sanity_check_inputs(input_files=input_pxl_file, allowed_extensions=("pxl",))
@@ -138,7 +139,7 @@ def sample_calling_cli(
         hashing_antibody_mapping=hashed_antibodies,
         output_folder=sample_calling_output,
         remove_incompatible=remove_incompatible,
-        confidence_threshold=confidence_threshold,
+        enrichment_threshold=enrichment_threshold,
         undetermined_sample_name=undetermined_sample_name,
     )
 
@@ -172,13 +173,13 @@ def sample_calling_cli(
     )
 
     if undetermined_sample_name in final_dataset.sample_names():
-        warn_if_undetermined_has_high_confidence(
-            undetermined_sample_confidences=final_dataset.filter(
+        warn_if_undetermined_has_high_enrichment(
+            undetermined_enrichment_factors=final_dataset.filter(
                 samples=undetermined_sample_name
             )
             .adata()
-            .obs["sample_confidence"],
-            confidence_threshold=confidence_threshold,
+            .obs["hash_enrichment_factor"],
+            enrichment_threshold=enrichment_threshold,
             undetermined_sample_name=undetermined_sample_name,
         )
 

--- a/src/pixelator/pna/sample_calling/__init__.py
+++ b/src/pixelator/pna/sample_calling/__init__.py
@@ -7,12 +7,12 @@ from pixelator.pna.sample_calling.sample_calling import (
     collect_hash_info,
     create_final_report,
     sample_calling,
-    warn_if_undetermined_has_high_confidence,
+    warn_if_undetermined_has_high_enrichment,
 )
 
 __all__ = [
     "collect_hash_info",
     "sample_calling",
     "create_final_report",
-    "warn_if_undetermined_has_high_confidence",
+    "warn_if_undetermined_has_high_enrichment",
 ]

--- a/src/pixelator/pna/sample_calling/report.py
+++ b/src/pixelator/pna/sample_calling/report.py
@@ -20,4 +20,4 @@ class SampleCallingTotalReport(SampleReport):
     report_type: str = "sample_calling_total"
     number_of_components: int
     percentage_of_components_successfully_called: float
-    sample_confidences_per_sample: dict[str, list[float]]
+    hash_enrichment_factors_per_sample: dict[str, list[float]]

--- a/src/pixelator/pna/sample_calling/sample_calling.py
+++ b/src/pixelator/pna/sample_calling/sample_calling.py
@@ -56,7 +56,7 @@ def collect_hash_info(
             of hashing antibodies (from panel).
         enrichment_threshold: Minimum hash enrichment factor required to assign a component to a
             sample. The enrichment factor is the highest hash count divided by the second highest
-            hash count. Defaults to 2.0.
+            hash count.
         undetermined_sample_name: Name to use for undetermined components. Defaults to
             "undetermined".
 
@@ -111,7 +111,9 @@ def collect_hash_info(
             pl.when(pl.col("max_value") == 0)
             .then(pl.lit(0.0))
             .when(pl.col("second_max_value") == 0)
-            .then(pl.lit(float("inf")))
+            .then(
+                pl.col("max_value").cast(pl.Float64)
+            )  # If second max is 0 but max is not, set enrichment to max_value (as if second max was 1).
             .otherwise(
                 pl.col("max_value").cast(pl.Float64)
                 / pl.col("second_max_value").cast(pl.Float64)
@@ -313,7 +315,7 @@ def sample_calling(
     input_pxl: PNAPixelDataset,
     hashing_antibody_mapping: HashedAntibodyMapping,
     output_folder: Path,
-    enrichment_threshold: float = 2.0,
+    enrichment_threshold: float = 10.0,
     remove_incompatible: bool = True,
     undetermined_sample_name: str = "undetermined",
 ) -> list[Path]:
@@ -334,7 +336,7 @@ def sample_calling(
         output_folder: Directory where output pxl files will be written.
         enrichment_threshold: Minimum hash enrichment factor required to assign a component to a
             sample. The enrichment factor is the highest hash count divided by the second highest
-            hash count. Defaults to 2.0.
+            hash count. Defaults to 10.0.
         remove_incompatible: Whether to remove hashes incompatible with the current sample from the
             edgelist. Defaults to True.
         undetermined_sample_name: Name to use for undetermined components. Defaults to

--- a/src/pixelator/pna/sample_calling/sample_calling.py
+++ b/src/pixelator/pna/sample_calling/sample_calling.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 def collect_hash_info(
     input_pxl_file: PNAPixelDataset,
     hashed_antibody_mapping: HashedAntibodyMapping,
-    confidence_threshold: float,
+    enrichment_threshold: float,
     undetermined_sample_name: str = "undetermined",
 ) -> pl.DataFrame:
     """Map components to samples in an sample-hashed dataset.
@@ -41,7 +41,11 @@ def collect_hash_info(
     This function processes a pixel dataset and a mapping of components to
     samples based on hashed antibodies. It computes the hashed antibody count
     for each component, determines the most likely sample assignment for each
-    component, and calculates a confidence score for the assignment.
+    component, and calculates a hash enrichment factor for the assignment.
+
+    The hash enrichment factor is the ratio of the highest hash count to the
+    second highest hash count across all hash buckets. A higher value means
+    the component is more clearly dominated by one sample.
 
     If the most likely assignment is to antibodies not belonging to any sample,
     the component is assigned to the "undetermined" sample.
@@ -50,14 +54,15 @@ def collect_hash_info(
         input_pxl_file: The input pixel dataset.
         hashed_antibody_mapping: Mapping of sample names to hashed antibody names and the full list
             of hashing antibodies (from panel).
-        confidence_threshold: Minimum confidence required to assign a component to a sample.
-            Defaults to 0.8.
+        enrichment_threshold: Minimum hash enrichment factor required to assign a component to a
+            sample. The enrichment factor is the highest hash count divided by the second highest
+            hash count. Defaults to 2.0.
         undetermined_sample_name: Name to use for undetermined components. Defaults to
             "undetermined".
 
     Returns:
-        Polars DataFrame with component id, per-sample hash counts, called sample, and confidence
-        score.
+        Polars DataFrame with component id, per-sample hash counts, called sample, and hash
+        enrichment factor.
     """
     ab_count_data = pl.from_pandas(input_pxl_file.adata().to_df().reset_index()).lazy()
     samples = hashed_antibody_mapping.keys()
@@ -95,16 +100,26 @@ def collect_hash_info(
             .str.strip_suffix("_hash_count")
             .alias("called_sample"),
             pl.col("value").max().alias("max_value"),
-            pl.col("value").sum().alias("total_value"),
+            pl.col("value")
+            .sort(descending=True)
+            .slice(1, 1)
+            .first()
+            .fill_null(0)
+            .alias("second_max_value"),
         )
         .with_columns(
-            pl.when(pl.col("total_value") == 0)
+            pl.when(pl.col("max_value") == 0)
             .then(pl.lit(0.0))
-            .otherwise(pl.col("max_value") / pl.col("total_value"))
-            .alias("sample_confidence")
+            .when(pl.col("second_max_value") == 0)
+            .then(pl.lit(float("inf")))
+            .otherwise(
+                pl.col("max_value").cast(pl.Float64)
+                / pl.col("second_max_value").cast(pl.Float64)
+            )
+            .alias("hash_enrichment_factor")
         )
         .with_columns(
-            pl.when(pl.col("sample_confidence") < confidence_threshold)
+            pl.when(pl.col("hash_enrichment_factor") < enrichment_threshold)
             .then(pl.lit(undetermined_sample_name))
             .otherwise(pl.col("called_sample"))
             .alias("called_sample")
@@ -119,7 +134,7 @@ def collect_hash_info(
         + [
             f"{undetermined_sample_name}_hash_count",
             "called_sample",
-            "sample_confidence",
+            "hash_enrichment_factor",
         ]
     )
 
@@ -241,7 +256,7 @@ def _build_post_sample_calling_anndata(
     call_aggregates(new_adata)
     new_adata = _add_missing_adata_info(new_adata, old_adata)
     new_adata.obs = new_adata.obs.join(
-        hash_info.select(["component", "sample_confidence"])
+        hash_info.select(["component", "hash_enrichment_factor"])
         .to_pandas()
         .set_index("component", drop=True),
         how="left",
@@ -298,7 +313,7 @@ def sample_calling(
     input_pxl: PNAPixelDataset,
     hashing_antibody_mapping: HashedAntibodyMapping,
     output_folder: Path,
-    confidence_threshold: float = 0.8,
+    enrichment_threshold: float = 2.0,
     remove_incompatible: bool = True,
     undetermined_sample_name: str = "undetermined",
 ) -> list[Path]:
@@ -306,10 +321,10 @@ def sample_calling(
 
     Splits components of a pixel dataset by their sample and writes out
     separate pxl files for each sample. This function processes a
-    PNAPixelDataset, assigns components to samples based on hash information
-    and confidence thresholds, and writes out pxl files for each determined
-    sample. It will also write a file for undetermined components (under the name
-    "{undetermined_sample_name}.dehashed.pxl").
+    PNAPixelDataset, assigns components to samples based on hash enrichment
+    factors and an enrichment threshold, and writes out pxl files for each
+    determined sample. It will also write a file for undetermined components
+    (under the name "{undetermined_sample_name}.dehashed.pxl").
     It supports removing incompatible hashes and renaming hash markers in the output.
 
     Args:
@@ -317,8 +332,9 @@ def sample_calling(
         hashing_antibody_mapping: Information about hashing antibodies, including a mapping from
             sample names to lists of hashed antibody names.
         output_folder: Directory where output pxl files will be written.
-        confidence_threshold: Minimum confidence required to assign a component to a sample.
-            Defaults to 0.8.
+        enrichment_threshold: Minimum hash enrichment factor required to assign a component to a
+            sample. The enrichment factor is the highest hash count divided by the second highest
+            hash count. Defaults to 2.0.
         remove_incompatible: Whether to remove hashes incompatible with the current sample from the
             edgelist. Defaults to True.
         undetermined_sample_name: Name to use for undetermined components. Defaults to
@@ -330,7 +346,7 @@ def sample_calling(
     hash_info = collect_hash_info(
         input_pxl,
         hashing_antibody_mapping,
-        confidence_threshold,
+        enrichment_threshold,
         undetermined_sample_name,
     )
     panel = PNAAntibodyPanel.from_pxl_dataset(input_pxl)
@@ -510,10 +526,10 @@ def create_final_report(
             n_undetermined_components / n_components
         )
 
-    sample_confidences_per_sample = {
+    hash_enrichment_factors_per_sample = {
         sample_name: final_dataset.filter(samples=sample_name)
         .adata()
-        .obs["sample_confidence"]
+        .obs["hash_enrichment_factor"]
         for sample_name in final_dataset.sample_names()
     }
 
@@ -522,34 +538,37 @@ def create_final_report(
         product_id="single-cell-pna",
         number_of_components=n_components,
         percentage_of_components_successfully_called=percentage_of_components_successfully_called,
-        sample_confidences_per_sample={
-            sample: confidences.to_list()
-            for sample, confidences in sample_confidences_per_sample.items()
+        hash_enrichment_factors_per_sample={
+            sample: enrichment_factors.to_list()
+            for sample, enrichment_factors in hash_enrichment_factors_per_sample.items()
         },
     )
     return total_report
 
 
-def warn_if_undetermined_has_high_confidence(
-    undetermined_sample_confidences: pd.Series | np.ndarray,
-    confidence_threshold: float,
+def warn_if_undetermined_has_high_enrichment(
+    undetermined_enrichment_factors: pd.Series | np.ndarray,
+    enrichment_threshold: float,
     undetermined_sample_name: str = "undetermined",
 ) -> None:
-    """Warn if the undetermined sample has a high confidence score.
+    """Warn if the undetermined sample has a high hash enrichment factor.
+
+    A high enrichment factor in undetermined components means they are clearly
+    dominated by one hash, suggesting the samplesheet may have wrong sample indices.
 
     Args:
-        undetermined_sample_confidences: Undetermined sample confidences.
-        confidence_threshold: Minimum confidence required to assign a component to a sample.
-            Defaults to 0.8.
+        undetermined_enrichment_factors: Hash enrichment factors for undetermined components.
+        enrichment_threshold: Minimum hash enrichment factor required to assign a component to a
+            sample.
         undetermined_sample_name: Name to use for undetermined components. Defaults to
             "undetermined".
     """
     if (
-        np.sum(undetermined_sample_confidences > confidence_threshold)
-        / len(undetermined_sample_confidences)
+        np.sum(undetermined_enrichment_factors > enrichment_threshold)
+        / len(undetermined_enrichment_factors)
         > 0.05
     ):
         logger.warning(
-            f"There are more than 5% of components in {undetermined_sample_name} that have a high confidence score. "
+            f"There are more than 5% of components in {undetermined_sample_name} that have a high hash enrichment factor. "
             "This may indicate that the samplesheet has the wrong sample indices."
         )

--- a/tests/pna/sample_calling/test_sample_calling.py
+++ b/tests/pna/sample_calling/test_sample_calling.py
@@ -21,7 +21,7 @@ from pixelator.pna.sample_calling import (
     collect_hash_info,
     create_final_report,
     sample_calling,
-    warn_if_undetermined_has_high_confidence,
+    warn_if_undetermined_has_high_enrichment,
 )
 from pixelator.pna.sample_calling.hash_antibodies import HashedAntibodyMapping
 from pixelator.pna.sample_calling.sample_calling import (
@@ -273,7 +273,7 @@ def test_collect_hash_info(sample_hashed_pixel_files):
                 "B2M-3",
             ],
         ),
-        confidence_threshold=0.8,
+        enrichment_threshold=1.5,
     )
 
     comp_counts = cc.group_by("called_sample").len("count")
@@ -304,7 +304,7 @@ def test_collect_hash_info_should_use_all_hashing_antibodies(sample_hashed_pixel
                 "B2M-3",
             ],
         ),
-        confidence_threshold=0.8,
+        enrichment_threshold=1.5,
         undetermined_sample_name="test",
     )
     # called_sample can be PBMC, Raji, or "test" (when undetermined_hash_count wins),
@@ -347,7 +347,7 @@ def test_collect_hash_info_all_undetermined(sample_hashed_pixel_files):
                 "B2M-3",
             ],
         ),
-        confidence_threshold=1.0,
+        enrichment_threshold=float("inf"),
         undetermined_sample_name="test",
     )
 
@@ -510,7 +510,7 @@ def test_sample_calling_does_not_strip_suffix_from_non_hash_markers(
         hashing_antibody_mapping=hashing_antibodies,
         output_folder=out_dir,
         remove_incompatible=True,
-        confidence_threshold=0.5,
+        enrichment_threshold=1.5,
     )
 
     output_files = list(out_dir.glob("*.dehashed.pxl"))
@@ -530,7 +530,7 @@ def test_sample_calling_with_undetermined(sample_hashed_pixel_files, tmp_path):
         sample_hashed_pixel_files: Sample hashed pixel files.
         tmp_path: Tmp path.
     """
-    confidence_threshold = 0.96
+    enrichment_threshold = 50.0
     pxl = read(sample_hashed_pixel_files)
     samplesheet, all_hashing = _samplesheet_and_hashing_for_three_samples()
     hashed_antibodies = HashedAntibodyMapping.from_samplesheet(
@@ -544,7 +544,7 @@ def test_sample_calling_with_undetermined(sample_hashed_pixel_files, tmp_path):
         hashing_antibody_mapping=hashed_antibodies,
         output_folder=output_folder,
         remove_incompatible=True,
-        confidence_threshold=confidence_threshold,
+        enrichment_threshold=enrichment_threshold,
     )
 
     output_files = list(output_folder.glob("*.dehashed.pxl"))
@@ -555,10 +555,11 @@ def test_sample_calling_with_undetermined(sample_hashed_pixel_files, tmp_path):
         dehashed_counts = dehashed_pxl.adata().to_df()
         sample_name = list(dehashed_pxl.metadata().keys())[0]
         if sample_name == "undetermined":
-            assert dehashed_counts.shape[0] == 2
+            assert dehashed_counts.shape[0] == 7
         else:
             assert all(
-                dehashed_pxl.adata().obs["sample_confidence"] >= confidence_threshold
+                dehashed_pxl.adata().obs["hash_enrichment_factor"]
+                >= enrichment_threshold
             )
 
 
@@ -621,16 +622,16 @@ class _FakeFilteredDataset:
         self,
         *,
         component_ids: set[str],
-        sample_confidences: list[float] | None = None,
+        hash_enrichment_factors: list[float] | None = None,
     ):
         """Initialize the instance.
 
         Args:
             component_ids: Component ids.
-            sample_confidences: Sample confidences.
+            hash_enrichment_factors: Hash enrichment factors.
         """
         self._component_ids = component_ids
-        self._sample_confidences = sample_confidences
+        self._hash_enrichment_factors = hash_enrichment_factors
 
     def components(self) -> set[str]:
         """Components.
@@ -651,14 +652,14 @@ class _FakeFilteredDataset:
             add_log1p_transform: Add log1p transform.
             add_clr_transform: Add clr transform.
         """
-        assert self._sample_confidences is not None
-        n = len(self._sample_confidences)
+        assert self._hash_enrichment_factors is not None
+        n = len(self._hash_enrichment_factors)
         # Explicit string obs index avoids AnnData ImplicitModificationWarning on index coercion.
         obs_index = [f"comp_{i}" for i in range(n)]
         return anndata.AnnData(
             X=np.zeros((n, 1)),
             obs=pd.DataFrame(
-                {"sample_confidence": self._sample_confidences},
+                {"hash_enrichment_factor": self._hash_enrichment_factors},
                 index=obs_index,
             ),
         )
@@ -672,18 +673,18 @@ class _FakeMergedDataset:
         *,
         all_components: set[str],
         undetermined_components: set[str] | None,
-        confidences_per_sample: dict[str, list[float]],
+        enrichment_factors_per_sample: dict[str, list[float]],
     ):
         """Initialize the instance.
 
         Args:
             all_components: All components.
             undetermined_components: Undetermined components.
-            confidences_per_sample: Confidences per sample.
+            enrichment_factors_per_sample: Hash enrichment factors per sample.
         """
         self._all_components = all_components
         self._undetermined_components = undetermined_components
-        self._confidences_per_sample = confidences_per_sample
+        self._enrichment_factors_per_sample = enrichment_factors_per_sample
 
     def components(self) -> set[str]:
         """Components.
@@ -699,7 +700,7 @@ class _FakeMergedDataset:
         Returns:
             Result (set[str]).
         """
-        return set(self._confidences_per_sample.keys())
+        return set(self._enrichment_factors_per_sample.keys())
 
     def filter(
         self,
@@ -721,15 +722,17 @@ class _FakeMergedDataset:
                 )
             return _FakeFilteredDataset(
                 component_ids=self._undetermined_components,
-                sample_confidences=self._confidences_per_sample.get("undetermined"),
+                hash_enrichment_factors=self._enrichment_factors_per_sample.get(
+                    "undetermined"
+                ),
             )
-        if samples not in self._confidences_per_sample:
+        if samples not in self._enrichment_factors_per_sample:
             raise ValueError(
                 "One or more of the specified samples do not exist in the dataset."
             )
         return _FakeFilteredDataset(
             component_ids=set(),
-            sample_confidences=self._confidences_per_sample[samples],
+            hash_enrichment_factors=self._enrichment_factors_per_sample[samples],
         )
 
 
@@ -738,9 +741,9 @@ def test_create_final_report_works_when_no_undetermined_sample():
     ds = _FakeMergedDataset(
         all_components={"c1", "c2", "c3"},
         undetermined_components=None,
-        confidences_per_sample={
-            "PBMC": [0.99, 0.98],
-            "Raji": [0.97],
+        enrichment_factors_per_sample={
+            "PBMC": [10.0, 9.5],
+            "Raji": [8.0],
         },
     )
     report = create_final_report(ds)  # type: ignore[arg-type]
@@ -750,9 +753,9 @@ def test_create_final_report_works_when_no_undetermined_sample():
     assert report.report_type == "sample_calling_total"
     assert report.number_of_components == 3
     assert report.percentage_of_components_successfully_called == 1.0
-    assert report.sample_confidences_per_sample == {
-        "PBMC": [0.99, 0.98],
-        "Raji": [0.97],
+    assert report.hash_enrichment_factors_per_sample == {
+        "PBMC": [10.0, 9.5],
+        "Raji": [8.0],
     }
 
 
@@ -761,17 +764,17 @@ def test_create_final_report_percentage_excludes_undetermined_components():
     ds = _FakeMergedDataset(
         all_components={"a", "b", "c", "d"},
         undetermined_components={"d"},
-        confidences_per_sample={
-            "PBMC": [1.0, 1.0, 1.0],
-            "undetermined": [0.2],
+        enrichment_factors_per_sample={
+            "PBMC": [10.0, 10.0, 10.0],
+            "undetermined": [1.2],
         },
     )
     report = create_final_report(ds)  # type: ignore[arg-type]
 
     assert report.number_of_components == 4
     assert report.percentage_of_components_successfully_called == pytest.approx(0.75)
-    assert report.sample_confidences_per_sample["PBMC"] == [1.0, 1.0, 1.0]
-    assert report.sample_confidences_per_sample["undetermined"] == [0.2]
+    assert report.hash_enrichment_factors_per_sample["PBMC"] == [10.0, 10.0, 10.0]
+    assert report.hash_enrichment_factors_per_sample["undetermined"] == [1.2]
 
 
 def test_create_final_report_zero_success_when_all_components_undetermined():
@@ -779,16 +782,16 @@ def test_create_final_report_zero_success_when_all_components_undetermined():
     ds = _FakeMergedDataset(
         all_components={"x", "y"},
         undetermined_components={"x", "y"},
-        confidences_per_sample={"undetermined": [0.1, 0.2]},
+        enrichment_factors_per_sample={"undetermined": [1.1, 1.2]},
     )
     report = create_final_report(ds)  # type: ignore[arg-type]
 
     assert report.number_of_components == 2
     assert report.percentage_of_components_successfully_called == 0.0
-    assert report.sample_confidences_per_sample["undetermined"] == [0.1, 0.2]
+    assert report.hash_enrichment_factors_per_sample["undetermined"] == [1.1, 1.2]
 
 
-def test_warn_if_undetermined_has_high_confidence_logs_when_fraction_above_five_percent(
+def test_warn_if_undetermined_has_high_enrichment_logs_when_fraction_above_five_percent(
     caplog,
 ):
     """More than 5% strictly above the threshold should emit one WARNING.
@@ -799,16 +802,16 @@ def test_warn_if_undetermined_has_high_confidence_logs_when_fraction_above_five_
     with caplog.at_level(
         logging.WARNING, logger="pixelator.pna.sample_calling.sample_calling"
     ):
-        warn_if_undetermined_has_high_confidence(
-            undetermined_sample_confidences=np.array([0.95] * 6 + [0.1] * 94),
-            confidence_threshold=0.9,
+        warn_if_undetermined_has_high_enrichment(
+            undetermined_enrichment_factors=np.array([10.5] * 6 + [1.5] * 94),
+            enrichment_threshold=10.0,
         )
     assert len(caplog.records) == 1
     assert caplog.records[0].levelname == "WARNING"
     assert "samplesheet" in caplog.text
 
 
-def test_warn_if_undetermined_has_high_confidence_no_log_when_fraction_is_exactly_five_percent(
+def test_warn_if_undetermined_has_high_enrichment_no_log_when_fraction_is_exactly_five_percent(
     caplog,
 ):
     """The check uses ``> 0.05``, so exactly 5% above threshold must not warn.
@@ -819,17 +822,17 @@ def test_warn_if_undetermined_has_high_confidence_no_log_when_fraction_is_exactl
     with caplog.at_level(
         logging.WARNING, logger="pixelator.pna.sample_calling.sample_calling"
     ):
-        warn_if_undetermined_has_high_confidence(
-            undetermined_sample_confidences=np.array([0.95] * 5 + [0.1] * 95),
-            confidence_threshold=0.9,
+        warn_if_undetermined_has_high_enrichment(
+            undetermined_enrichment_factors=np.array([10.5] * 5 + [1.5] * 95),
+            enrichment_threshold=10.0,
         )
     assert caplog.records == []
 
 
-def test_warn_if_undetermined_has_high_confidence_no_log_when_all_at_or_below_threshold(
+def test_warn_if_undetermined_has_high_enrichment_no_log_when_all_at_or_below_threshold(
     caplog,
 ):
-    """Values equal to the threshold are not counted as high confidence (strict ``>``).
+    """Values equal to the threshold are not counted as high enrichment (strict ``>``).
 
     Args:
         caplog: Caplog.
@@ -837,18 +840,18 @@ def test_warn_if_undetermined_has_high_confidence_no_log_when_all_at_or_below_th
     with caplog.at_level(
         logging.WARNING, logger="pixelator.pna.sample_calling.sample_calling"
     ):
-        warn_if_undetermined_has_high_confidence(
-            undetermined_sample_confidences=np.full(50, 0.9),
-            confidence_threshold=0.9,
+        warn_if_undetermined_has_high_enrichment(
+            undetermined_enrichment_factors=np.full(50, 10.0),
+            enrichment_threshold=10.0,
         )
-        warn_if_undetermined_has_high_confidence(
-            undetermined_sample_confidences=np.array([0.1, 0.2, 0.5]),
-            confidence_threshold=0.9,
+        warn_if_undetermined_has_high_enrichment(
+            undetermined_enrichment_factors=np.array([1.5, 2.5, 5.0]),
+            enrichment_threshold=10.0,
         )
     assert caplog.records == []
 
 
-def test_warn_if_undetermined_has_high_confidence_logs_for_single_high_value(caplog):
+def test_warn_if_undetermined_has_high_enrichment_logs_for_single_high_value(caplog):
     """One component above threshold is 100% of the undetermined set, which is > 5%.
 
     Args:
@@ -857,8 +860,8 @@ def test_warn_if_undetermined_has_high_confidence_logs_for_single_high_value(cap
     with caplog.at_level(
         logging.WARNING, logger="pixelator.pna.sample_calling.sample_calling"
     ):
-        warn_if_undetermined_has_high_confidence(
-            undetermined_sample_confidences=np.array([0.99]),
-            confidence_threshold=0.9,
+        warn_if_undetermined_has_high_enrichment(
+            undetermined_enrichment_factors=np.array([10.5]),
+            enrichment_threshold=10.0,
         )
     assert len(caplog.records) == 1

--- a/tests/pna/sample_calling/test_sample_calling_cli.py
+++ b/tests/pna/sample_calling/test_sample_calling_cli.py
@@ -34,8 +34,8 @@ def test_runs_ok(pna_data_root):
             "--samplesheet",
             str(pna_data_root) + "/sample_calling/samplesheet.csv",
             "--remove-incompatible",
-            "--confidence-threshold",
-            "0.96",
+            "--enrichment-threshold",
+            "40.0",
             "--save-undetermined",
             "--output",
             d,
@@ -74,10 +74,10 @@ def test_runs_ok(pna_data_root):
         total_data = json.loads(total_report.read_text())
         assert total_data["report_type"] == "sample_calling_total"
         assert total_data["sample_id"] == "all"
-        assert "sample_confidences_per_sample" in total_data
+        assert "hash_enrichment_factors_per_sample" in total_data
         assert "percentage_of_components_successfully_called" in total_data
         assert (
-            np.abs(total_data["percentage_of_components_successfully_called"] - 14 / 15)
+            np.abs(total_data["percentage_of_components_successfully_called"] - 12 / 15)
             < 1e-6
         )
         total_components = 0


### PR DESCRIPTION
This PR changes sample calling evaluation criteria from purity-based to hash enrichment-factor-based. The hash enrichment factor is the ratio of the highest hash count to the second highest hash count across all hash buckets. The previous metric, sample_confidence (a.k.a hash purity), was the ratio of the highest hash count to the sum of counts across all other hash buckets. 

The new metric makes the score less prone to changes based on 

Fixes: PNA-2881

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Existing tests are adapted for the new metric.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
