### PR TITLE
WIP: Do one more refinement iteration after edge cycle verification

### DIFF
--- a/src/pixelator/pna/graph/community_detection.py
+++ b/src/pixelator/pna/graph/community_detection.py
@@ -618,6 +618,22 @@ def find_components(
         logger.info(
             f"Edge cycle verification completed in {time.time() - time_start:.2f} seconds."
         )
+        ## One more component refinement iteration after cycle verification
+        if refinement_options.max_component_refinement_depth > 1:
+            logger.info(
+                "Starting refinement stages on edgelist after cycle verification."
+            )
+            time_start = time.time()
+            component_stats, new_discarded_sizes = run_leiden_refinement(
+                component_edgelists_path=latest_working_edgelist_path,
+                refinement_options=refinement_options,
+                component_stats=component_stats,
+                max_workers=n_threads,
+            )
+            discard_sizes = pl.concat((discard_sizes, new_discarded_sizes))
+            logger.info(
+                f"Refinement stages after cycle verification completed in {time.time() - time_start:.2f} seconds."
+            )
 
     logger.info("Filtering connected components by size.")
     latest_working_edgelist_path, component_stats = filter_connected_components_by_size(

--- a/src/pixelator/pna/graph/component_recovery_utils.py
+++ b/src/pixelator/pna/graph/component_recovery_utils.py
@@ -601,7 +601,8 @@ def filter_connected_components_by_size(
         ConnectedComponentException: If no components remain after filtering.
     """
     component_sizes = create_component_size_data_frame(input_edgelist_path)
-    component_sizes = pl.concat([component_sizes, discard_sizes], how="vertical")
+    if discard_sizes.height > 0:
+        component_sizes = pl.concat([component_sizes, discard_sizes], how="vertical")
 
     unique, counts = np.unique(
         component_sizes["n_umi"].cast(pl.Int32), return_counts=True

--- a/src/pixelator/pna/graph/cycle_analysis.py
+++ b/src/pixelator/pna/graph/cycle_analysis.py
@@ -387,7 +387,7 @@ def remove_no_cycle_edges(
                 [out_paths],
             )
             con.execute(
-                "COPY merged_edgelist TO ? (FORMAT PARQUET)",
+                "COPY merged_edgelist TO ? (FORMAT PARQUET, PARTITION_BY (component))",
                 [str(output_path)],
             )
             return total_removed_edges, edge_cycle_length_dist, output_path


### PR DESCRIPTION
This PR investigates whether doing an additional Leiden refinement after edge cycle verification improves sample calling success rate in 8K-cell pools.

Fixes: PNA-2779

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

WIP 


## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
