### PR TITLE
Always route DuckDB spill files to a local temp directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Switch sample calling evaluation metric to hash enrichment factor instead of hash purity.
 
+### Fixed
+- Always route DuckDB spill files to a local temp directory (`PIXELATOR_DUCKDB_TEMP_DIR` or `/tmp`)
+  instead of next to the `.pxl` database file. This prevents `denoise`, component filtering and other
+  commands from spilling onto networked filesystems (e.g. to S3 when running the pipeline in the cloud)
+  where the `.pxl` may live.
+
 ## [0.28.0] - 2026-06-03
 
 ### Added

--- a/src/pixelator/cli/main.py
+++ b/src/pixelator/cli/main.py
@@ -5,14 +5,16 @@ Copyright © 2022 Pixelgen Technologies AB.
 
 import atexit
 import multiprocessing
-import os
 import sys
-from pathlib import Path
 
 import click
 import yappi
 
 from pixelator import __version__
+from pixelator.common.duckdb_utils import (
+    get_duckdb_max_temp_dir_size_from_env,
+    get_duckdb_temp_dir_from_env,
+)
 from pixelator.common.utils import click_echo
 from pixelator.mpx.cli.adapterqc import adapterqc
 from pixelator.mpx.cli.amplicon import amplicon
@@ -96,13 +98,13 @@ def main_cli(ctx, verbose: bool, profile: bool, log_file: str, cores: int):
     ctx.obj["CORES"] = max(1, cores)
 
     # Read in environment variables
-    duckdb_temp_dir = os.environ.get("PIXELATOR_DUCKDB_TEMP_DIR")
+    duckdb_temp_dir = get_duckdb_temp_dir_from_env()
     if duckdb_temp_dir:
-        ctx.obj["DUCKDB_TEMP_DIR"] = Path(duckdb_temp_dir)
+        ctx.obj["DUCKDB_TEMP_DIR"] = duckdb_temp_dir
 
-    duckdb_tmp_dir_size = os.environ.get("PIXELATOR_DUCKDB_MAX_TEMP_DIR_SIZE")
+    duckdb_tmp_dir_size = get_duckdb_max_temp_dir_size_from_env()
     if duckdb_tmp_dir_size:
-        ctx.obj["DUCKDB_MAX_TEMP_DIR_SIZE"] = duckdb_tmp_dir_size.strip()
+        ctx.obj["DUCKDB_MAX_TEMP_DIR_SIZE"] = duckdb_tmp_dir_size
 
     return 0
 

--- a/src/pixelator/common/duckdb_utils.py
+++ b/src/pixelator/common/duckdb_utils.py
@@ -1,0 +1,85 @@
+"""Shared DuckDB connection helpers for Pixelator.
+
+These helpers ensure DuckDB's spill (``temp_directory``) location is always set
+explicitly. DuckDB otherwise defaults the spill location to a directory next to
+the database file, which fails when the ``.pxl`` file lives on a networked
+filesystem (e.g. Fusion/S3).
+
+Copyright © 2025 Pixelgen Technologies AB.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import duckdb
+
+DEFAULT_DUCKDB_TEMP_DIR = Path("/tmp")
+
+
+def get_duckdb_temp_dir_from_env() -> Path | None:
+    """Return ``PIXELATOR_DUCKDB_TEMP_DIR`` as a ``Path``, or ``None`` if unset."""
+    value = os.environ.get("PIXELATOR_DUCKDB_TEMP_DIR")
+    return Path(value) if value else None
+
+
+def get_duckdb_max_temp_dir_size_from_env() -> str | None:
+    """Return ``PIXELATOR_DUCKDB_MAX_TEMP_DIR_SIZE``, or ``None`` if unset."""
+    value = os.environ.get("PIXELATOR_DUCKDB_MAX_TEMP_DIR_SIZE")
+    return value.strip() if value else None
+
+
+def resolve_duckdb_temp_dir(temp_dir: Path | str | None = None) -> Path:
+    """Resolve the DuckDB spill directory.
+
+    Uses the explicit argument, then ``PIXELATOR_DUCKDB_TEMP_DIR``, then ``/tmp``.
+
+    Args:
+        temp_dir: An explicit spill directory that takes precedence over the env var.
+
+    Returns:
+        The resolved spill directory.
+    """
+    if temp_dir is not None:
+        return Path(temp_dir)
+    return get_duckdb_temp_dir_from_env() or DEFAULT_DUCKDB_TEMP_DIR
+
+
+def connect_duckdb(
+    database: str | Path = ":memory:",
+    *,
+    read_only: bool = False,
+    config: dict | None = None,
+    temp_dir: str | Path | None = None,
+    temp_dir_size_limit: str | None = None,
+) -> duckdb.DuckDBPyConnection:
+    """Open a DuckDB connection with the spill (temp) directory always set.
+
+    This prevents DuckDB from spilling next to the database file, which may be on a
+    networked filesystem.
+
+    Args:
+        database: The database to connect to. Defaults to an in-memory database.
+        read_only: Whether to open the database in read-only mode.
+        config: A DuckDB configuration dict passed through to ``duckdb.connect``.
+        temp_dir: The spill directory. Defaults to ``PIXELATOR_DUCKDB_TEMP_DIR`` or ``/tmp``.
+        temp_dir_size_limit: The spill directory size limit. Defaults to
+            ``PIXELATOR_DUCKDB_MAX_TEMP_DIR_SIZE`` when unset.
+
+    Returns:
+        A DuckDB connection with ``temp_directory`` configured.
+    """
+    conn = duckdb.connect(
+        database=str(database), read_only=read_only, config=config or {}
+    )
+
+    resolved_temp_dir = str(resolve_duckdb_temp_dir(temp_dir).absolute())
+    commands = [f"SET temp_directory = '{resolved_temp_dir}';"]
+
+    resolved_size = temp_dir_size_limit or get_duckdb_max_temp_dir_size_from_env()
+    if resolved_size is not None:
+        commands.append(f"SET max_temp_directory_size = '{resolved_size}';")
+
+    conn.execute("\n".join(commands))
+    return conn

--- a/src/pixelator/pna/graph/community_detection.py
+++ b/src/pixelator/pna/graph/community_detection.py
@@ -11,13 +11,13 @@ from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path
 
-import duckdb
 import networkx as nx
 import pandas as pd
 import polars as pl
 from graspologic_native import leiden
 from pixelator_core import run_hybrid_community_detection
 
+from pixelator.common.duckdb_utils import connect_duckdb
 from pixelator.common.utils import get_process_pool_executor
 from pixelator.pna.cli.common import logger
 from pixelator.pna.graph.component_recovery_utils import (
@@ -90,7 +90,7 @@ def map_working_to_original_umi_names(
 ) -> Path:
     """Replace working UMI names in an edgelist with original names and write parquet."""
     output_path = working_dir / "edgelist_with_original_umis.parquet"
-    with duckdb.connect() as con:
+    with connect_duckdb() as con:
         missing_count_row = con.execute(f"""
             SELECT COUNT(*) AS n_missing
             FROM parquet_scan('{str(input_edgelist_path)}') e
@@ -254,7 +254,7 @@ def refine_component(
         int: Number of crossing edges removed during refinement.
         pd.Series: Sizes of discarded components after refinement.
     """
-    with duckdb.connect(config=duckdb_config) as con:
+    with connect_duckdb(config=duckdb_config) as con:
         edgelist = con.execute(f"""
             SELECT *
             FROM read_parquet('{str(component_edgelists_path)}/component={component_id}', hive_partitioning = true)
@@ -338,7 +338,7 @@ def get_component_sizes(
         component_edgelists_path: Path to the component edgelists in Parquet (hive partitioned)
             format.
     """
-    with duckdb.connect() as con:
+    with connect_duckdb() as con:
         component_sizes = con.execute(f"""
             SELECT component, COUNT(DISTINCT umi1) + COUNT(DISTINCT umi2) AS n_umi
             FROM read_parquet(

--- a/src/pixelator/pna/graph/component_recovery_utils.py
+++ b/src/pixelator/pna/graph/component_recovery_utils.py
@@ -12,13 +12,13 @@ import logging
 import typing
 from pathlib import Path
 
-import duckdb
 import numpy as np
 import polars as pl
 import xxhash
 from pixelator_core import PyGraphProperties
 
 from pixelator.common.annotate.cell_calling import find_component_size_limits
+from pixelator.common.duckdb_utils import connect_duckdb
 from pixelator.common.exceptions import PixelatorBaseException
 from pixelator.pna.graph.constants import DEFAULT_WORKING_DIR, MIN_PNA_COMPONENT_SIZE
 from pixelator.pna.graph.report import GraphStatistics
@@ -106,7 +106,7 @@ def name_components_with_umi_hashes_from_parquet(
 ) -> Path:
     """Rewrite component ids to deterministic UMI-based hashes and write parquet."""
     output_path = working_dir / "edgelist_with_hashed_components.parquet"
-    with duckdb.connect() as con:
+    with connect_duckdb() as con:
         component_rows = con.execute(f"""
             SELECT
                 component,
@@ -166,7 +166,7 @@ def get_count_statistics(edgelist_path: Path) -> dict:
         edgelist. - 'n_umi': Total number of distinct UMIs in the edgelist. - 'n_reads': Total
         number of reads in the edgelist. - 'n_molecules': Total number of molecules in the edgelist.
     """
-    with duckdb.connect() as con:
+    with connect_duckdb() as con:
         con.execute(
             f"CREATE VIEW edgelist AS SELECT * FROM parquet_scan('{str(edgelist_path)}')"
         )
@@ -217,7 +217,7 @@ def write_hive_partitioned_edgelist_without_small_components(
     hive_partitioned_edgelist_path = working_dir / "hive_partitioned_edgelist.parquet"
     min_sz = int(min_component_size_to_prune)
     logger.debug("Filtering out small components from edge list")
-    with duckdb.connect(working_dir / "temp_hivepartition.duckdb") as conn:
+    with connect_duckdb(working_dir / "temp_hivepartition.duckdb") as conn:
         conn.execute(f"""
             CREATE TEMP TABLE component_counts AS
                 SELECT
@@ -267,7 +267,7 @@ def find_clashing_umis(
         (pl.Series, GraphStatistics): A tuple containing a Polars Series of clashing UMIs
         and the updated component statistics.
     """
-    with duckdb.connect() as con:
+    with connect_duckdb() as con:
         con.execute(
             f"CREATE VIEW edgelist AS SELECT * FROM parquet_scan('{str(input_file)}')"
         )
@@ -319,7 +319,7 @@ def remove_umis(
         Path to the written Parquet file (``no_clash_edgelist.parquet`` in ``working_dir``).
     """
     target_path = working_dir / "no_clash_edgelist.parquet"
-    with duckdb.connect() as con:
+    with connect_duckdb() as con:
         con.execute(
             f"CREATE VIEW edgelist AS SELECT * FROM parquet_scan('{str(input_edgelist_path)}')"
         )
@@ -390,7 +390,7 @@ def create_working_edgelist(
     """
     node_map_path = working_dir / "node_map.parquet"
     working_edgelist_path = working_dir / "working_edgelist.parquet"
-    with duckdb.connect() as con:
+    with connect_duckdb() as con:
         con.execute(
             f"CREATE VIEW input_edgelist AS SELECT * FROM parquet_scan('{str(input_edgelist_path)}')"
         )
@@ -453,7 +453,7 @@ def filter_edgelist_by_read_count(
         Path to the filtered edgelist and updated graph statistics.
     """
     filtered_edgelist_path = working_dir / "filtered_edgelist.parquet"
-    with duckdb.connect() as con:
+    with connect_duckdb() as con:
         con.execute(
             f"CREATE VIEW edgelist AS SELECT * FROM parquet_scan('{str(input_edgelist_path)}')"
         )
@@ -496,7 +496,7 @@ def save_new_working_edgelist(
     output_path = working_dir / "working_edgelist_with_new_assignments.parquet"
     w = str(input_working_edgelist_path)
     a = str(new_assignments_path)
-    with duckdb.connect() as con:
+    with connect_duckdb() as con:
         c1 = component_column_name + "_1"
         c2 = component_column_name + "_2"
         con.execute(f"""
@@ -552,7 +552,7 @@ def create_component_size_data_frame(
         A Polars DataFrame with columns ``component`` and ``n_umi``, where ``n_umi`` is the count
         of distinct UMIs in that component (counting both ``umi1`` and ``umi2``).
     """
-    with duckdb.connect() as con:
+    with connect_duckdb() as con:
         component_sizes = con.execute(f"""
             SELECT
                 component,
@@ -660,7 +660,7 @@ def filter_connected_components_by_size(
     )
 
     filtered_edgelist_path = working_dir / "component_size_filtered_edgelist.parquet"
-    with duckdb.connect() as con:
+    with connect_duckdb() as con:
         con.register(
             "passing_components",
             passing_components.to_frame().to_arrow(),

--- a/src/pixelator/pna/graph/cycle_analysis.py
+++ b/src/pixelator/pna/graph/cycle_analysis.py
@@ -17,7 +17,6 @@ import os
 import tempfile
 from pathlib import Path
 
-import duckdb
 import networkx as nx
 import numpy as np
 import pandas as pd
@@ -25,6 +24,7 @@ import polars as pl
 from joblib import Parallel, delayed
 from scipy.sparse import csc_matrix
 
+from pixelator.common.duckdb_utils import connect_duckdb
 from pixelator.pna.graph.constants import (
     DEFAULT_WORKING_DIR,
     MAX_CYCLE_SEARCH_STEPS,
@@ -214,7 +214,7 @@ class ShortestPathFinder:
 
 def process_component(comp_name, edgelist_path, tmpdir):
     """Process a single component to remove edges not participating in cycles."""
-    with duckdb.connect() as con:
+    with connect_duckdb() as con:
         con.execute(
             """
             CREATE TEMP TABLE comp_edgelist AS
@@ -309,7 +309,7 @@ def remove_no_cycle_edges(
     output_path = working_dir / "working_edgelist_with_cycle_verification"
     logger.info("Starting removal of no-cycle edges")
     with tempfile.TemporaryDirectory() as tmpdir:
-        with duckdb.connect(tmpdir + "/temp_duckdb.db") as con:
+        with connect_duckdb(tmpdir + "/temp_duckdb.db") as con:
             con.execute(
                 """
                 CREATE TEMP TABLE graph_edgelist AS

--- a/src/pixelator/pna/pixeldataset/io/__init__.py
+++ b/src/pixelator/pna/pixeldataset/io/__init__.py
@@ -108,7 +108,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-import duckdb
+from pixelator.common.duckdb_utils import connect_duckdb
 
 from .inplace_pixel_data_filterer import InplacePixelDataFilterer
 from .pixel_data_viewer import PixelDataViewer, PixelDataViewerSession
@@ -150,5 +150,5 @@ def copy_databases(src_db: Path, target_db: Path) -> None:
     COPY FROM DATABASE src TO target;
     """
 
-    with duckdb.connect() as connection:
+    with connect_duckdb() as connection:
         connection.execute(query)

--- a/src/pixelator/pna/pixeldataset/io/inplace_pixel_data_filterer.py
+++ b/src/pixelator/pna/pixeldataset/io/inplace_pixel_data_filterer.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import duckdb
 
+from pixelator.common.duckdb_utils import connect_duckdb
 from pixelator.pna.pixeldataset.io.anndata_helper import AnnDataHelper
 from pixelator.pna.pixeldataset.io.pixel_data_viewer import PixelDataViewer
 from pixelator.pna.pixeldataset.io.pixel_file_writer import PixelFileWriter
@@ -100,7 +101,7 @@ class InplacePixelDataFilterer:
 
         components_as_list: list[str] = normalize_input_to_list(components)  # type: ignore
 
-        with duckdb.connect(self.pxl_file.path) as connection:
+        with connect_duckdb(self.pxl_file.path) as connection:
             self._filter_edgelist(connection, components_as_list)
             self._filter_proximity(connection, components_as_list)
             self._filter_layouts(connection, components_as_list)

--- a/src/pixelator/pna/pixeldataset/io/pixel_data_viewer.py
+++ b/src/pixelator/pna/pixeldataset/io/pixel_data_viewer.py
@@ -12,6 +12,8 @@ from typing import Iterable
 import duckdb
 import polars as pl
 
+from pixelator.common.duckdb_utils import connect_duckdb
+
 from .pxl_file import PXL_FILE_MANDATOR_TABLES, PXL_FILE_OTHER_TABLES, PxlFile
 from .query_builder import Query
 
@@ -209,7 +211,7 @@ class PixelDataViewerSession:
 
     def _create_open_connection(self) -> duckdb.DuckDBPyConnection:
         """Create an in-memory DuckDB connection with PXL files attached."""
-        connection = duckdb.connect(":memory:")
+        connection = connect_duckdb(":memory:")
         self._attach_to_files(connection)
         for table in PXL_FILE_OTHER_TABLES:
             self._simple_union_table_view(connection, table, table)

--- a/src/pixelator/pna/pixeldataset/io/pixel_file_writer.py
+++ b/src/pixelator/pna/pixeldataset/io/pixel_file_writer.py
@@ -12,6 +12,8 @@ import duckdb
 import polars as pl
 from anndata import AnnData
 
+from pixelator.pna.utils import init_duckdb_conn
+
 
 class PixelFileWriter:
     """Writer class for PXL files.
@@ -31,23 +33,38 @@ class PixelFileWriter:
             writer.write_edgelist(Path("edgelist.parquet"))
     """
 
-    def __init__(self, path: Path, exits_ok: bool = False):
+    def __init__(
+        self,
+        path: Path,
+        exits_ok: bool = False,
+        temp_dir: Path | str | None = None,
+        temp_dir_size_limit: str | None = None,
+    ):
         """Initialize the PixelFileWriter.
 
         Args:
             path: The path to the PXL file.
-            exists_ok: Whether to remove the file if it exists.
-            exits_ok: Exits ok.
+            exits_ok: Whether to remove the file if it exists.
+            temp_dir: DuckDB spill directory. Defaults to PIXELATOR_DUCKDB_TEMP_DIR or /tmp.
+            temp_dir_size_limit: DuckDB spill size limit. Defaults to
+                PIXELATOR_DUCKDB_MAX_TEMP_DIR_SIZE when set.
         """
         self.path = path
         self.exists_ok = exits_ok
+        self._temp_dir = temp_dir
+        self._temp_dir_size_limit = temp_dir_size_limit
         if self.exists_ok and self.path.exists():
             self.path.unlink()
         self._connection: duckdb.DuckDBPyConnection = None  # type: ignore
 
     def open(self):
         """Open a connection to the PXL file."""
-        self._connection = duckdb.connect(self.path)
+        self._connection = init_duckdb_conn(
+            path=self.path,
+            read_only=False,
+            temp_dir=self._temp_dir,
+            temp_dir_size_limit=self._temp_dir_size_limit,
+        )
 
     def close(self):
         """Close the connection to the PXL file."""

--- a/src/pixelator/pna/pixeldataset/io/pixel_file_writer.py
+++ b/src/pixelator/pna/pixeldataset/io/pixel_file_writer.py
@@ -45,9 +45,9 @@ class PixelFileWriter:
         Args:
             path: The path to the PXL file.
             exits_ok: Whether to remove the file if it exists.
-            temp_dir: DuckDB spill directory. Defaults to PIXELATOR_DUCKDB_TEMP_DIR or /tmp.
+            temp_dir: DuckDB spill directory. Defaults to ``PIXELATOR_DUCKDB_TEMP_DIR`` or ``/tmp``.
             temp_dir_size_limit: DuckDB spill size limit. Defaults to
-                PIXELATOR_DUCKDB_MAX_TEMP_DIR_SIZE when set.
+                ``PIXELATOR_DUCKDB_MAX_TEMP_DIR_SIZE`` when set.
         """
         self.path = path
         self.exists_ok = exits_ok

--- a/src/pixelator/pna/pixeldataset/io/pxl_file.py
+++ b/src/pixelator/pna/pixeldataset/io/pxl_file.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 import duckdb
 
+from pixelator.common.duckdb_utils import connect_duckdb
+
 PXL_FILE_MANDATOR_TABLES = [
     "__adata__X",
     "__adata__var",
@@ -48,7 +50,7 @@ class PxlFile:
 
     def is_pxl_file(self) -> bool:
         """Check if the file is a PXL file."""
-        with duckdb.connect(self.path, read_only=True) as con:
+        with connect_duckdb(self.path, read_only=True) as con:
             tables = con.sql("SHOW ALL TABLES").to_df()
             return len(
                 set(PXL_FILE_MANDATOR_TABLES).intersection(
@@ -59,7 +61,7 @@ class PxlFile:
     def metadata(self) -> dict:
         """Read the metadata from the PXL file."""
         try:
-            with duckdb.connect(self.path, read_only=True) as con:
+            with connect_duckdb(self.path, read_only=True) as con:
                 metadata = con.sql("SELECT * FROM metadata").fetchone()
                 return json.loads(metadata[0]) if metadata else {}
         except duckdb.CatalogException:

--- a/src/pixelator/pna/utils/utils.py
+++ b/src/pixelator/pna/utils/utils.py
@@ -14,6 +14,7 @@ import duckdb as dd
 import pandas as pd
 import polars as pl
 
+from pixelator.common.duckdb_utils import connect_duckdb
 from pixelator.common.utils import (
     R1_REGEX,
     R2_REGEX,
@@ -250,15 +251,20 @@ def init_duckdb_conn(
         read_only: Whether to open the database in read-only mode. Defaults to False.
         memory_limit: The memory limit in bytes. If None, no limit is set. Defaults to None.
         threads: The number of threads to use. If None, duckdb will decide. Defaults to None.
-        temp_dir: The directory to use for temporary files. If None, duckdb will decide (defaults to
-            /tmp). Defaults to None.
-        temp_dir_size_limit: The maximum size of the temporary directory. If None, no limit is set.
-            Defaults to None.
+        temp_dir: The directory to use for temporary files. If None, defaults to
+            PIXELATOR_DUCKDB_TEMP_DIR or /tmp (never next to the database file).
+        temp_dir_size_limit: The maximum size of the temporary directory. If None, defaults to
+            PIXELATOR_DUCKDB_MAX_TEMP_DIR_SIZE when set, otherwise no limit.
 
     Returns:
         A duckdb connection object.
     """
-    conn = dd.connect(database=str(path), read_only=read_only)
+    conn = connect_duckdb(
+        database=path,
+        read_only=read_only,
+        temp_dir=temp_dir,
+        temp_dir_size_limit=temp_dir_size_limit,
+    )
 
     commands = []
     if memory_limit is not None:
@@ -267,13 +273,6 @@ def init_duckdb_conn(
     if threads is not None:
         commands.append(f"SET threads = {threads};")
         logger.debug("Using DuckDB threads limit: %s", threads)
-    if temp_dir is not None:
-        temp_dir = str(Path(temp_dir).absolute())
-        commands.append(f"SET temp_directory = '{temp_dir}';")
-        logger.debug("Using DuckDB temp directory: %s", temp_dir)
-    if temp_dir_size_limit is not None:
-        commands.append(f"SET max_temp_directory_size = '{temp_dir_size_limit}';")
-        logger.debug("Using DuckDB temp directory size limit: %s", temp_dir_size_limit)
 
     if commands:
         conn.execute("\n".join(commands))

--- a/src/pixelator/pna/utils/utils.py
+++ b/src/pixelator/pna/utils/utils.py
@@ -252,9 +252,9 @@ def init_duckdb_conn(
         memory_limit: The memory limit in bytes. If None, no limit is set. Defaults to None.
         threads: The number of threads to use. If None, duckdb will decide. Defaults to None.
         temp_dir: The directory to use for temporary files. If None, defaults to
-            PIXELATOR_DUCKDB_TEMP_DIR or /tmp (never next to the database file).
+            ``PIXELATOR_DUCKDB_TEMP_DIR`` or ``/tmp`` (never next to the database file).
         temp_dir_size_limit: The maximum size of the temporary directory. If None, defaults to
-            PIXELATOR_DUCKDB_MAX_TEMP_DIR_SIZE when set, otherwise no limit.
+            ``PIXELATOR_DUCKDB_MAX_TEMP_DIR_SIZE`` when set, otherwise no limit.
 
     Returns:
         A duckdb connection object.

--- a/tests/pna/pixeldataset/test_pixel_file_writer.py
+++ b/tests/pna/pixeldataset/test_pixel_file_writer.py
@@ -20,9 +20,11 @@ class TestPixelFileWriter:
         monkeypatch.setenv("PIXELATOR_DUCKDB_TEMP_DIR", str(duckdb_tmp))
         target = tmp_path / "file.pxl"
         with PixelFileWriter(target) as writer:
-            setting = writer.get_connection().execute(
-                "SELECT current_setting('temp_directory')"
-            ).fetchone()[0]
+            setting = (
+                writer.get_connection()
+                .execute("SELECT current_setting('temp_directory')")
+                .fetchone()[0]
+            )
         assert setting == str(duckdb_tmp.absolute())
 
     def test_open_defaults_temp_directory_to_tmp(self, tmp_path, monkeypatch):
@@ -35,9 +37,11 @@ class TestPixelFileWriter:
         monkeypatch.delenv("PIXELATOR_DUCKDB_TEMP_DIR", raising=False)
         target = tmp_path / "file.pxl"
         with PixelFileWriter(target) as writer:
-            setting = writer.get_connection().execute(
-                "SELECT current_setting('temp_directory')"
-            ).fetchone()[0]
+            setting = (
+                writer.get_connection()
+                .execute("SELECT current_setting('temp_directory')")
+                .fetchone()[0]
+            )
         assert setting == str(Path("/tmp").absolute())
 
     def test_write_edgelist(self, tmp_path, edgelist_parquet_path):

--- a/tests/pna/pixeldataset/test_pixel_file_writer.py
+++ b/tests/pna/pixeldataset/test_pixel_file_writer.py
@@ -1,10 +1,44 @@
 """Copyright © 2025 Pixelgen Technologies AB."""
 
+from pathlib import Path
+
 from pixelator.pna.pixeldataset.io import PixelFileWriter
 
 
 class TestPixelFileWriter:
     """Represent test pixel file writer."""
+
+    def test_open_honors_duckdb_temp_dir_env(self, tmp_path, monkeypatch):
+        """The writer's DuckDB connection should use PIXELATOR_DUCKDB_TEMP_DIR for spilling.
+
+        Args:
+            tmp_path: tmp path.
+            monkeypatch: pytest monkeypatch fixture.
+        """
+        duckdb_tmp = tmp_path / "duckdb_scratch"
+        duckdb_tmp.mkdir()
+        monkeypatch.setenv("PIXELATOR_DUCKDB_TEMP_DIR", str(duckdb_tmp))
+        target = tmp_path / "file.pxl"
+        with PixelFileWriter(target) as writer:
+            setting = writer.get_connection().execute(
+                "SELECT current_setting('temp_directory')"
+            ).fetchone()[0]
+        assert setting == str(duckdb_tmp.absolute())
+
+    def test_open_defaults_temp_directory_to_tmp(self, tmp_path, monkeypatch):
+        """The writer should default the DuckDB spill directory to /tmp when env is unset.
+
+        Args:
+            tmp_path: tmp path.
+            monkeypatch: pytest monkeypatch fixture.
+        """
+        monkeypatch.delenv("PIXELATOR_DUCKDB_TEMP_DIR", raising=False)
+        target = tmp_path / "file.pxl"
+        with PixelFileWriter(target) as writer:
+            setting = writer.get_connection().execute(
+                "SELECT current_setting('temp_directory')"
+            ).fetchone()[0]
+        assert setting == str(Path("/tmp").absolute())
 
     def test_write_edgelist(self, tmp_path, edgelist_parquet_path):
         """Verify write edgelist.


### PR DESCRIPTION
## Summary

DuckDB defaults its `temp_directory` (disk-spill location) to a directory next to the database file. When a `.pxl` file lives on a networked filesystem (e.g. Fusion/S3), spill files are written there, and heavy queries fail to read them back — for example the crash seen in `single-cell-pna denoise` (`Could not read enough bytes from file "...duckdb_temp_storage_*.tmp"`). The existing `PIXELATOR_DUCKDB_TEMP_DIR` env var was only wired into `demux` and `combine-collapse`.

This PR makes every DuckDB connection respect a local spill directory.

- Add `pixelator.common.duckdb_utils` with env helpers (`get_duckdb_temp_dir_from_env`, `get_duckdb_max_temp_dir_size_from_env`, `resolve_duckdb_temp_dir`) and a `connect_duckdb()` wrapper that always sets `temp_directory` (resolving to `PIXELATOR_DUCKDB_TEMP_DIR`, then `/tmp`) and `max_temp_directory_size`.
- Route `init_duckdb_conn` through the new helper, so `demux`/`combine-collapse` also default to `/tmp` and honor the size env var.
- Convert all remaining bare `duckdb.connect(...)` call sites to honor the temp dir:
  - `PixelFileWriter` (fixes `denoise` and all other PXL writers); adds optional `temp_dir` / `temp_dir_size_limit` constructor args.
  - `InplacePixelDataFilterer.filter_components` (the spill path in `saver.save()` on the final output location).
  - PXL IO readers/viewer: `pxl_file.py`, `pixel_data_viewer.py`, `io/__init__.py` `copy_databases`.
  - Graph stage: `cycle_analysis.py`, `component_recovery_utils.py`, `community_detection.py`.
- Update the shared CLI `main.py` to use the common env helpers.

`get_single_thread_duckdb_config` is intentionally left as a bare `duckdb.connect()`: it only runs `SELECT current_setting('memory_limit')` (never spills) and is mock-patched by existing tests.

## Test plan

- [x] `ruff check` on all changed files
- [x] New tests: `PixelFileWriter` honors `PIXELATOR_DUCKDB_TEMP_DIR` and defaults to `/tmp`
- [x] Existing suites pass: `test_pixel_file_writer`, `test_duckdb_utils`, `test_community_detection`, `test_anndata`, `test_pixel_data_viewer`, `test_combine_collapse`, `test_component_recovery_pipeline`, `test_pna_pixeldataset`
- [ ] CI green

Made with [Cursor](https://cursor.com)