### PR TITLE
Fix cycle verification "worker stopped" warning 

### DIFF
--- a/src/pixelator/pna/graph/cycle_analysis.py
+++ b/src/pixelator/pna/graph/cycle_analysis.py
@@ -214,7 +214,7 @@ class ShortestPathFinder:
 
 def process_component(comp_name, edgelist_path, tmpdir):
     """Process a single component to remove edges not participating in cycles."""
-    with connect_duckdb() as con:
+    with connect_duckdb(config={"threads": "1"}) as con:
         con.execute(
             """
             CREATE TEMP TABLE comp_edgelist AS
@@ -352,7 +352,13 @@ def remove_no_cycle_edges(
             logger.info(
                 f"Processing {len(components)} components in parallel using {n_threads} threads."
             )
-            n_removed_edges_list = Parallel(n_jobs=n_threads)(
+            # Keep workers alive longer to avoid worker-restart warnings
+            # during long component processing batches.
+            n_removed_edges_list = Parallel(
+                n_jobs=n_threads,
+                backend="loky",
+                backend_kwargs={"timeout": 1800},
+            )(
                 delayed(process_component)(comp_name, input_edgelist_path, tmpdir)
                 for comp_name in components
             )


### PR DESCRIPTION
During edge cycle verification, we get a warning about workers being terminated. This warning is benign and we recover all components, but still we would like to understand and fix the issue.

Update: The issue of workers stopping is resolved by assigning a high timeout value in joblib 'Parallel' initialization. We have also limited the number of threads used in duckdb connections that are initiated by parallelized workers to 1. 


Fixes: PNA-2198

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tried on a few samples to verify that the warning disappears.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
