### PR TITLE
changes min_allowed_nodes_pct in adaptive_core_expansion to 0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- The default `min_allowed_nodes_pct` in `adaptive_core_expansion` has been changed from 0.8 to 0.9, meaning that a valid "high" core partition must include at least 90% of all nodes. Components that don't meet this criteria will not be denoised by ACE. 
+
 ## [0.29.0] - 2026-06-15
 
 ### Added

--- a/src/pixelator/pna/graph/adaptive_core_expansion.py
+++ b/src/pixelator/pna/graph/adaptive_core_expansion.py
@@ -257,7 +257,7 @@ def adaptive_core_expansion(
     max_iter: int = 200,
     min_seed_pct: float = 0.1,
     nodes_to_move_threshold: int = 10,
-    min_allowed_nodes_pct: float = 0.8,
+    min_allowed_nodes_pct: float = 0.9,
     select_lcc: bool = True,
 ) -> Graph:
     """Perform Adaptive Core Expansion (ACE) graph partitioning.

--- a/tests/pna/denoise/test_denoise.py
+++ b/tests/pna/denoise/test_denoise.py
@@ -513,7 +513,8 @@ def test_denoise_one_core_analysis(denoise_pxl_dataset, tmp_path):
 
 
 REFERENCE_ACE_COMPONENT = "57129a8b0fff38c6"
-REFERENCE_ACE_LOW_NODE_COUNT = 5436
+REFERENCE_ACE_COMPONENT_HIGH_QUALITY = "c4c3ef9497b3746d"
+REFERENCE_ACE_LOW_NODE_COUNT = 32
 
 
 def test_denoise_pls_reference_component_runs_and_cleans_coreness(denoise_pxl_dataset):
@@ -588,13 +589,14 @@ def test_denoise_ace_reference_component(denoise_pxl_dataset):
         denoise_pxl_dataset: Denoise pxl dataset.
     """
     comp_graph = PNAGraph.from_edgelist(
-        denoise_pxl_dataset.filter(components=[REFERENCE_ACE_COMPONENT])
+        denoise_pxl_dataset.filter(components=[REFERENCE_ACE_COMPONENT_HIGH_QUALITY])
         .edgelist()
         .to_polars()
         .lazy()
     )
     removed = denoise_ace(comp_graph)
     assert removed != [None]
+    a = len(removed)
     assert len(removed) == REFERENCE_ACE_LOW_NODE_COUNT
     partitions = nx.get_node_attributes(comp_graph.raw, "partition")
     low_ids = {n for n, p in partitions.items() if p == "low"}
@@ -625,7 +627,9 @@ def test_denoise_ace_analysis(denoise_pxl_dataset, tmp_path):
         == obs["number_of_nodes_removed_in_denoise"]
     ).all()
     assert int(
-        obs.loc[REFERENCE_ACE_COMPONENT, "denoised_nodes_marked_only_by_ace"]
+        obs.loc[
+            REFERENCE_ACE_COMPONENT_HIGH_QUALITY, "denoised_nodes_marked_only_by_ace"
+        ]
     ) == (REFERENCE_ACE_LOW_NODE_COUNT)
 
     assert (
@@ -633,13 +637,13 @@ def test_denoise_ace_analysis(denoise_pxl_dataset, tmp_path):
     )  # ACE-only denoising with LCC seed should not produce stranded nodes
 
     orig_graph = PNAGraph.from_edgelist(
-        denoise_pxl_dataset.filter(components=[REFERENCE_ACE_COMPONENT])
+        denoise_pxl_dataset.filter(components=[REFERENCE_ACE_COMPONENT_HIGH_QUALITY])
         .edgelist()
         .to_polars()
         .lazy()
     )
     denoised_graph = PNAGraph.from_edgelist(
-        denoised_dataset.filter(components=[REFERENCE_ACE_COMPONENT])
+        denoised_dataset.filter(components=[REFERENCE_ACE_COMPONENT_HIGH_QUALITY])
         .edgelist()
         .to_polars()
         .lazy()

--- a/tests/pna/denoise/test_denoise_cli.py
+++ b/tests/pna/denoise/test_denoise_cli.py
@@ -72,8 +72,7 @@ def test_denoise_ace_cli_runs_ok(denoise_pxl_file):
         result = read(out_pxl)
         obs = result.adata().obs
         assert (
-            int(obs.loc["57129a8b0fff38c6", "denoised_nodes_marked_only_by_ace"])
-            == 5436
+            int(obs.loc["c4c3ef9497b3746d", "denoised_nodes_marked_only_by_ace"]) == 32
         )
         summary_cols = [
             "denoised_nodes_marked_only_by_ace",


### PR DESCRIPTION
## Description

In samples with extremely low connectivity, ACE can be quite aggressive and remove >10% of UMIs. For PBMC samples, this is quite bad. 

This PR changes the default value for `min_allowed_nodes_pct` from 0.8 to 0.9 in `adaptive_core_expansion`. This means that we will not allow ACE to remove more than 10% of UMIs. On the downside, it will not select the best possible denoising solution. For e.g. MOLT4, we should expect higher noise levels with this change.

For the majority of experiments which are PBMC, it's probably better to be cautious and keep more data in the graphs.

Fixes: PNA-3083

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Updated tests in `tests/pna/denoise/test_denoise.py`

Note that I added a second component (`REFERENCE_ACE_COMPONENT_HIGH_QUALITY`) to make sure that we test ACE on a component that actually gets denoised. The previous component (`REFERENCE_ACE_COMPONENT` still used in other tests) didn't get denoised at all because ACE failed to find a partition where the "high" core layer was > 90% of nodes (according to our new `min_allowed_nodes_pct` threshold at 0.9).

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [x] I have checked my code and documentation and corrected any misspellings
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
