### PR TITLE
Add abundance/proximity similarity check functions for PNA sample pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `pixelator.pna.analysis.comparison.compare_sample_pairs` to check that pairs of PNA samples are similar in terms of abundance (mean marker CLR) and proximity (mean marker-pair proximity score) patterns, reporting the correlation between each pair.
+- `compare_sample_pairs_by_gate` to run the same comparison restricted to components matching a cell-type gate (e.g. `["+CD3e", "+CD4", "-CD19"]`), with positive/negative thresholds determined automatically from each marker's CLR distribution.
+- `pixelator.pna.analysis.gating.determine_marker_threshold` to determine a positive/negative CLR threshold for a marker, warning and skipping markers whose distribution appears unimodal.
+- `pixelator.pna.plot.plot_sample_pair_comparison` and `write_sample_pair_comparison_report` to plot and collect sample pair abundance/proximity comparisons into an HTML report.
+
 ### Changed
 - The default `min_allowed_nodes_pct` in `adaptive_core_expansion` has been changed from 0.8 to 0.9, meaning that a valid "high" core partition must include at least 90% of all nodes. Components that don't meet this criteria will not be denoised by ACE. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `pixelator.pna.analysis.comparison.compare_sample_pairs` to check that pairs of PNA samples are similar in terms of abundance (mean marker CLR) and proximity (mean marker-pair proximity score) patterns, reporting the correlation between each pair.
-- `compare_sample_pairs_by_gate` to run the same comparison restricted to components matching a cell-type gate (e.g. `["+CD3e", "+CD4", "-CD19"]`), with positive/negative thresholds determined automatically from each marker's CLR distribution.
+- `pixelator.pna.analysis.compare_sample_pairs_by_gate` to run the same comparison restricted to components matching a cell-type gate (e.g. `["+CD3e", "+CD4", "-CD19"]`), with positive/negative thresholds determined automatically from each marker's CLR distribution.
 - `pixelator.pna.analysis.gating.determine_marker_threshold` to determine a positive/negative CLR threshold for a marker, warning and skipping markers whose distribution appears unimodal.
 - `pixelator.pna.plot.plot_sample_pair_comparison` and `write_sample_pair_comparison_report` to plot and collect sample pair abundance/proximity comparisons into an HTML report.
 

--- a/src/pixelator/pna/analysis/__init__.py
+++ b/src/pixelator/pna/analysis/__init__.py
@@ -6,3 +6,10 @@ Copyright © 2024 Pixelgen Technologies AB.
 from pixelator.pna.analysis.proximity import calculate_differential_proximity
 
 __all__ = ["calculate_differential_proximity"]
+
+# Note: pixelator.pna.analysis.comparison is intentionally not imported here.
+# It depends on pixelator.pna.pixeldataset, which itself imports
+# pixelator.pna.analysis.analytical_proximity_query_helper during its own
+# initialization. Eagerly importing comparison here would create a circular
+# import. Import it directly, e.g. `from pixelator.pna.analysis.comparison
+# import compare_sample_pairs`.

--- a/src/pixelator/pna/analysis/comparison.py
+++ b/src/pixelator/pna/analysis/comparison.py
@@ -1,0 +1,414 @@
+"""Functions for comparing abundance and proximity similarity between sample pairs.
+
+Copyright © 2026 Pixelgen Technologies AB.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Sequence
+
+import pandas as pd
+
+from pixelator.common.utils import logger
+from pixelator.pna.analysis.gating import MarkerThreshold, gate_mask
+from pixelator.pna.pixeldataset import PNAPixelDataset, read
+
+
+@dataclass
+class SamplePairComparisonResult:
+    """The result of comparing abundance and proximity similarity between a pair of samples.
+
+    Attributes:
+        sample1_name: The name of the first sample.
+        sample2_name: The name of the second sample.
+        abundance: A DataFrame with one row per marker, containing the mean CLR
+            value of that marker in each of the two samples.
+        abundance_correlation: The Pearson correlation between the two samples'
+            mean marker CLR values.
+        proximity: A DataFrame with one row per marker pair, containing the mean
+            proximity log2 ratio and number of contributing components for each
+            of the two samples.
+        proximity_correlation: The Pearson correlation between the two samples'
+            mean proximity log2 ratios.
+        gate: The cell-type gate applied to both samples before comparison, if
+            any, e.g. ``["+CD3e", "+CD4", "-CD19"]``.
+
+    """
+
+    sample1_name: str
+    sample2_name: str
+    abundance: pd.DataFrame
+    abundance_correlation: float
+    proximity: pd.DataFrame
+    proximity_correlation: float
+    gate: list[str] | None = field(default=None)
+
+
+def _load_dataset(pxl) -> PNAPixelDataset:
+    """Load a PNAPixelDataset from a pxl file path (or pass one through unchanged)."""
+    if isinstance(pxl, PNAPixelDataset):
+        return pxl
+    return read(pxl)
+
+
+def _resolve_sample_name(dataset: PNAPixelDataset, provided_name: str | None) -> str:
+    if provided_name is not None:
+        return provided_name
+
+    sample_names = dataset.sample_names()
+    if len(sample_names) != 1:
+        raise ValueError(
+            "Could not infer a unique sample name from the dataset "
+            f"(found {sorted(sample_names)}). Please provide a sample name explicitly."
+        )
+    return next(iter(sample_names))
+
+
+def _summarize_abundance(clr: pd.DataFrame, markers: set[str]) -> pd.Series:
+    return clr[sorted(markers)].mean(axis=0)
+
+
+def _summarize_proximity(
+    proximity_df: pd.DataFrame,
+    min_expected_join_count: int,
+    min_n_cells: int,
+) -> pd.DataFrame:
+    """Summarize the proximity data by marker pairs.
+
+    Filters out marker pairs with a low expected join count, and only keeps
+    marker pairs supported by at least ``min_n_cells`` components.
+    """
+    filtered = proximity_df[
+        proximity_df["join_count_expected_mean"] > min_expected_join_count
+    ]
+
+    summary = filtered.groupby(["marker_1", "marker_2"]).agg(
+        mean_log2_ratio=("log2_ratio", "mean"), n_cells=("log2_ratio", "size")
+    )
+    summary = summary[summary["n_cells"] > min_n_cells].reset_index()
+    return summary
+
+
+def _expressed_markers(
+    clr1: pd.DataFrame,
+    clr2: pd.DataFrame,
+    candidate_markers: set[str],
+    min_mean_clr: float,
+) -> set[str]:
+    markers_1 = {m for m in candidate_markers if clr1[m].mean() > min_mean_clr}
+    markers_2 = {m for m in candidate_markers if clr2[m].mean() > min_mean_clr}
+    return markers_1 & markers_2
+
+
+def compare_sample_pair(
+    pxl1,
+    pxl2,
+    sample1_name: str | None = None,
+    sample2_name: str | None = None,
+    markers: set[str] | None = None,
+    min_mean_clr: float = 1.5,
+    min_expected_join_count: int = 10,
+    min_n_cells: int = 50,
+) -> SamplePairComparisonResult:
+    """Compare abundance and proximity similarity between a single pair of samples.
+
+    Markers are first restricted to those expressed (mean CLR above
+    ``min_mean_clr``) in both samples. Mean marker CLR values (abundance) and
+    mean marker-pair proximity log2 ratios are then compared between the two
+    samples, and the Pearson correlation is computed for each.
+
+    Args:
+        pxl1: The first sample, given as a `PNAPixelDataset`, a path to a
+            ``.pxl`` file, or anything accepted by `pixelator.pna.read`.
+        pxl2: The second sample, in the same forms as ``pxl1``.
+        sample1_name: A name for the first sample, used for labeling the
+            output. If not provided, it is inferred from the dataset.
+        sample2_name: A name for the second sample, used for labeling the
+            output. If not provided, it is inferred from the dataset.
+        markers: If provided, restrict the comparison to this set of markers
+            (still subject to the ``min_mean_clr`` filter). Defaults to all
+            markers shared by the two datasets.
+        min_mean_clr: The minimum mean CLR value (in both samples) for a
+            marker to be included in the comparison. Defaults to 1.5.
+        min_expected_join_count: The minimum expected join count for a marker
+            pair to be included in the proximity comparison. Defaults to 10.
+        min_n_cells: The minimum number of components required for a marker
+            pair to be included in the proximity comparison. Defaults to 50.
+
+    Returns:
+        A `SamplePairComparisonResult` with the abundance and proximity
+        comparison data and their correlations.
+
+    """
+    dataset1 = _load_dataset(pxl1)
+    dataset2 = _load_dataset(pxl2)
+
+    sample1_name = _resolve_sample_name(dataset1, sample1_name)
+    sample2_name = _resolve_sample_name(dataset2, sample2_name)
+
+    if sample1_name == sample2_name:
+        raise ValueError(
+            "sample1_name and sample2_name must be different, got "
+            f"'{sample1_name}' for both samples. Pass explicit, distinct names."
+        )
+
+    clr1 = dataset1.adata().obsm["clr"]
+    clr2 = dataset2.adata().obsm["clr"]
+
+    candidate_markers = (
+        markers if markers is not None else set(clr1.columns) & set(clr2.columns)
+    )
+    expressed_markers = _expressed_markers(clr1, clr2, candidate_markers, min_mean_clr)
+
+    if not expressed_markers:
+        raise ValueError(
+            "No markers passed the min_mean_clr filter in both samples. "
+            "Try lowering min_mean_clr."
+        )
+
+    abundance_1 = _summarize_abundance(clr1, expressed_markers)
+    abundance_2 = _summarize_abundance(clr2, expressed_markers)
+    abundance = pd.DataFrame(
+        {
+            "marker": sorted(expressed_markers),
+            f"mean_clr_{sample1_name}": abundance_1.loc[
+                sorted(expressed_markers)
+            ].values,
+            f"mean_clr_{sample2_name}": abundance_2.loc[
+                sorted(expressed_markers)
+            ].values,
+        }
+    )
+    abundance_correlation = float(
+        abundance[f"mean_clr_{sample1_name}"].corr(
+            abundance[f"mean_clr_{sample2_name}"]
+        )
+    )
+
+    proximity_1 = dataset1.filter(markers=expressed_markers).proximity().to_df()
+    proximity_2 = dataset2.filter(markers=expressed_markers).proximity().to_df()
+
+    summary_1 = _summarize_proximity(
+        proximity_1, min_expected_join_count, min_n_cells
+    ).rename(
+        columns={
+            "mean_log2_ratio": f"log2_ratio_{sample1_name}",
+            "n_cells": f"n_cells_{sample1_name}",
+        }
+    )
+    summary_2 = _summarize_proximity(
+        proximity_2, min_expected_join_count, min_n_cells
+    ).rename(
+        columns={
+            "mean_log2_ratio": f"log2_ratio_{sample2_name}",
+            "n_cells": f"n_cells_{sample2_name}",
+        }
+    )
+
+    proximity = summary_1.merge(summary_2, on=["marker_1", "marker_2"], how="inner")
+
+    if proximity.empty:
+        raise ValueError(
+            "No marker pairs passed the proximity filtering criteria in both "
+            "samples. Try lowering min_expected_join_count or min_n_cells."
+        )
+
+    proximity_correlation = float(
+        proximity[f"log2_ratio_{sample1_name}"].corr(
+            proximity[f"log2_ratio_{sample2_name}"]
+        )
+    )
+
+    return SamplePairComparisonResult(
+        sample1_name=sample1_name,
+        sample2_name=sample2_name,
+        abundance=abundance,
+        abundance_correlation=abundance_correlation,
+        proximity=proximity,
+        proximity_correlation=proximity_correlation,
+    )
+
+
+def compare_sample_pairs(
+    pairs: Sequence[tuple],
+    sample_names: Sequence[tuple[str, str]] | None = None,
+    markers: set[str] | None = None,
+    min_mean_clr: float = 1.5,
+    min_expected_join_count: int = 10,
+    min_n_cells: int = 50,
+) -> list[SamplePairComparisonResult]:
+    """Compare abundance and proximity similarity across a list of sample pairs.
+
+    This is the main entry point for checking that pairs of samples are
+    similar in terms of abundance and proximity patterns. For each pair, mean
+    marker abundances (CLR) and mean marker-pair proximity scores are compared,
+    and their correlations are reported. See `compare_sample_pair` for details
+    on how a single pair is compared.
+
+    Args:
+        pairs: A list of ``(pxl1, pxl2)`` pairs, where each element is a
+            `PNAPixelDataset`, a path to a ``.pxl`` file, or anything accepted
+            by `pixelator.pna.read`.
+        sample_names: An optional list of ``(sample1_name, sample2_name)``
+            tuples, parallel to ``pairs``, used for labeling the output. If
+            not provided, sample names are inferred from each dataset.
+        markers: If provided, restrict the comparison to this set of markers
+            for all pairs (still subject to the ``min_mean_clr`` filter).
+        min_mean_clr: The minimum mean CLR value (in both samples) for a
+            marker to be included in the comparison. Defaults to 1.5.
+        min_expected_join_count: The minimum expected join count for a marker
+            pair to be included in the proximity comparison. Defaults to 10.
+        min_n_cells: The minimum number of components required for a marker
+            pair to be included in the proximity comparison. Defaults to 50.
+
+    Returns:
+        A list of `SamplePairComparisonResult`, one per pair in ``pairs``.
+
+    """
+    if sample_names is not None and len(sample_names) != len(pairs):
+        raise ValueError("sample_names must have the same length as pairs.")
+
+    results = []
+    for i, (pxl1, pxl2) in enumerate(pairs):
+        sample1_name, sample2_name = sample_names[i] if sample_names else (None, None)
+        logger.info("Comparing sample pair %d/%d", i + 1, len(pairs))
+        results.append(
+            compare_sample_pair(
+                pxl1,
+                pxl2,
+                sample1_name=sample1_name,
+                sample2_name=sample2_name,
+                markers=markers,
+                min_mean_clr=min_mean_clr,
+                min_expected_join_count=min_expected_join_count,
+                min_n_cells=min_n_cells,
+            )
+        )
+    return results
+
+
+def compare_sample_pairs_by_gate(
+    pairs: Sequence[tuple],
+    gate: list[str],
+    sample_names: Sequence[tuple[str, str]] | None = None,
+    min_separation_score: float = 3.0,
+    markers: set[str] | None = None,
+    min_mean_clr: float = 1.5,
+    min_expected_join_count: int = 10,
+    min_n_cells: int = 50,
+) -> list[SamplePairComparisonResult]:
+    """Compare abundance and proximity similarity across sample pairs, restricted to a cell-type gate.
+
+    Since components in a `PNAPixelDataset` don't have cell types assigned,
+    this wrapper first filters each pair of samples to the components matching
+    a gating specification, e.g. ``["+CD3e", "+CD4", "-CD19"]``, before running
+    the same comparison as `compare_sample_pairs`.
+
+    For each pair, the positive/negative threshold for every marker in
+    ``gate`` is determined from the pooled CLR distribution of both samples in
+    that pair (so that both samples are gated using the exact same threshold).
+    If a marker's distribution appears unimodal, a warning is issued and that
+    marker is ignored when gating (see `pixelator.pna.analysis.gating.determine_marker_threshold`).
+
+    Args:
+        pairs: A list of ``(pxl1, pxl2)`` pairs, where each element is a
+            `PNAPixelDataset`, a path to a ``.pxl`` file, or anything accepted
+            by `pixelator.pna.read`.
+        gate: A list of gating strings, e.g. ``["+CD3e", "+CD4", "-CD19"]``.
+        sample_names: An optional list of ``(sample1_name, sample2_name)``
+            tuples, parallel to ``pairs``, used for labeling the output.
+        min_separation_score: The minimum separation score required for a
+            gating marker's distribution to be considered bimodal. Defaults to 3.0.
+        markers: If provided, restrict the abundance/proximity comparison to
+            this set of markers for all pairs.
+        min_mean_clr: The minimum mean CLR value (in both samples) for a
+            marker to be included in the comparison. Defaults to 1.5.
+        min_expected_join_count: The minimum expected join count for a marker
+            pair to be included in the proximity comparison. Defaults to 10.
+        min_n_cells: The minimum number of components required for a marker
+            pair to be included in the proximity comparison. Defaults to 50.
+
+    Returns:
+        A list of `SamplePairComparisonResult`, one per pair in ``pairs``, each
+        annotated with the ``gate`` that was applied.
+
+    """
+    if sample_names is not None and len(sample_names) != len(pairs):
+        raise ValueError("sample_names must have the same length as pairs.")
+
+    results = []
+    for i, (pxl1, pxl2) in enumerate(pairs):
+        sample1_name, sample2_name = sample_names[i] if sample_names else (None, None)
+
+        dataset1 = _load_dataset(pxl1)
+        dataset2 = _load_dataset(pxl2)
+
+        sample1_name = _resolve_sample_name(dataset1, sample1_name)
+        sample2_name = _resolve_sample_name(dataset2, sample2_name)
+
+        clr1 = dataset1.adata().obsm["clr"]
+        clr2 = dataset2.adata().obsm["clr"]
+
+        pooled_clr = pd.concat([clr1, clr2], axis=0)
+        pooled_mask, thresholds = gate_mask(
+            pooled_clr, gate, min_separation_score=min_separation_score
+        )
+        _log_gate_thresholds(thresholds, sample1_name, sample2_name)
+
+        mask1 = pooled_mask.loc[clr1.index]
+        mask2 = pooled_mask.loc[clr2.index]
+
+        if not mask1.any():
+            raise ValueError(
+                f"No components in sample '{sample1_name}' pass the gate {gate}."
+            )
+        if not mask2.any():
+            raise ValueError(
+                f"No components in sample '{sample2_name}' pass the gate {gate}."
+            )
+
+        gated_dataset1 = dataset1.filter(components=mask1[mask1].index)
+        gated_dataset2 = dataset2.filter(components=mask2[mask2].index)
+
+        logger.info(
+            "Gated sample pair %d/%d (%s vs %s): %d vs %d components pass the gate %s",
+            i + 1,
+            len(pairs),
+            sample1_name,
+            sample2_name,
+            int(mask1.sum()),
+            int(mask2.sum()),
+            gate,
+        )
+
+        result = compare_sample_pair(
+            gated_dataset1,
+            gated_dataset2,
+            sample1_name=sample1_name,
+            sample2_name=sample2_name,
+            markers=markers,
+            min_mean_clr=min_mean_clr,
+            min_expected_join_count=min_expected_join_count,
+            min_n_cells=min_n_cells,
+        )
+        result.gate = list(gate)
+        results.append(result)
+
+    return results
+
+
+def _log_gate_thresholds(
+    thresholds: list[MarkerThreshold], sample1_name: str, sample2_name: str
+) -> None:
+    for t in thresholds:
+        if t.threshold is not None:
+            logger.debug(
+                "Gate threshold for marker '%s' (pooled %s/%s): %.3f "
+                "(separation score %.3f)",
+                t.marker,
+                sample1_name,
+                sample2_name,
+                t.threshold,
+                t.separation_score,
+            )

--- a/src/pixelator/pna/analysis/comparison.py
+++ b/src/pixelator/pna/analysis/comparison.py
@@ -189,7 +189,7 @@ def compare_sample_pair(
     if pd.isna(abundance_correlation):
         raise ValueError(
             "Abundance correlation is undefined. "
-            "(need >=2 expressed markers with non-constant values)."
+            "(need >=2 markers with non-constant values)."
         )
 
     proximity_1 = dataset1.filter(markers=expressed_markers).proximity().to_df()

--- a/src/pixelator/pna/analysis/comparison.py
+++ b/src/pixelator/pna/analysis/comparison.py
@@ -80,13 +80,13 @@ def _summarize_proximity(
     marker pairs supported by at least ``min_n_cells`` components.
     """
     filtered = proximity_df[
-        proximity_df["join_count_expected_mean"] > min_expected_join_count
+        proximity_df["join_count_expected_mean"] >= min_expected_join_count
     ]
 
     summary = filtered.groupby(["marker_1", "marker_2"]).agg(
         mean_log2_ratio=("log2_ratio", "mean"), n_cells=("log2_ratio", "size")
     )
-    summary = summary[summary["n_cells"] > min_n_cells].reset_index()
+    summary = summary[summary["n_cells"] >= min_n_cells].reset_index()
     return summary
 
 
@@ -159,6 +159,7 @@ def compare_sample_pair(
     candidate_markers = (
         markers if markers is not None else set(clr1.columns) & set(clr2.columns)
     )
+
     expressed_markers = _expressed_markers(clr1, clr2, candidate_markers, min_mean_clr)
 
     if not expressed_markers:
@@ -167,16 +168,16 @@ def compare_sample_pair(
             "Try lowering min_mean_clr."
         )
 
-    abundance_1 = _summarize_abundance(clr1, expressed_markers)
-    abundance_2 = _summarize_abundance(clr2, expressed_markers)
+    abundance_1 = _summarize_abundance(clr1, candidate_markers)
+    abundance_2 = _summarize_abundance(clr2, candidate_markers)
     abundance = pd.DataFrame(
         {
-            "marker": sorted(expressed_markers),
+            "marker": sorted(candidate_markers),
             f"mean_clr_{sample1_name}": abundance_1.loc[
-                sorted(expressed_markers)
+                sorted(candidate_markers)
             ].values,
             f"mean_clr_{sample2_name}": abundance_2.loc[
-                sorted(expressed_markers)
+                sorted(candidate_markers)
             ].values,
         }
     )
@@ -185,6 +186,11 @@ def compare_sample_pair(
             abundance[f"mean_clr_{sample2_name}"]
         )
     )
+    if pd.isna(abundance_correlation):
+        raise ValueError(
+            "Abundance correlation is undefined. "
+            "(need >=2 expressed markers with non-constant values)."
+        )
 
     proximity_1 = dataset1.filter(markers=expressed_markers).proximity().to_df()
     proximity_2 = dataset2.filter(markers=expressed_markers).proximity().to_df()
@@ -219,6 +225,12 @@ def compare_sample_pair(
             proximity[f"log2_ratio_{sample2_name}"]
         )
     )
+    if pd.isna(proximity_correlation):
+        raise ValueError(
+            "Proximity correlation is undefined. "
+            "(need >=2 marker pairs with non-constant values). "
+            "Try lowering min_expected_join_count or min_n_cells."
+        )
 
     return SamplePairComparisonResult(
         sample1_name=sample1_name,

--- a/src/pixelator/pna/analysis/comparison.py
+++ b/src/pixelator/pna/analysis/comparison.py
@@ -113,10 +113,10 @@ def compare_sample_pair(
 ) -> SamplePairComparisonResult:
     """Compare abundance and proximity similarity between a single pair of samples.
 
-    Markers are first restricted to those expressed (mean CLR above
-    ``min_mean_clr``) in both samples. Mean marker CLR values (abundance) and
-    mean marker-pair proximity log2 ratios are then compared between the two
-    samples, and the Pearson correlation is computed for each.
+    Mean marker CLR values (abundance) and mean marker-pair proximity log2 ratios
+    are compared between the two samples, and the Pearson correlation is computed
+    for each. For proximity scores, markers are first restricted to those expressed
+    (mean CLR above ``min_mean_clr``) in both samples.
 
     Args:
         pxl1: The first sample, given as a `PNAPixelDataset`, a path to a

--- a/src/pixelator/pna/analysis/gating.py
+++ b/src/pixelator/pna/analysis/gating.py
@@ -82,7 +82,7 @@ def determine_marker_threshold(
     (rather than 0), since the two components end up splitting the single
     mode. The default cutoff of 3.0 was chosen empirically to reliably
     separate unimodal distributions from clearly bimodal ones (separated by
-    several standard deviations); consider tuning it for your own data.
+    several standard deviations).
 
     Args:
         values: The CLR values (across components) for a single marker.

--- a/src/pixelator/pna/analysis/gating.py
+++ b/src/pixelator/pna/analysis/gating.py
@@ -1,0 +1,179 @@
+"""Functions for gating components based on marker abundance (CLR) distributions.
+
+Copyright © 2026 Pixelgen Technologies AB.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+from sklearn.mixture import GaussianMixture
+
+from pixelator.common.utils import logger
+
+_GATE_REGEX = re.compile(r"^(?P<sign>[+-])(?P<marker>.+)$")
+
+
+@dataclass
+class MarkerThreshold:
+    """The result of determining a positive/negative threshold for a marker.
+
+    Attributes:
+        marker: The name of the marker.
+        threshold: The CLR value used to call a component positive for the marker.
+            ``None`` if the distribution was found to be unimodal and no
+            threshold could reliably be determined.
+        separation_score: A measure of how well separated the two components
+            of the fitted Gaussian mixture model are. Higher values indicate
+            a more clearly bimodal distribution.
+
+    """
+
+    marker: str
+    threshold: float | None
+    separation_score: float
+
+
+def parse_gate(gate: list[str]) -> list[tuple[str, str]]:
+    """Parse a gating specification into a list of (marker, sign) tuples.
+
+    Args:
+        gate: A list of gating strings, e.g. ``["+CD3e", "+CD4", "-CD19"]``. Each
+            entry must start with ``+`` (positive) or ``-`` (negative) followed
+            by a marker name.
+
+    Returns:
+        A list of ``(marker, sign)`` tuples, e.g. ``[("CD3e", "+"), ("CD4", "+"), ("CD19", "-")]``.
+
+    Raises:
+        ValueError: If any entry in ``gate`` is not prefixed with ``+`` or ``-``.
+
+    """
+    parsed = []
+    for entry in gate:
+        match = _GATE_REGEX.match(entry)
+        if not match:
+            raise ValueError(
+                f"Invalid gate specification: '{entry}'. Expected a marker name "
+                "prefixed with '+' (positive) or '-' (negative), e.g. '+CD3e'."
+            )
+        parsed.append((match.group("marker"), match.group("sign")))
+    return parsed
+
+
+def determine_marker_threshold(
+    values: pd.Series | np.ndarray,
+    min_separation_score: float = 3.0,
+    marker: str = "",
+) -> MarkerThreshold:
+    """Determine a positive/negative threshold for a marker from its CLR distribution.
+
+    A 2-component Gaussian mixture model is fit to the values, and the threshold
+    is set to the midpoint between the two component means. The separation
+    between the components is quantified as ``|mean_1 - mean_0| / (var_0 + var_1)``.
+    If this separation score is below ``min_separation_score``, the distribution
+    is considered unimodal, a warning is issued, and no threshold is returned.
+
+    Note that fitting a 2-component mixture to a genuinely unimodal
+    distribution still tends to produce a separation score around 1-3
+    (rather than 0), since the two components end up splitting the single
+    mode. The default cutoff of 3.0 was chosen empirically to reliably
+    separate unimodal distributions from clearly bimodal ones (separated by
+    several standard deviations); consider tuning it for your own data.
+
+    Args:
+        values: The CLR values (across components) for a single marker.
+        min_separation_score: The minimum separation score required for the
+            distribution to be considered bimodal. Defaults to 3.0.
+        marker: The name of the marker, used only for the warning message.
+
+    Returns:
+        A `MarkerThreshold` instance with the determined threshold (or ``None``
+        if the distribution is unimodal) and the separation score.
+
+    """
+    values_arr = np.asarray(values, dtype=float).reshape(-1, 1)
+
+    gmm = GaussianMixture(n_components=2, max_iter=1000, random_state=0)
+    gmm.fit(values_arr)
+
+    means = gmm.means_.flatten()
+    variances = gmm.covariances_.flatten()
+    order = np.argsort(means)
+    means = means[order]
+    variances = variances[order]
+
+    separation_score = float(np.abs(means[1] - means[0]) / np.sum(variances))
+
+    if separation_score < min_separation_score:
+        logger.warning(
+            "Marker '%s' has a unimodal CLR distribution (separation score "
+            "%.3f < %.3f). It will be ignored for gating.",
+            marker,
+            separation_score,
+            min_separation_score,
+        )
+        return MarkerThreshold(
+            marker=marker, threshold=None, separation_score=separation_score
+        )
+
+    threshold = float(np.mean(means))
+    return MarkerThreshold(
+        marker=marker, threshold=threshold, separation_score=separation_score
+    )
+
+
+def gate_mask(
+    clr: pd.DataFrame,
+    gate: list[str],
+    min_separation_score: float = 3.0,
+) -> tuple[pd.Series, list[MarkerThreshold]]:
+    """Compute a boolean mask of components passing a gating specification.
+
+    For each marker in the gate, a positive/negative threshold is determined
+    from its CLR distribution in ``clr`` (see `determine_marker_threshold`).
+    Markers whose distribution is unimodal are ignored (i.e. they do not
+    constrain the mask).
+
+    Args:
+        clr: A DataFrame of CLR values with components as rows and markers as
+            columns.
+        gate: A list of gating strings, e.g. ``["+CD3e", "+CD4", "-CD19"]``.
+        min_separation_score: The minimum separation score required for a
+            marker's distribution to be considered bimodal. Defaults to 3.0.
+
+    Returns:
+        A tuple of:
+            - A boolean `pd.Series` (indexed like ``clr``) that is ``True`` for
+              components passing all (non-ignored) gating criteria.
+            - A list of `MarkerThreshold` instances, one per marker in ``gate``.
+
+    Raises:
+        KeyError: If a marker in ``gate`` is not a column of ``clr``.
+
+    """
+    parsed_gate = parse_gate(gate)
+
+    mask = pd.Series(True, index=clr.index)
+    thresholds = []
+    for marker, sign in parsed_gate:
+        if marker not in clr.columns:
+            raise KeyError(f"Marker '{marker}' not found in the CLR data.")
+
+        marker_threshold = determine_marker_threshold(
+            clr[marker], min_separation_score=min_separation_score, marker=marker
+        )
+        thresholds.append(marker_threshold)
+
+        if marker_threshold.threshold is None:
+            continue
+
+        if sign == "+":
+            mask &= clr[marker] >= marker_threshold.threshold
+        else:
+            mask &= clr[marker] < marker_threshold.threshold
+
+    return mask, thresholds

--- a/src/pixelator/pna/plot/__init__.py
+++ b/src/pixelator/pna/plot/__init__.py
@@ -9,6 +9,17 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
 
+from pixelator.pna.plot.comparison import (
+    plot_sample_pair_comparison,
+    write_sample_pair_comparison_report,
+)
+
+__all__ = [
+    "molecule_rank_plot",
+    "plot_sample_pair_comparison",
+    "write_sample_pair_comparison_report",
+]
+
 
 def molecule_rank_plot(
     data: pd.DataFrame, group_by: Optional[str] = None

--- a/src/pixelator/pna/plot/comparison.py
+++ b/src/pixelator/pna/plot/comparison.py
@@ -1,0 +1,180 @@
+"""Plots and HTML reports for comparing abundance/proximity similarity between sample pairs.
+
+Copyright © 2026 Pixelgen Technologies AB.
+"""
+
+from __future__ import annotations
+
+import base64
+from html import escape
+from io import BytesIO
+from pathlib import Path
+from typing import Sequence
+
+import matplotlib.pyplot as plt
+import seaborn as sns
+from matplotlib.figure import Figure
+
+from pixelator.pna.analysis.comparison import SamplePairComparisonResult
+
+
+def _plot_similarity_scatter(ax, data, x, y, correlation, xlabel, ylabel, title):
+    sns.scatterplot(data=data, x=x, y=y, alpha=0.7, ax=ax)
+
+    lo = min(data[x].min(), data[y].min())
+    hi = max(data[x].max(), data[y].max())
+    ax.plot([lo, hi], [lo, hi], color="red", linestyle="--", label="y = x")
+
+    ax.text(
+        0.05,
+        0.95,
+        f"Correlation: {correlation:.2f}",
+        transform=ax.transAxes,
+        fontsize=12,
+        verticalalignment="top",
+    )
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)
+    ax.set_title(title)
+    ax.legend()
+
+
+def plot_sample_pair_comparison(
+    result: SamplePairComparisonResult,
+) -> tuple[Figure, tuple[plt.Axes, plt.Axes]]:
+    """Plot the abundance and proximity comparison for a sample pair.
+
+    Produces a figure with two scatter plots, both expected to be concentrated
+    around the ``y = x`` line if the two samples are similar:
+
+    - Abundance: mean marker CLR value in sample 1 vs. sample 2.
+    - Proximity: mean marker-pair proximity log2 ratio in sample 1 vs. sample 2.
+
+    The Pearson correlation is annotated on each subplot.
+
+    Args:
+        result: A `SamplePairComparisonResult`, as returned by
+            `pixelator.pna.analysis.comparison.compare_sample_pair`.
+
+    Returns:
+        A tuple of the created `matplotlib.figure.Figure` and its two `Axes`
+        (abundance, proximity).
+
+    """
+    sample1_name = result.sample1_name
+    sample2_name = result.sample2_name
+
+    fig, (ax_abundance, ax_proximity) = plt.subplots(1, 2, figsize=(14, 6))
+
+    _plot_similarity_scatter(
+        ax_abundance,
+        result.abundance,
+        x=f"mean_clr_{sample1_name}",
+        y=f"mean_clr_{sample2_name}",
+        correlation=result.abundance_correlation,
+        xlabel=f"Mean marker CLR ({sample1_name})",
+        ylabel=f"Mean marker CLR ({sample2_name})",
+        title="Abundance",
+    )
+    _plot_similarity_scatter(
+        ax_proximity,
+        result.proximity,
+        x=f"log2_ratio_{sample1_name}",
+        y=f"log2_ratio_{sample2_name}",
+        correlation=result.proximity_correlation,
+        xlabel=f"Mean proximity log2 ratio ({sample1_name})",
+        ylabel=f"Mean proximity log2 ratio ({sample2_name})",
+        title="Proximity",
+    )
+
+    title = f"{sample1_name} vs {sample2_name}"
+    if result.gate:
+        title += f" (gate: {', '.join(result.gate)})"
+    fig.suptitle(title)
+    fig.tight_layout()
+
+    return fig, (ax_abundance, ax_proximity)
+
+
+def _figure_to_base64_png(fig: Figure) -> str:
+    buffer = BytesIO()
+    fig.savefig(buffer, format="png", bbox_inches="tight")
+    buffer.seek(0)
+    return base64.b64encode(buffer.read()).decode("ascii")
+
+
+def write_sample_pair_comparison_report(
+    results: Sequence[SamplePairComparisonResult],
+    output_path: Path | str,
+    title: str = "Sample pair abundance/proximity similarity report",
+) -> Path:
+    """Collect abundance/proximity comparisons for a set of sample pairs into an HTML report.
+
+    For each `SamplePairComparisonResult` in ``results``, this creates the
+    abundance/proximity comparison figure (see `plot_sample_pair_comparison`)
+    and embeds it, together with the sample names, correlations, and gate (if
+    any), into a single self-contained HTML file.
+
+    Args:
+        results: The comparison results to include in the report, e.g. as
+            returned by `pixelator.pna.analysis.comparison.compare_sample_pairs`
+            or `pixelator.pna.analysis.comparison.compare_sample_pairs_by_gate`.
+        output_path: The path to write the HTML report to.
+        title: The title of the report. Defaults to
+            "Sample pair abundance/proximity similarity report".
+
+    Returns:
+        The path to the written HTML report.
+
+    """
+    output_path = Path(output_path)
+
+    sections = []
+    for result in results:
+        fig, _ = plot_sample_pair_comparison(result)
+        encoded_png = _figure_to_base64_png(fig)
+        plt.close(fig)
+
+        sample1_name = escape(result.sample1_name)
+        sample2_name = escape(result.sample2_name)
+
+        gate_html = (
+            f"<p><strong>Gate:</strong> {escape(', '.join(result.gate))}</p>"
+            if result.gate
+            else ""
+        )
+        sections.append(f"""
+        <section>
+            <h2>{sample1_name} vs {sample2_name}</h2>
+            {gate_html}
+            <p>
+                <strong>Abundance correlation:</strong> {result.abundance_correlation:.3f}
+                &nbsp;|&nbsp;
+                <strong>Proximity correlation:</strong> {result.proximity_correlation:.3f}
+            </p>
+            <img src="data:image/png;base64,{encoded_png}"
+                 alt="Abundance/proximity comparison for {sample1_name} vs {sample2_name}" />
+        </section>
+        """)
+
+    escaped_title = escape(title)
+    html = f"""<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>{escaped_title}</title>
+<style>
+    body {{ font-family: sans-serif; margin: 2rem; }}
+    section {{ margin-bottom: 3rem; border-bottom: 1px solid #ccc; padding-bottom: 2rem; }}
+    img {{ max-width: 100%; height: auto; }}
+</style>
+</head>
+<body>
+<h1>{escaped_title}</h1>
+{"".join(sections)}
+</body>
+</html>
+"""
+
+    output_path.write_text(html)
+    return output_path

--- a/tests/pna/analysis/test_comparison.py
+++ b/tests/pna/analysis/test_comparison.py
@@ -1,0 +1,252 @@
+"""Tests for the pna sample pair comparison module.
+
+Copyright © 2026 Pixelgen Technologies AB.
+"""
+
+from io import StringIO
+
+import pandas as pd
+import polars as pl
+import pytest
+
+from pixelator.pna.analysis.comparison import (
+    SamplePairComparisonResult,
+    compare_sample_pair,
+    compare_sample_pairs,
+    compare_sample_pairs_by_gate,
+)
+from pixelator.pna.pixeldataset import PNAPixelDataset
+from tests.pna.conftest import create_pxl_file
+from tests.pna.data.pxl_data import EDGELIST_DATA, PROXIMITY_DATA
+
+# The component ids used by the shared EDGELIST_DATA/PROXIMITY_DATA fixtures,
+# remapped to a distinct set of ids so a second, independent sample can be
+# built from otherwise identical data (real samples never share component ids).
+_SAMPLE2_ID_MAP = {
+    "fc07dea9b679aca7": "fc07dea9b679acb8",
+    "e7d82bca9694eea7": "e7d82bca9694eeb8",
+    "4920229146151c29": "4920229146151c38",
+    "3770519d30f36d18": "3770519d30f36d28",
+}
+
+_EDGELIST_SCHEMA = {
+    "umi1": pl.UInt64,
+    "umi2": pl.UInt64,
+    "read_count": pl.UInt32,
+    "uei_count": pl.UInt32,
+    "marker_1": pl.Utf8,
+    "marker_2": pl.Utf8,
+    "component": pl.Utf8,
+}
+
+
+def _remap_component_ids(csv_text: str) -> str:
+    for old, new in _SAMPLE2_ID_MAP.items():
+        csv_text = csv_text.replace(old, new)
+    return csv_text
+
+
+@pytest.fixture(name="pxl_file_2", scope="module")
+def pxl_file_2_fixture(tmp_path_factory, panel):
+    """A second, independent pxl file with the same panel/marker structure as `pxl_file`."""
+    edgelist_df = pl.read_csv(
+        StringIO(_remap_component_ids(EDGELIST_DATA)), schema=_EDGELIST_SCHEMA
+    )
+    proximity_df = pl.read_csv(StringIO(_remap_component_ids(PROXIMITY_DATA)))
+
+    tmp_dir = tmp_path_factory.mktemp("data2")
+    edgelist_path = tmp_dir / "edgelist2.parquet"
+    proximity_path = tmp_dir / "proximity2.parquet"
+    edgelist_df.write_parquet(edgelist_path)
+    proximity_df.write_parquet(proximity_path)
+
+    target = tmp_dir / "file2.pxl"
+    return create_pxl_file(
+        target=target,
+        sample_name="test_sample_2",
+        edgelist_parquet_path=edgelist_path,
+        proximity_parquet_path=proximity_path,
+        layout_parquet_path=None,
+        panel=panel,
+    )
+
+
+@pytest.fixture(name="pxl_dataset_2")
+def pxl_dataset_2_fixture(pxl_file_2):
+    """A `PNAPixelDataset` for the second sample."""
+    return PNAPixelDataset.from_pxl_files(pxl_file_2)
+
+
+@pytest.fixture(name="lenient_kwargs")
+def lenient_kwargs_fixture():
+    """Filtering kwargs lenient enough for the tiny test datasets to produce data."""
+    return {
+        "min_mean_clr": -100.0,
+        "min_expected_join_count": 0,
+        "min_n_cells": 0,
+    }
+
+
+def test_compare_sample_pair(pxl_dataset, pxl_dataset_2, lenient_kwargs):
+    """Verify a basic pairwise comparison between two (identical, relabeled) samples."""
+    result = compare_sample_pair(
+        pxl_dataset,
+        pxl_dataset_2,
+        sample1_name="sample1",
+        sample2_name="sample2",
+        **lenient_kwargs,
+    )
+
+    assert isinstance(result, SamplePairComparisonResult)
+    assert result.gate is None
+
+    assert set(result.abundance.columns) == {
+        "marker",
+        "mean_clr_sample1",
+        "mean_clr_sample2",
+    }
+    assert not result.abundance.empty
+
+    assert not result.proximity.empty
+    assert {"marker_1", "marker_2"}.issubset(result.proximity.columns)
+
+    # sample1 and sample2 are built from identical underlying data (just
+    # relabeled component ids), so the two samples should be perfectly
+    # correlated in both abundance and proximity.
+    assert result.abundance_correlation == pytest.approx(1.0)
+    assert result.proximity_correlation == pytest.approx(1.0)
+
+
+def test_compare_sample_pair_requires_distinct_sample_names(
+    pxl_dataset, pxl_dataset_2, lenient_kwargs
+):
+    """Verify comparing two samples with the same name raises a ValueError."""
+    with pytest.raises(ValueError, match="must be different"):
+        compare_sample_pair(
+            pxl_dataset,
+            pxl_dataset_2,
+            sample1_name="same_name",
+            sample2_name="same_name",
+            **lenient_kwargs,
+        )
+
+
+def test_compare_sample_pair_no_markers_pass_filter(pxl_dataset, pxl_dataset_2):
+    """Verify an overly strict min_mean_clr raises an informative ValueError."""
+    with pytest.raises(ValueError, match="No markers passed"):
+        compare_sample_pair(
+            pxl_dataset,
+            pxl_dataset_2,
+            sample1_name="sample1",
+            sample2_name="sample2",
+            min_mean_clr=1e6,
+        )
+
+
+def test_compare_sample_pair_no_marker_pairs_pass_filter(
+    pxl_dataset, pxl_dataset_2, lenient_kwargs
+):
+    """Verify an overly strict proximity filter raises an informative ValueError."""
+    kwargs = dict(lenient_kwargs)
+    kwargs["min_expected_join_count"] = 1e6
+    with pytest.raises(ValueError, match="No marker pairs passed"):
+        compare_sample_pair(
+            pxl_dataset,
+            pxl_dataset_2,
+            sample1_name="sample1",
+            sample2_name="sample2",
+            **kwargs,
+        )
+
+
+def test_compare_sample_pairs(pxl_dataset, pxl_dataset_2, lenient_kwargs):
+    """Verify the multi-pair wrapper delegates to compare_sample_pair per pair."""
+    results = compare_sample_pairs(
+        [(pxl_dataset, pxl_dataset_2)],
+        sample_names=[("sample1", "sample2")],
+        **lenient_kwargs,
+    )
+
+    assert len(results) == 1
+    assert results[0].sample1_name == "sample1"
+    assert results[0].sample2_name == "sample2"
+
+
+def test_compare_sample_pairs_sample_names_length_mismatch(
+    pxl_dataset, pxl_dataset_2, lenient_kwargs
+):
+    """Verify a mismatched sample_names length raises a ValueError."""
+    with pytest.raises(ValueError, match="same length"):
+        compare_sample_pairs(
+            [(pxl_dataset, pxl_dataset_2)],
+            sample_names=[("sample1", "sample2"), ("sample3", "sample4")],
+            **lenient_kwargs,
+        )
+
+
+def test_compare_sample_pairs_by_gate_unimodal_marker_is_noop(
+    pxl_dataset, pxl_dataset_2, lenient_kwargs
+):
+    """Verify a gate on a marker that isn't clearly bimodal enough doesn't filter anything."""
+    gate = ["+MarkerA"]
+
+    results = compare_sample_pairs_by_gate(
+        [(pxl_dataset, pxl_dataset_2)],
+        gate=gate,
+        sample_names=[("sample1", "sample2")],
+        min_separation_score=1e6,  # nothing can be this well separated -> gate is a no-op
+        **lenient_kwargs,
+    )
+
+    assert len(results) == 1
+    result = results[0]
+    assert result.gate == gate
+    assert not result.abundance.empty
+    assert not result.proximity.empty
+
+
+def test_compare_sample_pairs_by_gate_filters_components(
+    pxl_dataset, pxl_dataset_2, lenient_kwargs, monkeypatch
+):
+    """Verify the wrapper applies a pooled gate mask per-sample before comparing."""
+    from pixelator.pna.analysis import comparison as comparison_module
+
+    # The only components with proximity data available in the tiny test fixtures.
+    kept_components = {"fc07dea9b679aca7", "fc07dea9b679acb8"}
+
+    def fake_gate_mask(pooled_clr, gate, min_separation_score):
+        mask = pd.Series(
+            [idx in kept_components for idx in pooled_clr.index],
+            index=pooled_clr.index,
+        )
+        return mask, []
+
+    monkeypatch.setattr(comparison_module, "gate_mask", fake_gate_mask)
+
+    results = compare_sample_pairs_by_gate(
+        [(pxl_dataset, pxl_dataset_2)],
+        gate=["+MarkerA"],
+        sample_names=[("sample1", "sample2")],
+        **lenient_kwargs,
+    )
+
+    result = results[0]
+    assert result.gate == ["+MarkerA"]
+    assert not result.abundance.empty
+    assert not result.proximity.empty
+
+
+def test_compare_sample_pairs_by_gate_no_components_pass(
+    pxl_dataset, pxl_dataset_2, lenient_kwargs
+):
+    """Verify a gate that excludes all components raises rather than silently comparing unfiltered data."""
+    gate = ["+MarkerA", "-MarkerA"]  # impossible to satisfy both at once
+
+    with pytest.raises(ValueError, match="No components"):
+        compare_sample_pairs_by_gate(
+            [(pxl_dataset, pxl_dataset_2)],
+            gate=gate,
+            sample_names=[("sample1", "sample2")],
+            min_separation_score=-1e6,
+            **lenient_kwargs,
+        )

--- a/tests/pna/analysis/test_gating.py
+++ b/tests/pna/analysis/test_gating.py
@@ -1,0 +1,121 @@
+"""Tests for the pna gating module.
+
+Copyright © 2026 Pixelgen Technologies AB.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from pixelator.pna.analysis.gating import (
+    determine_marker_threshold,
+    gate_mask,
+    parse_gate,
+)
+
+
+@pytest.mark.parametrize(
+    "gate,expected",
+    [
+        (["+CD3e"], [("CD3e", "+")]),
+        (["-CD19"], [("CD19", "-")]),
+        (["+CD3e", "+CD4", "-CD19"], [("CD3e", "+"), ("CD4", "+"), ("CD19", "-")]),
+    ],
+)
+def test_parse_gate(gate, expected):
+    """Verify gate strings are parsed into (marker, sign) tuples."""
+    assert parse_gate(gate) == expected
+
+
+@pytest.mark.parametrize("invalid_gate", [["CD3e"], ["*CD3e"], [""]])
+def test_parse_gate_invalid(invalid_gate):
+    """Verify an invalid gate specification raises a ValueError."""
+    with pytest.raises(ValueError):
+        parse_gate(invalid_gate)
+
+
+def test_determine_marker_threshold_bimodal():
+    """Verify a clearly bimodal distribution yields a threshold between the two modes."""
+    rng = np.random.default_rng(0)
+    values = np.concatenate(
+        [rng.normal(0, 0.2, 200), rng.normal(6, 0.2, 200)],
+    )
+
+    result = determine_marker_threshold(values, min_separation_score=3.0, marker="A")
+
+    assert result.marker == "A"
+    assert result.threshold is not None
+    assert 0 < result.threshold < 6
+    assert result.separation_score >= 3.0
+
+
+def test_determine_marker_threshold_unimodal_is_ignored(caplog):
+    """Verify a unimodal distribution yields no threshold and logs a warning."""
+    rng = np.random.default_rng(0)
+    values = rng.normal(2, 0.5, 400)
+
+    result = determine_marker_threshold(values, min_separation_score=3.0, marker="B")
+
+    assert result.threshold is None
+    assert result.separation_score < 3.0
+    assert any("unimodal" in message.lower() for message in caplog.messages)
+
+
+def test_gate_mask_positive_and_negative():
+    """Verify gate_mask combines positive and negative marker criteria."""
+    rng = np.random.default_rng(0)
+    n = 200
+    clr = pd.DataFrame(
+        {
+            "A": np.concatenate(
+                [rng.normal(0, 0.2, n // 2), rng.normal(6, 0.2, n // 2)]
+            ),
+            "B": np.concatenate(
+                [rng.normal(0, 0.2, n // 2), rng.normal(6, 0.2, n // 2)]
+            ),
+        },
+        index=[f"c{i}" for i in range(n)],
+    )
+
+    mask, thresholds = gate_mask(clr, ["+A", "-B"], min_separation_score=3.0)
+
+    assert set(mask.index) == set(clr.index)
+    assert (
+        mask
+        == (
+            (clr["A"] >= thresholds[0].threshold) & (clr["B"] < thresholds[1].threshold)
+        )
+    ).all()
+    assert mask.sum() == 0  # no component is both high-A and low-B in this construction
+
+
+def test_gate_mask_ignores_unimodal_marker():
+    """Verify a unimodal marker in the gate is ignored (does not constrain the mask)."""
+    rng = np.random.default_rng(0)
+    n = 200
+    clr = pd.DataFrame(
+        {
+            "A": np.concatenate(
+                [rng.normal(0, 0.2, n // 2), rng.normal(6, 0.2, n // 2)]
+            ),
+            "B": rng.normal(2, 0.5, n),
+        },
+        index=[f"c{i}" for i in range(n)],
+    )
+
+    mask, thresholds = gate_mask(clr, ["+A", "+B"], min_separation_score=3.0)
+
+    b_threshold = next(t for t in thresholds if t.marker == "B")
+    assert b_threshold.threshold is None
+
+    a_threshold = next(t for t in thresholds if t.marker == "A")
+    expected_mask = clr["A"] >= a_threshold.threshold
+    assert (mask == expected_mask).all()
+
+
+def test_gate_mask_missing_marker_raises():
+    """Verify gating on a marker missing from the CLR data raises a KeyError."""
+    clr = pd.DataFrame({"A": [1.0, 2.0, 3.0]}, index=["c1", "c2", "c3"])
+
+    with pytest.raises(KeyError):
+        gate_mask(clr, ["+NotAMarker"])

--- a/tests/pna/plot/test_comparison_plot.py
+++ b/tests/pna/plot/test_comparison_plot.py
@@ -1,0 +1,121 @@
+"""Tests for the pna sample pair comparison plot/report module.
+
+Copyright © 2026 Pixelgen Technologies AB.
+"""
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+
+from pixelator.pna.analysis.comparison import SamplePairComparisonResult
+from pixelator.pna.plot import (
+    plot_sample_pair_comparison,
+    write_sample_pair_comparison_report,
+)
+
+
+@pytest.fixture(name="comparison_result")
+def comparison_result_fixture():
+    """A synthetic `SamplePairComparisonResult`, independent of any real pxl data."""
+    abundance = pd.DataFrame(
+        {
+            "marker": ["MarkerA", "MarkerB", "MarkerC"],
+            "mean_clr_sample1": [1.0, 2.0, 3.0],
+            "mean_clr_sample2": [1.1, 2.1, 2.9],
+        }
+    )
+    proximity = pd.DataFrame(
+        {
+            "marker_1": ["MarkerA", "MarkerB"],
+            "marker_2": ["MarkerA", "MarkerC"],
+            "log2_ratio_sample1": [0.5, -0.2],
+            "n_cells_sample1": [80, 90],
+            "log2_ratio_sample2": [0.4, -0.3],
+            "n_cells_sample2": [70, 95],
+        }
+    )
+    return SamplePairComparisonResult(
+        sample1_name="sample1",
+        sample2_name="sample2",
+        abundance=abundance,
+        abundance_correlation=0.98,
+        proximity=proximity,
+        proximity_correlation=0.91,
+    )
+
+
+def test_plot_sample_pair_comparison(comparison_result):
+    """Verify the comparison plot has two labeled scatter subplots."""
+    fig, (ax_abundance, ax_proximity) = plot_sample_pair_comparison(comparison_result)
+
+    assert isinstance(fig, plt.Figure)
+    assert ax_abundance.get_title() == "Abundance"
+    assert ax_proximity.get_title() == "Proximity"
+    assert "sample1" in ax_abundance.get_xlabel()
+    assert "sample2" in ax_abundance.get_ylabel()
+
+    plt.close(fig)
+
+
+def test_plot_sample_pair_comparison_with_gate(comparison_result):
+    """Verify the gate is reflected in the figure title when present."""
+    comparison_result.gate = ["+MarkerA", "-MarkerB"]
+    fig, _ = plot_sample_pair_comparison(comparison_result)
+
+    assert "+MarkerA" in fig.get_suptitle()
+    plt.close(fig)
+
+
+def test_write_sample_pair_comparison_report(comparison_result, tmp_path):
+    """Verify the HTML report embeds sample names, correlations, and an image per result."""
+    output_path = tmp_path / "report.html"
+
+    result_path = write_sample_pair_comparison_report(
+        [comparison_result], output_path, title="My report"
+    )
+
+    assert result_path == output_path
+    html = output_path.read_text()
+
+    assert "My report" in html
+    assert "sample1 vs sample2" in html
+    assert "0.980" in html
+    assert "0.910" in html
+    assert html.count("<img") == 1
+    assert "data:image/png;base64," in html
+
+
+def test_write_sample_pair_comparison_report_multiple_results_and_gate(
+    comparison_result, tmp_path
+):
+    """Verify multiple results are all included, and a gate is rendered when present."""
+    gated_result = SamplePairComparisonResult(
+        sample1_name="sample3",
+        sample2_name="sample4",
+        abundance=comparison_result.abundance.rename(
+            columns={
+                "mean_clr_sample1": "mean_clr_sample3",
+                "mean_clr_sample2": "mean_clr_sample4",
+            }
+        ),
+        abundance_correlation=0.5,
+        proximity=comparison_result.proximity.rename(
+            columns={
+                "log2_ratio_sample1": "log2_ratio_sample3",
+                "n_cells_sample1": "n_cells_sample3",
+                "log2_ratio_sample2": "log2_ratio_sample4",
+                "n_cells_sample2": "n_cells_sample4",
+            }
+        ),
+        proximity_correlation=0.4,
+        gate=["+MarkerA", "-MarkerB"],
+    )
+
+    output_path = tmp_path / "report.html"
+    write_sample_pair_comparison_report([comparison_result, gated_result], output_path)
+
+    html = output_path.read_text()
+    assert html.count("<img") == 2
+    assert "sample1 vs sample2" in html
+    assert "sample3 vs sample4" in html
+    assert "+MarkerA, -MarkerB" in html


### PR DESCRIPTION
Add functions to verify pairs of PNA samples are similar in terms of abundance (mean marker CLR) and proximity (mean marker-pair proximity score) patterns, with per-pair scatter plots and correlations, a cell-type gating wrapper based on per-marker GMM thresholding, and an HTML report wrapper that collects results across pairs.

Fixes: PNA-2911

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

New unit tests and manual comparison with previous analyses.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
