### PR TITLE
Clear docs warnings

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  DOCS_BASE_URL: https://PixelgenTechnologies.github.io/pixelator
+  DOCS_BASE_URL: https://karlmoresco.github.io/pixelator
 
 jobs:
   build:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  DOCS_BASE_URL: https://karlmoresco.github.io/pixelator
+  DOCS_BASE_URL: https://PixelgenTechnologies.github.io/pixelator
 
 jobs:
   build:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build docs
         env:
           DOCS_VERSION: ${{ steps.ver.outputs.version }}
-        run: uv run sphinx-build -b html docs docs/_build/html --keep-going -n
+        run: uv run sphinx-build -b html docs docs/_build/html --fail-on-warning -n
       - uses: actions/upload-artifact@v4
         with:
           name: docs-html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `pixelator.pna.analysis.compare_sample_pairs_by_gate` to run the same comparison restricted to components matching a cell-type gate (e.g. `["+CD3e", "+CD4", "-CD19"]`), with positive/negative thresholds determined automatically from each marker's CLR distribution.
 - `pixelator.pna.analysis.gating.determine_marker_threshold` to determine a positive/negative CLR threshold for a marker, warning and skipping markers whose distribution appears unimodal.
 - `pixelator.pna.plot.plot_sample_pair_comparison` and `write_sample_pair_comparison_report` to plot and collect sample pair abundance/proximity comparisons into an HTML report.
+- Setup for generating API documentation pages from source files, and a workflow for building and deploying the docs automatically.
 
 ### Changed
-- The default `min_allowed_nodes_pct` in `adaptive_core_expansion` has been changed from 0.8 to 0.9, meaning that a valid "high" core partition must include at least 90% of all nodes. Components that don't meet this criteria will not be denoised by ACE. 
+- The default `min_allowed_nodes_pct` in `adaptive_core_expansion` has been changed from 0.8 to 0.9, meaning that a valid "high" core partition must include at least 90% of all nodes. Components that don't meet this criteria will not be denoised by ACE.
 
 ## [0.29.0] - 2026-06-15
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,6 +6,7 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
+import logging
 import os
 
 project = "Pixelator"
@@ -47,7 +48,31 @@ nitpick_ignore_regex = [
     ),
 ]
 
-suppress_warnings = ["ref.python", "autoapi.python_import_resolution"]
+suppress_warnings = [
+    "ref.python",
+    "autoapi.python_import_resolution",
+    "toc.not_included",
+    "toc.not_readable",
+]
+
+# Warnings emitted without a Sphinx type/subtype, so suppress_warnings
+# cannot match them; they are suppressed via a logging filter instead.
+_suppressed_warning_fragments = (
+    # Import placeholders AutoAPI could not resolve.
+    "Unknown type: placeholder",
+    # pna_config is assigned 4 times in config_instance.py; AutoAPI
+    # documents each assignment.
+    "duplicate object description of pixelator.pna.config.config_instance.pna_config",
+)
+
+
+def _keep_warning(record):
+    message = record.getMessage()
+    return not any(fragment in message for fragment in _suppressed_warning_fragments)
+
+
+for _logger_name in ("sphinx.autoapi._mapper", "sphinx.sphinx.domains.python"):
+    logging.getLogger(_logger_name).addFilter(_keep_warning)
 
 extensions = [
     "sphinx.ext.autodoc",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,6 +28,23 @@ nitpick_ignore_regex = [
     # --- Unresolvable source annotations ---
     (r"py:.*", r"matplotlib\.pyplot\..*"),
     (r"py:.*", r"pyarrow\.schema"),
+    # --- Private, internal, TypeVar, protocol-base, and native targets ---
+    # These come from annotations, base-class lists, or TypeVars in the source code.
+    (
+        r"py:.*",
+        r"(Edge|Vertex|VertexSequence|AmpliconBuilder|BarcodeDemuxer"
+        r"|DemuxFilenamePolicy|PipelineRunner|StatisticsClass"
+        r"|NetworkxBasedVertexClustering|T|mpctx_Process)",
+    ),
+    (r"py:.*", r"(_SummaryStatsDict|_PartitionCandidate|_COMPONENT_BATCH_SIZE)"),
+    (r"py:.*", r"pixelator_core\.PyGraphProperties"),
+    (r"py:.*", r"pixelator\.pna\.pixeldataset\.legacy\.PNALegacyPixelDataset"),
+    (r"py:.*", r"pixelator\.types\.PathType"),
+    (
+        r"py:.*",
+        r"pixelator\.common\.graph\.backends\.implementations\._networkx"
+        r"\.NetworkXGraphBackend",
+    ),
 ]
 
 suppress_warnings = ["ref.python", "autoapi.python_import_resolution"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,7 +128,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 _docs_version = os.environ.get("DOCS_VERSION", "latest")
 _docs_base_url = os.environ.get(
     "DOCS_BASE_URL",
-    "https://PixelgenTechnologies.github.io/pixelator",
+    "https://karlmoresco.github.io/pixelator",
 ).rstrip("/")
 
 html_baseurl = f"{_docs_base_url}/"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,7 +128,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 _docs_version = os.environ.get("DOCS_VERSION", "latest")
 _docs_base_url = os.environ.get(
     "DOCS_BASE_URL",
-    "https://karlmoresco.github.io/pixelator",
+    "https://PixelgenTechnologies.github.io/pixelator",
 ).rstrip("/")
 
 html_baseurl = f"{_docs_base_url}/"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,12 @@ nitpick_ignore_regex = [
     (r"py:.*", r"numpy\..*"),
     (r"py:.*", r"duckdb\..*"),
     (r"py:.*", r"faiss\..*"),
+    # --- Unresolvable source annotations ---
+    (r"py:.*", r"matplotlib\.pyplot\..*"),
+    (r"py:.*", r"pyarrow\.schema"),
 ]
+
+suppress_warnings = ["ref.python", "autoapi.python_import_resolution"]
 
 extensions = [
     "sphinx.ext.autodoc",

--- a/src/pixelator/common/statistics.py
+++ b/src/pixelator/common/statistics.py
@@ -107,7 +107,7 @@ def correct_pvalues(pvalues: np.ndarray) -> np.ndarray:
         pvalues: An array of p-values to adjust.
 
     Returns:
-        np.ndarray: The array of adjusted p-values in the same order as the input array.
+        The array of adjusted p-values in the same order as the input array.
     """
     # Most descriptions of the BH method states that p-values should
     # first be ordered in ascending order an ranked, however doing so
@@ -141,7 +141,7 @@ def log1p_transformation(df: pd.DataFrame) -> pd.DataFrame:
         df: The dataframe of antibody counts (antibodies as columns).
 
     Returns:
-        pd.DataFrame: A dataframe with the counts normalized.
+        A dataframe with the counts normalized.
     """
     logger.debug(
         (
@@ -170,7 +170,7 @@ def rate_diff_transformation(df: pd.DataFrame) -> pd.DataFrame:
         df: The dataframe of raw antibody counts (antibodies as columns).
 
     Returns:
-        pd.DataFrame: A dataframe with the counts difference from expected values.
+        A dataframe with the counts difference from expected values.
     """
     antibody_counts_per_component = df.sum(axis=1)
     antibody_rates = df.sum(axis=0)
@@ -196,7 +196,7 @@ def rel_normalization(df: pd.DataFrame, axis: Literal[0, 1] = 0) -> pd.DataFrame
             columns, and `axis=1` applies it by rows.
 
     Returns:
-        pd.DataFrame: A dataframe with the counts normalized.
+        A dataframe with the counts normalized.
 
     Raises:
         AssertionError: If the input axis is not 0 or 1.
@@ -233,7 +233,7 @@ def wilcoxon_test(
         value_column: Name of the column containing the values to compare.
 
     Returns:
-        pd.Series: A series containing the test statistic, p-value, and median difference.
+        A series containing the test statistic, p-value, and median difference.
     """
     reference_df = df.loc[df[contrast_column] == reference, :]
     target_df = df.loc[df[contrast_column] == target, :]

--- a/src/pixelator/pna/analysis/gating.py
+++ b/src/pixelator/pna/analysis/gating.py
@@ -146,10 +146,10 @@ def gate_mask(
             marker's distribution to be considered bimodal. Defaults to 3.0.
 
     Returns:
-        A tuple of:
-            - A boolean `pd.Series` (indexed like ``clr``) that is ``True`` for
-              components passing all (non-ignored) gating criteria.
-            - A list of `MarkerThreshold` instances, one per marker in ``gate``.
+        A tuple whose first element is a boolean ``pd.Series`` (indexed like
+        ``clr``) that is ``True`` for components passing all (non-ignored)
+        gating criteria, and whose second element is a list of
+        ``MarkerThreshold`` instances, one per marker in ``gate``.
 
     Raises:
         KeyError: If a marker in ``gate`` is not a column of ``clr``.

--- a/src/pixelator/pna/analysis/proximity.py
+++ b/src/pixelator/pna/analysis/proximity.py
@@ -106,7 +106,7 @@ def proximity_with_permute_stats(
         min_marker_count: Minimum marker count threshold for filtering the edgelist. Defaults to 0.
 
     Returns:
-        pd.DataFrame: A DataFrame containing the proximity results augmented with
+        A DataFrame containing the proximity results augmented with
         statistical measures, including expected means, standard deviations,
         z-scores, and p-values for the specified result columns.
     """
@@ -159,7 +159,7 @@ def jcs_with_permute_stats(
         min_marker_count: Minimum marker count to consider. Defaults to 0.
 
     Returns:
-        pd.DataFrame: A DataFrame containing the proximity statistics.
+        A DataFrame containing the proximity statistics.
     """
     return proximity_with_permute_stats(
         edgelist,

--- a/src/pixelator/pna/collapse/utilities.py
+++ b/src/pixelator/pna/collapse/utilities.py
@@ -230,7 +230,7 @@ def _find_connected_components_cluster(
 
 @dataclasses.dataclass(frozen=True, slots=True)
 class CollapseInputs:
-    """Output object for :func:`check_collapse_strategy_inputs`."""
+    """Output object for :func:`~pixelator.pna.collapse.utilities.check_collapse_strategy_inputs`."""
 
     parquet: list[Path] | tuple[list[Path], list[Path]]
     reports: list[Path] | tuple[list[Path], list[Path]]

--- a/src/pixelator/pna/graph/community_detection.py
+++ b/src/pixelator/pna/graph/community_detection.py
@@ -250,9 +250,9 @@ def refine_component(
         duckdb_config: Configuration for DuckDB connection.
 
     Returns:
-        pd.Series: Sizes of new components after refinement.
-        int: Number of crossing edges removed during refinement.
-        pd.Series: Sizes of discarded components after refinement.
+        A tuple of the sizes of the new components after refinement, the
+        number of crossing edges removed during refinement, and the sizes of
+        the discarded components after refinement.
     """
     with connect_duckdb(config=duckdb_config) as con:
         edgelist = con.execute(f"""
@@ -369,7 +369,7 @@ def run_leiden_refinement(
         max_workers: Maximum number of worker processes to use.
 
     Returns:
-        tuple[GraphStatistics, pl.DataFrame]: Updated component statistics and DataFrame of
+        A tuple of the updated component statistics and a DataFrame of
         discarded component sizes.
 
     Raises:
@@ -494,7 +494,8 @@ def find_components(
         n_threads: Number of threads to use for parallel processing.
 
     Returns:
-        tuple[GraphStatistics, Path]: Component statistics and path to the edgelist with components.
+        A tuple of the component statistics and the path to the edgelist with
+        components.
     """
     logger.info("Starting component finding process.")
     component_stats = initialize_graph_statistics(

--- a/src/pixelator/pna/graph/component_recovery_utils.py
+++ b/src/pixelator/pna/graph/component_recovery_utils.py
@@ -264,8 +264,8 @@ def find_clashing_umis(
         component_stats: Statistics object to update with clash information.
 
     Returns:
-        (pl.Series, GraphStatistics): A tuple containing a Polars Series of clashing UMIs
-        and the updated component statistics.
+        A tuple containing a Polars Series of clashing UMIs and the updated
+        component statistics.
     """
     with connect_duckdb() as con:
         con.execute(
@@ -594,8 +594,8 @@ def filter_connected_components_by_size(
         working_dir: Directory for temporary parquet output.
 
     Returns:
-        tuple[Path, GraphStatistics]: Path to the filtered parquet edgelist and updated component
-        statistics.
+        A tuple of the path to the filtered parquet edgelist and the updated
+        component statistics.
 
     Raises:
         ConnectedComponentException: If no components remain after filtering.

--- a/src/pixelator/pna/graph/node_pls.py
+++ b/src/pixelator/pna/graph/node_pls.py
@@ -131,8 +131,7 @@ def create_node_neighborhood_abundance_matrix(
             None.
 
     Returns:
-        pd.DataFrame: A DataFrame containing expanded and normalized node
-        abundance values.
+        A DataFrame containing expanded and normalized node abundance values.
 
     Raises:
         ValueError: If the number of rows in model_mat does not match the number of nodes in the
@@ -237,8 +236,8 @@ def node_pls(
             effects of the covariates in `model_mat` before fitting the PLS model. Defaults to None.
 
     Returns:
-        PLSRegression: A fitted sklearn PLSRegression model, which contains the results of the PLS
-        regression including coefficients, scores, and loadings.
+        A fitted sklearn PLSRegression model, which contains the results of the
+        PLS regression including coefficients, scores, and loadings.
 
     Raises:
         ValueError: If variables are not found or if the input matrices are incompatible.

--- a/src/pixelator/pna/pixeldataset/__init__.py
+++ b/src/pixelator/pna/pixeldataset/__init__.py
@@ -79,7 +79,7 @@ def read(paths: Path | list[Path] | str | list[str]) -> PNAPixelDataset:
         The data from the ``.pxl`` file(s).
 
     Raises:
-        IOException: If a file is not a DuckDB database file.
+        duckdb.IOException: If a file is not a DuckDB database file.
         ValueError: If a file is not a valid ``.pxl`` file, if a sample name cannot be determined from file metadata.
         FileNotFoundError: If any path does not exist on disk.
     """

--- a/src/pixelator/pna/pixeldataset/io/pixel_data_viewer.py
+++ b/src/pixelator/pna/pixeldataset/io/pixel_data_viewer.py
@@ -52,9 +52,9 @@ def _validate_session_file_path(path: Path) -> None:
 
 
 class PixelDataViewer:
-    """Maps sample names to PXL files and can open a :class:`PixelDataViewerSession`.
+    """Maps sample names to PXL files and can open a :class:`~pixelator.pna.pixeldataset.io.pixel_data_viewer.PixelDataViewerSession`.
 
-    Query execution uses a :class:`PixelDataViewerSession` from ``viewer.open()``
+    Query execution uses a :class:`~pixelator.pna.pixeldataset.io.pixel_data_viewer.PixelDataViewerSession` from ``viewer.open()``
 
     .. code-block:: python
 
@@ -185,7 +185,7 @@ class PixelDataViewerSession:
     """DuckDB session over one or more attached PXL files.
 
     Pass a list of ``(sample_name, pxl_path, db_name)`` tuples, where
-    ``db_name`` is the DuckDB attach alias (see :meth:`PixelDataViewer.normalized_sample_db_name`).
+    ``db_name`` is the DuckDB attach alias (see :meth:`~pixelator.pna.pixeldataset.io.pixel_data_viewer.PixelDataViewer.normalized_sample_db_name`).
 
     At construction time, ``sample_name``, ``db_name``, and the path string are
     validated to only use valid DuckDB identifiers.


### PR DESCRIPTION
## Description

Cleared Sphinx build warnings by fixing docstrings and adding suppression behavior. Set build command in build/deploy workflow to fail on warning. These changes are necessary for robust API docs publishing.

Broad suppression was implemented, see details in [ticket](https://linear.app/pixelgen-technologies/issue/PNA-3163/resolve-silenced-sphinx-warnings-in-order-to-narrow-blanket).

Fixes: [PNA-2145](https://linear.app/pixelgen-technologies/issue/PNA-2145/setup-api-docs-for-pixelator)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

No manual tests.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
