### PR TITLE
DO NOT MERGE - set a default large component threshold

### DIFF
--- a/src/pixelator/pna/cli/graph.py
+++ b/src/pixelator/pna/cli/graph.py
@@ -159,7 +159,7 @@ from pixelator.pna.graph.report import GraphSampleReport
 )
 @click.option(
     "--component-size-min-threshold",
-    default=None,
+    default=MIN_PNA_COMPONENT_SIZE,
     required=False,
     type=click.IntRange(min=1, max=None),
     show_default=True,

--- a/src/pixelator/pna/cli/graph.py
+++ b/src/pixelator/pna/cli/graph.py
@@ -148,7 +148,7 @@ from pixelator.pna.graph.report import GraphSampleReport
 )
 @click.option(
     "--component-size-max-threshold",
-    default=None,
+    default=500_000,
     required=False,
     type=click.IntRange(min=1, max=None),
     show_default=True,

--- a/src/pixelator/pna/graph/community_detection.py
+++ b/src/pixelator/pna/graph/community_detection.py
@@ -490,7 +490,7 @@ def find_components(
         edge_cycle_verification: Whether to perform edge cycle verification.
         min_read_count: Minimum read count threshold for an edge to be retained.
         refinement_options: Options for staged refinement during community detection.
-        component_size_threshold: Minimum size threshold for components to be retained.
+        component_size_threshold: Minimum and maximum size threshold for components to be retained.
         n_threads: Number of threads to use for parallel processing.
 
     Returns:

--- a/src/pixelator/pna/graph/community_detection.py
+++ b/src/pixelator/pna/graph/community_detection.py
@@ -565,16 +565,21 @@ def find_components(
     logger.info(
         "Writing hive partitioned edgelist without out-of-size-bound components."
     )
+    upper_component_size_bound = (
+        component_size_threshold[1]
+        if isinstance(component_size_threshold, tuple)
+        else np.iinfo(np.uint64).max
+    )
     logger.info(
         "Filtering connected components by size: min=%d, max=%d",
         refinement_options.initial_stage_options.min_component_size_to_prune,
-        component_size_threshold[1],
+        upper_component_size_bound,
     )
     hive_partitioned_edgelist_path, discard_sizes = (
         write_hive_partitioned_edgelist_without_out_of_size_bound_components(
             input_edgelist_path=partitioned_edgelist_path,
             min_component_size_to_prune=refinement_options.initial_stage_options.min_component_size_to_prune,
-            max_component_size_to_prune=component_size_threshold[1],
+            max_component_size_to_prune=upper_component_size_bound,
             working_dir=working_dir,
         )
     )

--- a/src/pixelator/pna/graph/community_detection.py
+++ b/src/pixelator/pna/graph/community_detection.py
@@ -12,6 +12,7 @@ from functools import partial
 from pathlib import Path
 
 import networkx as nx
+import numpy as np
 import pandas as pd
 import polars as pl
 from graspologic_native import leiden
@@ -477,7 +478,7 @@ def find_components(
     refinement_options: StagedRefinementOptions = StagedRefinementOptions(),
     component_size_threshold: bool | tuple[int, int] = (
         MIN_PNA_COMPONENT_SIZE,
-        2**32 - 1,
+        np.iinfo(np.uint64).max,
     ),
     n_threads: int = 1,
 ) -> tuple[GraphStatistics, Path]:

--- a/src/pixelator/pna/graph/community_detection.py
+++ b/src/pixelator/pna/graph/community_detection.py
@@ -30,7 +30,7 @@ from pixelator.pna.graph.component_recovery_utils import (
     name_components_with_umi_hashes_from_parquet,
     populate_component_stats_from_hybrid_detection,
     remove_clashing_umis,
-    write_hive_partitioned_edgelist_without_small_components,
+    write_hive_partitioned_edgelist_without_out_of_size_bound_components,
 )
 from pixelator.pna.graph.constants import (
     LEIDEN_RANDOM_SEED,
@@ -562,11 +562,19 @@ def find_components(
         post_recovery_stats=post_recovery_stats,
     )
 
-    logger.info("Writing hive partitioned edgelist without small components.")
+    logger.info(
+        "Writing hive partitioned edgelist without out-of-size-bound components."
+    )
+    logger.info(
+        "Filtering connected components by size: min=%d, max=%d",
+        refinement_options.initial_stage_options.min_component_size_to_prune,
+        component_size_threshold[1],
+    )
     hive_partitioned_edgelist_path, discard_sizes = (
-        write_hive_partitioned_edgelist_without_small_components(
+        write_hive_partitioned_edgelist_without_out_of_size_bound_components(
             input_edgelist_path=partitioned_edgelist_path,
             min_component_size_to_prune=refinement_options.initial_stage_options.min_component_size_to_prune,
+            max_component_size_to_prune=component_size_threshold[1],
             working_dir=working_dir,
         )
     )

--- a/src/pixelator/pna/graph/component_recovery_utils.py
+++ b/src/pixelator/pna/graph/component_recovery_utils.py
@@ -194,12 +194,13 @@ def get_count_statistics(edgelist_path: Path) -> dict:
     }
 
 
-def write_hive_partitioned_edgelist_without_small_components(
+def write_hive_partitioned_edgelist_without_out_of_size_bound_components(
     input_edgelist_path: Path,
     min_component_size_to_prune: int,
+    max_component_size_to_prune: int = np.iinfo(np.uint64).max,
     working_dir: Path = DEFAULT_WORKING_DIR,
 ) -> tuple[Path, pl.DataFrame]:
-    """Remove components below a UMI score threshold and write a hive-partitioned edgelist.
+    """Remove components outside the specified size bounds and write a hive-partitioned edgelist.
 
     The per-component score matches hybrid community detection:
     ``COUNT(DISTINCT umi1) + COUNT(DISTINCT umi2)``. Rows from components that pass the
@@ -207,7 +208,8 @@ def write_hive_partitioned_edgelist_without_small_components(
 
     Args:
         input_edgelist_path: Parquet file with component assignments (e.g. after hybrid detection).
-        min_component_size_to_prune: Components with a score strictly below this are dropped.
+        min_component_size_to_prune: Components with number of UMIs strictly below this are dropped.
+        max_component_size_to_prune: Components with number of UMIs strictly above this are dropped.
         working_dir: Directory for a temporary DuckDB file and the hive-partition output. Defaults
             to ``DEFAULT_WORKING_DIR`` (``/tmp``).
 
@@ -216,7 +218,7 @@ def write_hive_partitioned_edgelist_without_small_components(
     """
     hive_partitioned_edgelist_path = working_dir / "hive_partitioned_edgelist.parquet"
     min_sz = int(min_component_size_to_prune)
-    logger.debug("Filtering out small components from edge list")
+    logger.debug("Filtering out components outside size bounds from edge list")
     with connect_duckdb(working_dir / "temp_hivepartition.duckdb") as conn:
         conn.execute(f"""
             CREATE TEMP TABLE component_counts AS
@@ -232,13 +234,13 @@ def write_hive_partitioned_edgelist_without_small_components(
             CREATE TABLE discarded_components AS
                 SELECT component, n_umi
                 FROM component_counts
-                WHERE n_umi < {min_sz};
+                WHERE n_umi < {min_sz} OR n_umi > {max_component_size_to_prune};
 
             CREATE TABLE edgelist AS
                 SELECT e.*
                 FROM parquet_scan('{str(input_edgelist_path)}') e
                 JOIN component_counts c ON e.component = c.component
-                WHERE c.n_umi >= {min_sz}
+                WHERE c.n_umi >= {min_sz} AND c.n_umi <= {max_component_size_to_prune}
                 ORDER BY e.component;
 
             COPY edgelist TO '{str(hive_partitioned_edgelist_path)}'

--- a/tests/pna/graph/test_component_recovery_utils.py
+++ b/tests/pna/graph/test_component_recovery_utils.py
@@ -10,7 +10,7 @@ from pixelator.pna.graph.component_recovery_utils import (
     get_count_statistics,
     name_components_with_umi_hashes,
     name_components_with_umi_hashes_from_parquet,
-    write_hive_partitioned_edgelist_without_small_components,
+    write_hive_partitioned_edgelist_without_out_of_size_bound_components,
 )
 from pixelator.pna.graph.report import GraphStatistics
 
@@ -41,7 +41,7 @@ def test_get_count_statistics(tmp_path: Path) -> None:
     }
 
 
-def test_write_hive_partitioned_edgelist_without_small_components_prunes(
+def test_write_hive_partitioned_edgelist_without_out_of_size_bound_components(
     tmp_path: Path,
 ) -> None:
     """Test components below the UMI score threshold are omitted and listed as discarded.
@@ -58,10 +58,12 @@ def test_write_hive_partitioned_edgelist_without_small_components_prunes(
         }
     ).write_parquet(partitioned)
 
-    out_path, discarded = write_hive_partitioned_edgelist_without_small_components(
-        input_edgelist_path=partitioned,
-        min_component_size_to_prune=3,
-        working_dir=tmp_path,
+    out_path, discarded = (
+        write_hive_partitioned_edgelist_without_out_of_size_bound_components(
+            input_edgelist_path=partitioned,
+            min_component_size_to_prune=3,
+            working_dir=tmp_path,
+        )
     )
 
     assert out_path == tmp_path / "hive_partitioned_edgelist.parquet"
@@ -74,7 +76,7 @@ def test_write_hive_partitioned_edgelist_without_small_components_prunes(
     assert discarded_sorted["n_umi"].to_list() == [2]
 
 
-def test_write_hive_partitioned_edgelist_without_small_components_nothing_discarded(
+def test_write_hive_partitioned_edgelist_without_out_of_size_bound_components_nothing_discarded(
     tmp_path: Path,
 ) -> None:
     """When every component meets the threshold, discarded frame is empty and all rows are kept.
@@ -91,7 +93,7 @@ def test_write_hive_partitioned_edgelist_without_small_components_nothing_discar
         }
     ).write_parquet(partitioned)
 
-    _, discarded = write_hive_partitioned_edgelist_without_small_components(
+    _, discarded = write_hive_partitioned_edgelist_without_out_of_size_bound_components(
         input_edgelist_path=partitioned,
         min_component_size_to_prune=2,
         working_dir=tmp_path,


### PR DESCRIPTION
Removing large components by default in the graph step. This should eventually be an option in the pipeline and not done by default.

Fixes: PNA-3188

## Type of change

TEMP



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Default graph behavior now hard-filters components by size (including dropping clusters >500k UMIs), which can materially change cell counts and downstream PXL output without explicit user configuration; marked TEMP in the PR description.
> 
> **Overview**
> The graph CLI now **defaults** `--component-size-max-threshold` to **500,000** and `--component-size-min-threshold` to **`MIN_PNA_COMPONENT_SIZE`**, so runs use **hard** min/max bounds instead of dynamic size filtering unless callers change those flags.
> 
> Early hive-partitioned edgelist writing was extended from **minimum-only** pruning to **min and max** UMI bounds: `write_hive_partitioned_edgelist_without_out_of_size_bound_components` drops components below the min or above the max (same UMI score as hybrid detection). `find_components` passes the upper bound from `component_size_threshold` into that step and logs the applied min/max; the default upper bound type uses `np.iinfo(np.uint64).max` instead of `2**32 - 1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9375ec8c5965c37504ab41137a8cd61103ef220e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->