### PR TITLE
Store filepath in assay and panel classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `pixelator.pna.analysis.gating.determine_marker_threshold` to determine a positive/negative CLR threshold for a marker, warning and skipping markers whose distribution appears unimodal.
 - `pixelator.pna.plot.plot_sample_pair_comparison` and `write_sample_pair_comparison_report` to plot and collect sample pair abundance/proximity comparisons into an HTML report.
 - Setup for generating API documentation pages from source files, and a workflow for building and deploying the docs automatically.
+- `PNAAssay` and `PNAAntibodyPanel` now hold an optional path to the path they were parsed from.
 
 ### Changed
 - The default `min_allowed_nodes_pct` in `adaptive_core_expansion` has been changed from 0.8 to 0.9, meaning that a valid "high" core partition must include at least 90% of all nodes. Components that don't meet this criteria will not be denoised by ACE.

--- a/src/pixelator/pna/config/assay.py
+++ b/src/pixelator/pna/config/assay.py
@@ -7,6 +7,7 @@ import enum
 import json
 import typing
 from functools import cache
+from pathlib import Path
 from typing import Any, List, Mapping, Optional, Set, Tuple
 
 try:
@@ -342,6 +343,7 @@ class PNAAssay:
     Attributes:
         name: Name of the assay
         assay_spec: List of regions defining the assay structure
+        filepath: Path to the file the assay was loaded from, if any
     """
 
     _REQUIRED_REGIONS = {
@@ -355,10 +357,16 @@ class PNAAssay:
         "uei",
     }
 
-    def __init__(self, name: str, assay_spec: Optional[List[Region]] = None):
+    def __init__(
+        self,
+        name: str,
+        assay_spec: Optional[List[Region]] = None,
+        filepath: Optional[PathType] = None,
+    ):
         """Initialize an assay."""
         self.name = name
         self.assay_spec: List[Region] = assay_spec or []
+        self.filepath: Optional[Path] = Path(filepath).resolve() if filepath else None
 
         self._update_parent_ids()
 
@@ -454,7 +462,9 @@ class PNAAssay:
         """
         yaml_obj = load_yaml_file(filename)
         checked_obj = AssayModel.model_validate(yaml_obj)
-        return cls._load_assay_model(checked_obj)
+        assay = cls._load_assay_model(checked_obj)
+        assay.filepath = Path(filename).resolve()
+        return assay
 
     def to_json(self):
         """Return a json representation of the assay."""

--- a/src/pixelator/pna/config/config_class.py
+++ b/src/pixelator/pna/config/config_class.py
@@ -5,12 +5,14 @@ Copyright © 2022 Pixelgen Technologies AB.
 
 from __future__ import annotations
 
+import atexit
 import importlib
 import importlib.resources
 import itertools
 import re
 import typing
 from collections import defaultdict
+from contextlib import ExitStack
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -297,6 +299,16 @@ class PNAConfig:
 ConfigType = typing.TypeVar("ConfigType", Config, PNAConfig)
 
 
+# Keep resource files materialized by ``importlib.resources.as_file`` alive for the
+# lifetime of the process. For packages imported from a zip (zipimport), ``as_file``
+# extracts the resource to a temporary file that is removed when its context manager
+# exits. Since assays/panels store the path they were loaded from (for forwarding to
+# e.g. a Rust binding), that temporary file must remain available for the whole run.
+# The stack is closed at interpreter exit to clean up any such temporary files.
+_resource_file_stack = ExitStack()
+atexit.register(_resource_file_stack.close)
+
+
 def load_assays_package(config: ConfigType, package_name: str) -> ConfigType:
     """Load default assays from a resources package.
 
@@ -308,8 +320,10 @@ def load_assays_package(config: ConfigType, package_name: str) -> ConfigType:
     """
     for resource in importlib.resources.files(package_name).iterdir():
         if resource.is_file():
-            with importlib.resources.as_file(resource) as file_path:
-                config.load_assay(file_path)
+            file_path = _resource_file_stack.enter_context(
+                importlib.resources.as_file(resource)
+            )
+            config.load_assay(file_path)
 
     return config
 
@@ -325,8 +339,10 @@ def load_panels_package(config: ConfigType, package_name: str) -> ConfigType:
     """
     for resource in importlib.resources.files(package_name).iterdir():
         if resource.is_file():
-            with importlib.resources.as_file(resource) as file_path:
-                config.load_panel_file(file_path)
+            file_path = _resource_file_stack.enter_context(
+                importlib.resources.as_file(resource)
+            )
+            config.load_panel_file(file_path)
 
     return config
 

--- a/src/pixelator/pna/config/panel.py
+++ b/src/pixelator/pna/config/panel.py
@@ -54,6 +54,7 @@ class PNAAntibodyPanel:
         df: pd.DataFrame,
         metadata: AntibodyPanelMetadata,
         file_name: Optional[str] = None,
+        filepath: Optional[PathType] = None,
     ) -> None:
         """Load a panel from a dataframe and metadata.
 
@@ -61,6 +62,7 @@ class PNAAntibodyPanel:
             df: The dataframe containing the panel information.
             metadata: The metadata for the panel.
             file_name: The optional basename of the file from which the panel is loaded.
+            filepath: The optional full path of the file from which the panel is loaded.
 
         Returns:
             None
@@ -68,6 +70,7 @@ class PNAAntibodyPanel:
             AssertionError: exception if panel file is missing, invalid or with incorrect format
         """
         self._filename = file_name
+        self._filepath: Optional[Path] = Path(filepath).resolve() if filepath else None
         self.metadata = metadata
         self._df = df
 
@@ -106,7 +109,7 @@ class PNAAntibodyPanel:
 
         logger.debug("Antibody panel from file %s created", filename)
 
-        return cls(df, metadata, file_name=panel_file.name)
+        return cls(df, metadata, file_name=panel_file.name, filepath=panel_file)
 
     @classmethod
     def from_pxl_dataset(
@@ -251,6 +254,11 @@ class PNAAntibodyPanel:
     def filename(self) -> Optional[str]:
         """Return the filename of the marker panel."""
         return self._filename
+
+    @property
+    def filepath(self) -> Optional[Path]:
+        """Return the full path of the marker panel file, if any."""
+        return self._filepath
 
     @cached_property
     def size(self) -> int:

--- a/tests/pna/config/test_config.py
+++ b/tests/pna/config/test_config.py
@@ -44,6 +44,7 @@ def test_load_assays_dir(pna_data_root):
 
     a1 = config.get_assay("test-pna-assay")
     assert a1.name == "test-pna-assay"
+    assert a1.filepath == (pna_data_root / "assays" / "test-pna-assay.yaml").resolve()
 
 
 def test_assay_region_ids():
@@ -273,6 +274,9 @@ def test_load_antibody_panel_util(pna_data_root):
     )
     assert path_panel.name == "test-pna-panel"
     assert path_panel.filename == "test-pna-panel-v1.1.0.csv"
+    assert (
+        path_panel.filepath == (pna_data_root / "test-pna-panel-v1.1.0.csv").resolve()
+    )
 
     with pytest.raises(AssertionError):
         load_antibody_panel(pna_config, "human-qwdqwdqwdqdw-proteomics")

--- a/tests/pna/config/test_panel.py
+++ b/tests/pna/config/test_panel.py
@@ -1,5 +1,6 @@
 """Copyright © 2025 Pixelgen Technologies AB."""
 
+from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 import pandas as pd
@@ -54,6 +55,7 @@ def test_panel_validation(panel_df):
     assert panel.markers == ["marker1", "marker2", "marker3"]
     assert_frame_equal(panel.df, panel_df)
     assert panel.filename == "test.csv"
+    assert panel.filepath is None
     assert panel.size == 3
 
 
@@ -180,6 +182,7 @@ MarkerA,no,ACTTCCTAGG,ACTTCCTAGG
 
     assert panel.name == "test-pna-panel"
     assert panel.version == "1.0.0"
+    assert panel.filepath == Path(tmp_file.name).resolve()
     assert "trailing comma" in caplog.text.lower()
 
 


### PR DESCRIPTION
## Description

Assays and Panel need to be parsed from files in the new edgelist rust bindings. To be able to use the default panel and assays, these need to hold the path to their original 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Updated tests

## PR checklist:

- [X] This comment contains a description of changes (with reason).
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and documentation and corrected any misspellings
- [X] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive metadata and resource-lifetime fix in config loading; no change to assay/panel parsing or lookup behavior beyond storing paths.
> 
> **Overview**
> **`PNAAssay`** and **`PNAAntibodyPanel`** now keep an optional resolved **`filepath`** when they are loaded from disk (YAML/CSV), alongside the existing basename **`filename`** on panels. In-memory constructions (e.g. from AnnData) leave **`filepath`** unset.
> 
> Bundled default assays/panels are loaded via a process-wide **`ExitStack`** so **`importlib.resources.as_file`** temp files are not deleted while the run still needs those paths (e.g. zip-installed packages and Rust edgelist bindings). Cleanup runs at interpreter exit.
> 
> Tests assert **`filepath`** for directory loads and **`from_csv`**, and **`None`** when built without a file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba6e94b67d055b52bc86dc1480c726efa478a4e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->