### PR TITLE
Remove large components before refinement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - The default `min_allowed_nodes_pct` in `adaptive_core_expansion` has been changed from 0.8 to 0.9, meaning that a valid "high" core partition must include at least 90% of all nodes. Components that don't meet this criteria will not be denoised by ACE.
-- `pixelator.mpx.plot` and `pixelator.pna.plot` functions now use the Pixelgen brand theme and color palettes from `pixelator.common.plot` by default, for a consistent, on-brand look across every plot.
+- `pixelator.mpx.plot` and `pixelator.pna.plot` functions now use the Pixelgen brand theme and color palettes from `pixelator.common.plot` by default.
 - `pixelgen_divergent_colormap` and the `plot_colocalization_heatmap`/`plot_colocalization_diff_volcano`/`plot_polarity_diff_volcano` plots that use it now center on a light Pixelgen grey rather than white, and use a `min_level` floor on both hues, so values near zero stay visible against a white background instead of fading out.
 - Color scales for signed metrics (`abundance_colocalization_plot`'s hue mapping, `plot_colocalization_heatmap`'s `center=0`, and the `CenteredNorm` used by the volcano plots) are now correctly centered on zero, instead of on the (potentially skewed) 10th-90th percentile midpoint or raw data min/max.
+- `single-cell-pna graph` now discards components above the max size threshold before the refinement step instead of only at the end, reducing peak memory usage. This only applies when `--component-size-max-threshold` is set.
 
 ### Fixed
-- `abundance_colocalization_plot` no longer fabricates zero-valued colocalization scores for marker pairs or components with no recorded colocalization data (previously an incorrect `fillna(0)` call skewed the quantile-based color/size scaling); points with no data are now correctly omitted instead.
+- The graph stage now raises an error instead of an internal DuckDB crash when a component-size threshold discards every component in the input.
 
 ## [0.29.0] - 2026-06-15
 

--- a/src/pixelator/pna/cli/graph.py
+++ b/src/pixelator/pna/cli/graph.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 
 import click
+import numpy as np
 
 from pixelator.common.utils import (
     create_output_stage_dir,
@@ -154,7 +155,8 @@ from pixelator.pna.graph.report import GraphSampleReport
     show_default=True,
     help=(
         "Components with more nodes than this will be filtered from the output data. "
-        "This is typically not needed. Setting this will disable the automatic size filtering."
+        "Setting this (or --component-size-min-threshold) switches from automatic "
+        "(dynamic) component size filtering to a fixed threshold."
     ),
 )
 @click.option(
@@ -165,7 +167,8 @@ from pixelator.pna.graph.report import GraphSampleReport
     show_default=True,
     help=(
         "Components with fewer nodes than this will be filtered from the output data. "
-        "This is typically not needed. Setting this will disable the automatic size filtering."
+        "Setting this (or --component-size-max-threshold) switches from automatic "
+        "(dynamic) component size filtering to a fixed threshold."
     ),
 )
 @panel_option
@@ -273,8 +276,12 @@ def graph(
     component_size_threshold = True
     if any([component_size_min_threshold, component_size_max_threshold]):
         component_size_threshold = (
-            component_size_min_threshold,
-            component_size_max_threshold,
+            component_size_min_threshold
+            if component_size_min_threshold is not None
+            else MIN_PNA_COMPONENT_SIZE,
+            component_size_max_threshold
+            if component_size_max_threshold is not None
+            else int(np.iinfo(np.uint32).max),
         )
 
     n_cores = ctx.obj.get("CORES")

--- a/src/pixelator/pna/graph/community_detection.py
+++ b/src/pixelator/pna/graph/community_detection.py
@@ -123,12 +123,15 @@ def map_working_to_original_umi_names(
 def calculate_post_recovery_component_statistics(
     edgelist_with_components_path: Path,
     component_stats: GraphStatistics,
+    discarded_large_components: pl.DataFrame | None = None,
 ) -> GraphStatistics:
     """Calculate and update graph statistics after multiplet recovery.
 
     Args:
         edgelist_with_components_path: Path to the edgelist with components in Parquet format.
         component_stats: Graph statistics to be updated.
+        discarded_large_components: Components already discarded for being above the upper size
+            bound before this point.
 
     Returns:
         GraphStatistics: Updated graph statistics.
@@ -144,17 +147,28 @@ def calculate_post_recovery_component_statistics(
         )
     ).collect()
 
+    all_component_sizes = node_comp_stats.select("n_umi")
+    n_discarded_large_components = 0
+    if discarded_large_components is not None and discarded_large_components.height > 0:
+        n_discarded_large_components = discarded_large_components.height
+        all_component_sizes = pl.concat(
+            [all_component_sizes, discarded_large_components.select("n_umi")],
+            how="vertical",
+        )
+
     component_stats.fraction_nodes_in_largest_component_post_recovery = (
-        node_comp_stats.select(pl.col("n_umi")).max()[0]
-        / node_comp_stats.select(pl.col("n_umi")).sum()[0]
+        all_component_sizes.select(pl.col("n_umi")).max()[0]
+        / all_component_sizes.select(pl.col("n_umi")).sum()[0]
     )[0, 0]
-    component_stats.component_count_post_recovery = node_comp_stats.height
+    component_stats.component_count_post_recovery = (
+        node_comp_stats.height + n_discarded_large_components
+    )
     component_stats.edge_count_post_recovery = node_comp_stats.select(
         pl.sum("n_edges")
     )[0, 0]
-    component_stats.node_count_post_recovery = node_comp_stats.select(pl.sum("n_umi"))[
-        0, 0
-    ]
+    component_stats.node_count_post_recovery = all_component_sizes.select(
+        pl.sum("n_umi")
+    )[0, 0]
 
     return component_stats
 
@@ -580,9 +594,22 @@ def find_components(
         write_hive_partitioned_edgelist_without_out_of_size_bound_components(
             input_edgelist_path=partitioned_edgelist_path,
             min_component_size_to_prune=refinement_options.initial_stage_options.min_component_size_to_prune,
+            max_component_size_to_prune=upper_component_size_bound,
             working_dir=working_dir,
         )
     )
+    discarded_large_components = discard_sizes.filter(
+        pl.col("n_umi") > upper_component_size_bound
+    )
+
+    if not any(hive_partitioned_edgelist_path.iterdir()):
+        msg = (
+            "No connected components found in the graph after filtering by component size. "
+            "Likely all components were filtered away for being too small or too large. "
+            "This indicates some serious issue with the data, or that the configured size "
+            "thresholds are too strict. Will not continue with the rest of the computations."
+        )
+        raise ConnectedComponentException(msg)
 
     latest_working_edgelist_path = hive_partitioned_edgelist_path
 
@@ -606,6 +633,7 @@ def find_components(
         component_stats = calculate_post_recovery_component_statistics(
             edgelist_with_components_path=latest_working_edgelist_path,
             component_stats=component_stats,
+            discarded_large_components=discarded_large_components,
         )
 
     logger.debug("Writing unified edgelist.")

--- a/src/pixelator/pna/graph/community_detection.py
+++ b/src/pixelator/pna/graph/community_detection.py
@@ -12,6 +12,7 @@ from functools import partial
 from pathlib import Path
 
 import networkx as nx
+import numpy as np
 import pandas as pd
 import polars as pl
 from graspologic_native import leiden
@@ -30,7 +31,7 @@ from pixelator.pna.graph.component_recovery_utils import (
     name_components_with_umi_hashes_from_parquet,
     populate_component_stats_from_hybrid_detection,
     remove_clashing_umis,
-    write_hive_partitioned_edgelist_without_small_components,
+    write_hive_partitioned_edgelist_without_out_of_size_bound_components,
 )
 from pixelator.pna.graph.constants import (
     LEIDEN_RANDOM_SEED,
@@ -477,7 +478,7 @@ def find_components(
     refinement_options: StagedRefinementOptions = StagedRefinementOptions(),
     component_size_threshold: bool | tuple[int, int] = (
         MIN_PNA_COMPONENT_SIZE,
-        2**32 - 1,
+        np.iinfo(np.uint64).max,
     ),
     n_threads: int = 1,
 ) -> tuple[GraphStatistics, Path]:
@@ -490,7 +491,7 @@ def find_components(
         edge_cycle_verification: Whether to perform edge cycle verification.
         min_read_count: Minimum read count threshold for an edge to be retained.
         refinement_options: Options for staged refinement during community detection.
-        component_size_threshold: Minimum size threshold for components to be retained.
+        component_size_threshold: Minimum and maximum size threshold for components to be retained.
         n_threads: Number of threads to use for parallel processing.
 
     Returns:
@@ -562,9 +563,21 @@ def find_components(
         post_recovery_stats=post_recovery_stats,
     )
 
-    logger.info("Writing hive partitioned edgelist without small components.")
+    logger.info(
+        "Writing hive partitioned edgelist without out-of-size-bound components."
+    )
+    upper_component_size_bound = (
+        component_size_threshold[1]
+        if isinstance(component_size_threshold, tuple)
+        else np.iinfo(np.uint64).max
+    )
+    logger.info(
+        "Filtering connected components by size: min=%d, max=%d",
+        refinement_options.initial_stage_options.min_component_size_to_prune,
+        upper_component_size_bound,
+    )
     hive_partitioned_edgelist_path, discard_sizes = (
-        write_hive_partitioned_edgelist_without_small_components(
+        write_hive_partitioned_edgelist_without_out_of_size_bound_components(
             input_edgelist_path=partitioned_edgelist_path,
             min_component_size_to_prune=refinement_options.initial_stage_options.min_component_size_to_prune,
             working_dir=working_dir,

--- a/src/pixelator/pna/graph/community_detection.py
+++ b/src/pixelator/pna/graph/community_detection.py
@@ -582,7 +582,10 @@ def find_components(
     )
     upper_component_size_bound = (
         component_size_threshold[1]
-        if isinstance(component_size_threshold, tuple)
+        if (
+            isinstance(component_size_threshold, tuple)
+            and component_size_threshold[1] is not None
+        )
         else np.iinfo(np.uint64).max
     )
     logger.info(

--- a/src/pixelator/pna/graph/community_detection.py
+++ b/src/pixelator/pna/graph/community_detection.py
@@ -147,12 +147,15 @@ def calculate_post_recovery_component_statistics(
         )
     ).collect()
 
-    all_component_sizes = node_comp_stats.select("n_umi")
+    all_component_sizes = node_comp_stats.select(["n_umi", "n_edges"])
     n_discarded_large_components = 0
     if discarded_large_components is not None and discarded_large_components.height > 0:
         n_discarded_large_components = discarded_large_components.height
         all_component_sizes = pl.concat(
-            [all_component_sizes, discarded_large_components.select("n_umi")],
+            [
+                all_component_sizes,
+                discarded_large_components.select(["n_umi", "n_edges"]),
+            ],
             how="vertical",
         )
 
@@ -163,7 +166,7 @@ def calculate_post_recovery_component_statistics(
     component_stats.component_count_post_recovery = (
         node_comp_stats.height + n_discarded_large_components
     )
-    component_stats.edge_count_post_recovery = node_comp_stats.select(
+    component_stats.edge_count_post_recovery = all_component_sizes.select(
         pl.sum("n_edges")
     )[0, 0]
     component_stats.node_count_post_recovery = all_component_sizes.select(
@@ -628,7 +631,9 @@ def find_components(
                 component_stats=component_stats,
                 max_workers=n_threads,
             )
-            discard_sizes = pl.concat((discard_sizes, new_discarded_sizes))
+            discard_sizes = pl.concat(
+                (discard_sizes.select(["component", "n_umi"]), new_discarded_sizes)
+            )
             logger.info(
                 f"Refinement stages completed in {time.time() - time_start:.2f} seconds."
             )

--- a/src/pixelator/pna/graph/component_recovery_utils.py
+++ b/src/pixelator/pna/graph/component_recovery_utils.py
@@ -228,12 +228,13 @@ def write_hive_partitioned_edgelist_without_out_of_size_bound_components(
                     CAST(
                         COUNT(DISTINCT umi1) + COUNT(DISTINCT umi2)
                         AS UINT32
-                    ) AS n_umi
+                    ) AS n_umi,
+                    COUNT(*) AS n_edges
                 FROM parquet_scan('{str(input_edgelist_path)}')
                 GROUP BY component;
 
             CREATE TABLE discarded_components AS
-                SELECT component, n_umi
+                SELECT component, n_umi, n_edges
                 FROM component_counts
                 WHERE n_umi < {min_sz} OR n_umi > {max_sz};
 

--- a/src/pixelator/pna/graph/component_recovery_utils.py
+++ b/src/pixelator/pna/graph/component_recovery_utils.py
@@ -194,12 +194,13 @@ def get_count_statistics(edgelist_path: Path) -> dict:
     }
 
 
-def write_hive_partitioned_edgelist_without_small_components(
+def write_hive_partitioned_edgelist_without_out_of_size_bound_components(
     input_edgelist_path: Path,
     min_component_size_to_prune: int,
+    max_component_size_to_prune: int = np.iinfo(np.uint64).max,
     working_dir: Path = DEFAULT_WORKING_DIR,
 ) -> tuple[Path, pl.DataFrame]:
-    """Remove components below a UMI score threshold and write a hive-partitioned edgelist.
+    """Remove components outside the specified size bounds and write a hive-partitioned edgelist..
 
     The per-component score matches hybrid community detection:
     ``COUNT(DISTINCT umi1) + COUNT(DISTINCT umi2)``. Rows from components that pass the
@@ -207,7 +208,8 @@ def write_hive_partitioned_edgelist_without_small_components(
 
     Args:
         input_edgelist_path: Parquet file with component assignments (e.g. after hybrid detection).
-        min_component_size_to_prune: Components with a score strictly below this are dropped.
+        min_component_size_to_prune: Components with number of UMIs strictly below this are dropped.
+        max_component_size_to_prune: Components with number of UMIs strictly above this are dropped.
         working_dir: Directory for a temporary DuckDB file and the hive-partition output. Defaults
             to ``DEFAULT_WORKING_DIR`` (``/tmp``).
 
@@ -216,7 +218,8 @@ def write_hive_partitioned_edgelist_without_small_components(
     """
     hive_partitioned_edgelist_path = working_dir / "hive_partitioned_edgelist.parquet"
     min_sz = int(min_component_size_to_prune)
-    logger.debug("Filtering out small components from edge list")
+    max_sz = int(max_component_size_to_prune)
+    logger.debug("Filtering out components outside size bounds from edge list")
     with connect_duckdb(working_dir / "temp_hivepartition.duckdb") as conn:
         conn.execute(f"""
             CREATE TEMP TABLE component_counts AS
@@ -232,13 +235,13 @@ def write_hive_partitioned_edgelist_without_small_components(
             CREATE TABLE discarded_components AS
                 SELECT component, n_umi
                 FROM component_counts
-                WHERE n_umi < {min_sz};
+                WHERE n_umi < {min_sz} OR n_umi > {max_sz};
 
             CREATE TABLE edgelist AS
                 SELECT e.*
                 FROM parquet_scan('{str(input_edgelist_path)}') e
                 JOIN component_counts c ON e.component = c.component
-                WHERE c.n_umi >= {min_sz}
+                WHERE c.n_umi >= {min_sz} AND c.n_umi <= {max_sz}
                 ORDER BY e.component;
 
             COPY edgelist TO '{str(hive_partitioned_edgelist_path)}'

--- a/tests/pna/graph/test_community_detection.py
+++ b/tests/pna/graph/test_community_detection.py
@@ -57,6 +57,7 @@ def test_calculate_post_recovery_component_statistics_includes_discarded_large_c
         {
             "component": ["huge"],
             "n_umi": pl.Series([1000], dtype=pl.UInt32),
+            "n_edges": pl.Series([5000], dtype=pl.UInt32),
         }
     )
     with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:

--- a/tests/pna/graph/test_community_detection.py
+++ b/tests/pna/graph/test_community_detection.py
@@ -43,6 +43,39 @@ def test_calculate_post_recovery_component_statistics():
     assert out.fraction_nodes_in_largest_component_post_recovery == pytest.approx(3 / 5)
 
 
+def test_calculate_post_recovery_component_statistics_includes_discarded_large_components():
+    """Components discarded early for being too large still count toward "largest component"."""
+    edgelist = pl.DataFrame(
+        {
+            "umi1": [1, 1, 100],
+            "umi2": [10, 11, 200],
+            "component": ["A", "A", "B"],
+        }
+    )
+    # Discarded upstream for being too large; its edges are gone, only its size is known.
+    discarded_large_components = pl.DataFrame(
+        {
+            "component": ["huge"],
+            "n_umi": pl.Series([1000], dtype=pl.UInt32),
+        }
+    )
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+        path = Path(f.name)
+    try:
+        edgelist.write_parquet(path)
+        stats = GraphStatistics()
+        out = calculate_post_recovery_component_statistics(
+            path, stats, discarded_large_components=discarded_large_components
+        )
+    finally:
+        path.unlink(missing_ok=True)
+
+    assert out.component_count_post_recovery == 3
+    assert out.fraction_nodes_in_largest_component_post_recovery == pytest.approx(
+        1000 / 1005
+    )
+
+
 def test_map_working_to_original_umi_names(tmp_path: Path) -> None:
     """Working UMI names in umi1 and umi2 are replaced with original names."""
     node_map_path = tmp_path / "node_map.parquet"

--- a/tests/pna/graph/test_component_recovery_pipeline.py
+++ b/tests/pna/graph/test_component_recovery_pipeline.py
@@ -202,6 +202,44 @@ def test_find_components_small(
         )
 
 
+def test_find_components_raises_when_every_component_is_too_large(random_graph_path):
+    """A hard max threshold below every component's size raises cleanly instead of crashing.
+
+    Every cluster in the fixture has 100+ nodes, so a max threshold of 50 discards all of them
+    in the early filter. This must surface as a clear ``ConnectedComponentException`` (matching
+    the existing "everything too small" case), not an unrelated crash further down the pipeline
+    (e.g. a division by zero while computing the now-empty "largest component" fraction, or a
+    failure to read an emptied-out hive-partitioned edgelist).
+
+    Args:
+        random_graph_path: random graph path.
+    """
+    staged_refinement_options = StagedRefinementOptions(
+        initial_stage_options=RefinementOptions(
+            leiden_resolution=1.0,
+            min_component_size_to_prune=10,
+        ),
+        refinement_stage_options=RefinementOptions(
+            leiden_resolution=0.01,
+        ),
+        max_component_refinement_depth=3,
+    )
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        working_dir = Path(temp_dir)
+        with pytest.raises(ConnectedComponentException):
+            find_components(
+                input_edgelist_path=Path(random_graph_path),
+                working_dir=working_dir,
+                multiplet_recovery=True,
+                edge_cycle_verification=False,
+                min_read_count=1,
+                component_size_threshold=(10, 50),
+                n_threads=10,
+                refinement_options=staged_refinement_options,
+            )
+
+
 def test_find_no_components(random_graph_path):
     """Verify find no components.
 

--- a/tests/pna/graph/test_component_recovery_utils.py
+++ b/tests/pna/graph/test_component_recovery_utils.py
@@ -10,7 +10,7 @@ from pixelator.pna.graph.component_recovery_utils import (
     get_count_statistics,
     name_components_with_umi_hashes,
     name_components_with_umi_hashes_from_parquet,
-    write_hive_partitioned_edgelist_without_small_components,
+    write_hive_partitioned_edgelist_without_out_of_size_bound_components,
 )
 from pixelator.pna.graph.report import GraphStatistics
 
@@ -41,7 +41,7 @@ def test_get_count_statistics(tmp_path: Path) -> None:
     }
 
 
-def test_write_hive_partitioned_edgelist_without_small_components_prunes(
+def test_write_hive_partitioned_edgelist_without_out_of_size_bound_components_prunes(
     tmp_path: Path,
 ) -> None:
     """Test components below the UMI score threshold are omitted and listed as discarded.
@@ -58,10 +58,12 @@ def test_write_hive_partitioned_edgelist_without_small_components_prunes(
         }
     ).write_parquet(partitioned)
 
-    out_path, discarded = write_hive_partitioned_edgelist_without_small_components(
-        input_edgelist_path=partitioned,
-        min_component_size_to_prune=3,
-        working_dir=tmp_path,
+    out_path, discarded = (
+        write_hive_partitioned_edgelist_without_out_of_size_bound_components(
+            input_edgelist_path=partitioned,
+            min_component_size_to_prune=3,
+            working_dir=tmp_path,
+        )
     )
 
     assert out_path == tmp_path / "hive_partitioned_edgelist.parquet"
@@ -74,7 +76,7 @@ def test_write_hive_partitioned_edgelist_without_small_components_prunes(
     assert discarded_sorted["n_umi"].to_list() == [2]
 
 
-def test_write_hive_partitioned_edgelist_without_small_components_nothing_discarded(
+def test_write_hive_partitioned_edgelist_without_out_of_size_bound_components_nothing_discarded(
     tmp_path: Path,
 ) -> None:
     """When every component meets the threshold, discarded frame is empty and all rows are kept.
@@ -91,7 +93,7 @@ def test_write_hive_partitioned_edgelist_without_small_components_nothing_discar
         }
     ).write_parquet(partitioned)
 
-    _, discarded = write_hive_partitioned_edgelist_without_small_components(
+    _, discarded = write_hive_partitioned_edgelist_without_out_of_size_bound_components(
         input_edgelist_path=partitioned,
         min_component_size_to_prune=2,
         working_dir=tmp_path,

--- a/tests/pna/graph/test_component_recovery_utils.py
+++ b/tests/pna/graph/test_component_recovery_utils.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import polars as pl
+import pytest
 
 from pixelator.pna.graph.component_recovery_utils import (
     create_component_size_data_frame,
@@ -76,6 +77,67 @@ def test_write_hive_partitioned_edgelist_without_out_of_size_bound_components_pr
     assert discarded_sorted["n_umi"].to_list() == [2]
 
 
+def test_write_hive_partitioned_edgelist_without_out_of_size_bound_components_prunes_large(
+    tmp_path: Path,
+) -> None:
+    """Components above the max UMI threshold are omitted and listed as discarded."""
+    partitioned = tmp_path / "partitioned_edgelist.parquet"
+    pl.DataFrame(
+        {
+            "component": ["at_max", "at_max", "over_max", "over_max"],
+            "umi1": ["a", "a", "w", "y"],
+            "umi2": ["b", "c", "x", "z"],
+        }
+    ).write_parquet(partitioned)
+
+    out_path, discarded = (
+        write_hive_partitioned_edgelist_without_out_of_size_bound_components(
+            input_edgelist_path=partitioned,
+            min_component_size_to_prune=0,
+            max_component_size_to_prune=3,
+            working_dir=tmp_path,
+        )
+    )
+
+    kept = pl.scan_parquet(out_path, hive_schema={"component": pl.String}).collect()
+    assert kept["component"].unique().to_list() == ["at_max"]
+    assert kept.height == 2
+
+    discarded_sorted = discarded.sort("component")
+    assert discarded_sorted["component"].to_list() == ["over_max"]
+    assert discarded_sorted["n_umi"].to_list() == [4]
+
+
+def test_write_hive_partitioned_edgelist_without_out_of_size_bound_components_prunes_both_directions(
+    tmp_path: Path,
+) -> None:
+    partitioned = tmp_path / "partitioned_edgelist.parquet"
+    pl.DataFrame(
+        {
+            "component": ["too_small", "keep", "keep", "too_large", "too_large"],
+            "umi1": ["a", "c", "c", "w", "y"],
+            "umi2": ["b", "d", "e", "x", "z"],
+        }
+    ).write_parquet(partitioned)
+
+    out_path, discarded = (
+        write_hive_partitioned_edgelist_without_out_of_size_bound_components(
+            input_edgelist_path=partitioned,
+            min_component_size_to_prune=3,
+            max_component_size_to_prune=3,
+            working_dir=tmp_path,
+        )
+    )
+
+    kept = pl.scan_parquet(out_path, hive_schema={"component": pl.String}).collect()
+    assert kept["component"].unique().to_list() == ["keep"]
+    assert kept.height == 2
+
+    discarded_sorted = discarded.sort("component")
+    assert discarded_sorted["component"].to_list() == ["too_large", "too_small"]
+    assert discarded_sorted["n_umi"].to_list() == [4, 2]
+
+
 def test_write_hive_partitioned_edgelist_without_out_of_size_bound_components_nothing_discarded(
     tmp_path: Path,
 ) -> None:
@@ -142,6 +204,50 @@ def test_filter_connected_components_by_size_hard_thresholds(tmp_path: Path) -> 
     assert stats.component_size_min_filtering_threshold == 3
     assert stats.component_size_max_filtering_threshold == 4
     assert stats.pre_filtering_component_sizes == {2: 1, 3: 1, 4: 1}
+
+
+def test_filter_connected_components_by_size_includes_early_discards_in_pre_filtering_stats(
+    tmp_path: Path,
+) -> None:
+    """Components discarded early (e.g. for being too large) still count in the "pre filtering" stats."""
+    input_path = tmp_path / "component_filter_input.parquet"
+    pl.DataFrame(
+        {
+            "component": ["a", "a", "b", "c", "c"],
+            "umi1": ["u1", "u3", "v1", "w1", "w1"],
+            "umi2": ["u2", "u4", "v2", "w2", "w3"],
+        }
+    ).write_parquet(input_path)
+    discard_sizes = pl.DataFrame(
+        {
+            "component": ["huge"],
+            "n_umi": pl.Series([10], dtype=pl.UInt32),
+        }
+    )
+    component_stats = GraphStatistics()
+
+    filtered_edgelist_path, stats = filter_connected_components_by_size(
+        input_edgelist_path=input_path,
+        component_size_threshold=(3, 4),
+        discard_sizes=discard_sizes,
+        component_stats=component_stats,
+        working_dir=tmp_path,
+    )
+
+    filtered = pl.scan_parquet(
+        filtered_edgelist_path, hive_schema={"component": pl.String}
+    ).collect()
+
+    assert set(filtered["component"].unique().to_list()) == {"a", "c"}
+    assert stats.component_count_pre_component_size_filtering == 4
+    assert stats.component_count_post_component_size_filtering == 2
+    assert stats.pre_filtering_component_sizes == {2: 1, 3: 1, 4: 1, 10: 1}
+    fraction_of_discarded_components = (
+        1
+        - stats.component_count_post_component_size_filtering
+        / stats.component_count_pre_component_size_filtering
+    )
+    assert fraction_of_discarded_components == pytest.approx(1 - 2 / 4)
 
 
 def test_create_component_size_data_frame_computes_sizes_per_component(


### PR DESCRIPTION
To avoid excessive memory useage in graph refinement, if a component is bigger than the threshold specified with `--component-size-max-threshold` it will be discarded already after the first Leiden iteration (a.k.a megacluster recovery).

Fixes: PNA-3191

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

New unit tests to verify that large components are discarded when a threshold is specified.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core PNA graph pipeline ordering and size filtering behavior when fixed thresholds are used; misconfigured min/max could drop valid cells, but behavior is covered by new tests and explicit errors.
> 
> **Overview**
> **`single-cell-pna graph`** now drops components above **`--component-size-max-threshold`** right after the initial hybrid (FLP + Leiden) step and **before** multiplet refinement, so huge clusters are not loaded through Leiden refinement (lower peak memory when a max threshold is set).
> 
> Size filtering is generalized: the hive-partition writer applies **min and max** UMI bounds (renamed helper), the CLI fills in the missing bound when only min or max is set, and an **empty graph after size filtering** raises **`ConnectedComponentException`** with a clear message instead of failing later in DuckDB.
> 
> **Reporting** counts early-discarded oversized components in post-recovery “largest component” metrics and in pre–size-filter stats when those components never appear in the retained edgelist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5399b45334c0194987521ea230831979aa26421. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->