### PR TITLE
fix n_edges type inconsistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - The graph stage now raises an error instead of an internal DuckDB crash when a component-size threshold discards every component in the input.
+- `single-cell-pna graph` no longer crashes with a `polars.exceptions.SchemaError` on `n_edges` (`Int64` vs `UInt32`) when calculating post-recovery component statistics with `--multiplet-recovery` and a `--component-size-max-threshold` that discards large components.
 
 ## [0.29.0] - 2026-06-15
 

--- a/src/pixelator/pna/graph/component_recovery_utils.py
+++ b/src/pixelator/pna/graph/component_recovery_utils.py
@@ -229,7 +229,7 @@ def write_hive_partitioned_edgelist_without_out_of_size_bound_components(
                         COUNT(DISTINCT umi1) + COUNT(DISTINCT umi2)
                         AS UINT32
                     ) AS n_umi,
-                    COUNT(*) AS n_edges
+                    CAST(COUNT(*) AS UINT32) AS n_edges
                 FROM parquet_scan('{str(input_edgelist_path)}')
                 GROUP BY component;
 

--- a/tests/pna/graph/test_community_detection.py
+++ b/tests/pna/graph/test_community_detection.py
@@ -13,6 +13,9 @@ from pixelator.pna.graph.community_detection import (
     map_working_to_original_umi_names,
     run_leiden_refinement,
 )
+from pixelator.pna.graph.component_recovery_utils import (
+    write_hive_partitioned_edgelist_without_out_of_size_bound_components,
+)
 from pixelator.pna.graph.report import GraphStatistics
 from pixelator.pna.utils.duckdb_utils import DuckdbPerThreadMemoryError
 
@@ -75,6 +78,52 @@ def test_calculate_post_recovery_component_statistics_includes_discarded_large_c
     assert out.fraction_nodes_in_largest_component_post_recovery == pytest.approx(
         1000 / 1005
     )
+
+
+def test_calculate_post_recovery_component_statistics_with_real_discarded_frame(
+    tmp_path: Path,
+):
+    """The discarded-components frame produced upstream must concat with n_edges from pl.len().
+
+    Regression test for a schema mismatch (Int64 vs UInt32) between the two `n_edges`
+    columns being concatenated.
+    """
+    edgelist = pl.DataFrame(
+        {
+            "umi1": [1, 1, 100],
+            "umi2": [10, 11, 200],
+            "component": ["A", "A", "B"],
+        }
+    )
+    kept_path = tmp_path / "edgelist.parquet"
+    edgelist.write_parquet(kept_path)
+
+    # A component large enough to be pruned upstream, producing the real
+    # discarded-components frame (as returned by community detection).
+    partitioned = tmp_path / "partitioned_edgelist.parquet"
+    pl.DataFrame(
+        {
+            "component": ["huge", "huge"],
+            "umi1": ["a", "c"],
+            "umi2": ["b", "d"],
+        }
+    ).write_parquet(partitioned)
+    _, discarded_large_components = (
+        write_hive_partitioned_edgelist_without_out_of_size_bound_components(
+            input_edgelist_path=partitioned,
+            min_component_size_to_prune=0,
+            max_component_size_to_prune=3,
+            working_dir=tmp_path,
+        )
+    )
+
+    stats = GraphStatistics()
+    out = calculate_post_recovery_component_statistics(
+        kept_path, stats, discarded_large_components=discarded_large_components
+    )
+
+    assert out.component_count_post_recovery == 3
+    assert out.edge_count_post_recovery == 5
 
 
 def test_map_working_to_original_umi_names(tmp_path: Path) -> None:

--- a/tests/pna/graph/test_component_recovery_utils.py
+++ b/tests/pna/graph/test_component_recovery_utils.py
@@ -75,6 +75,8 @@ def test_write_hive_partitioned_edgelist_without_out_of_size_bound_components_pr
     discarded_sorted = discarded.sort("component")
     assert discarded_sorted["component"].to_list() == ["drop"]
     assert discarded_sorted["n_umi"].to_list() == [2]
+    assert discarded_sorted.schema["n_umi"] == pl.UInt32
+    assert discarded_sorted.schema["n_edges"] == pl.UInt32
 
 
 def test_write_hive_partitioned_edgelist_without_out_of_size_bound_components_prunes_large(


### PR DESCRIPTION
n_edges parameter used for graph statistics reports has an inconsitent type (UInt32 and Int64), this is to ensure that we always use UInt32.

Fixes: Tech-445

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added assertion of the data type in the corresponding unit test and added test_calculate_post_recovery_component_statistics_with_real_discarded_frame to ensure that this won't regress.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow dtype fix in graph statistics with added regression tests; no auth, data model, or API surface changes.
> 
> **Overview**
> Fixes a **`polars.exceptions.SchemaError`** when `single-cell-pna graph` computes post-recovery component stats with **`--multiplet-recovery`** and a **`--component-size-max-threshold`** that drops large components upstream.
> 
> **`write_hive_partitioned_edgelist_without_out_of_size_bound_components`** now casts **`n_edges`** to **`UInt32`** in the DuckDB `component_counts` query (same as **`n_umi`**), so the discarded-components frame matches the **`n_edges`** dtype from post-recovery stats and Polars can concat them safely.
> 
> Tests assert **`UInt32`** on discarded frames and add a regression test that runs **`calculate_post_recovery_component_statistics`** with a real upstream discarded frame. **CHANGELOG** documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b3bb28309c7cdbc393693a3ac1c42511eff0a0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->