### PR TITLE
Spectral layout – base implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Setup for generating API documentation pages from source files, and a workflow for building and deploying the docs automatically.
 - `PNAAssay` and `PNAAntibodyPanel` now hold an optional path to the path they were parsed from.
 - `pixelator.common.plot` with Pixelgen's brand colors, gradients, palettes, and theme (`PIXELGEN_ACCENT_COLORS`, `PIXELGEN_CELL_PALETTE`, `pixelgen_gradient`, `pixelgen_palette`, `pixelgen_accent_colors`, `pixelgen_discrete_colors`, `create_discrete_palette`, `pixelgen_colorscale`/`pixelgen_sequential_colormap`/`pixelgen_divergent_colormap`/`pixelgen_colormap`, `set_pixelgen_theme`/`pixelgen_theme`, `style_facet_strips`), ported from the internal `themes_and_palettes.R` ggplot2 helpers.
+- Spectral layout algorithm
 
 ### Changed
 - The default `min_allowed_nodes_pct` in `adaptive_core_expansion` has been changed from 0.8 to 0.9, meaning that a valid "high" core partition must include at least 90% of all nodes. Components that don't meet this criteria will not be denoised by ACE.

--- a/src/pixelator/common/graph/backends/implementations/_networkx.py
+++ b/src/pixelator/common/graph/backends/implementations/_networkx.py
@@ -1055,27 +1055,41 @@ def coarsened_pmds_layout(
 
 def _spectral_layout_eigen(g, nodes, dim, normalize, seed):
     """Compute the spectral layout coordinates by eigendecomposition of the 
-    (optionally degree-normalized) graph Laplacian"""
+    (optionally) symmetrically normalized graph Laplacian"""
 
     # Get the (sparse) adjacency matrix A
     A = nx.to_scipy_sparse_array(g, nodelist=nodes, weight=None, format="csr")
 
     # Build the Laplacian
-    L = sp.sparse.csgraph.laplacian(A)
+    if normalize:
+        # Symmetrically normalized Laplacian: L_sym = D^(-1/2) L D^(-1/2)
+        L = sp.sparse.csgraph.laplacian(A, normed=True)
 
+        # Diagonal inverse square root degree matrix
+        degrees = np.asarray(A.sum(axis=1)).ravel()
+        diag_inv_sqrt = sp.sparse.diags(1.0 / np.sqrt(degrees))
+    else:
+        # Non-normalized Laplacian
+        L = sp.sparse.csgraph.laplacian(A, normed=False)
+    
     # Compute eigenpairs (k=dim + 1 to account for trivial 0-eigenvalue)
     vals, vecs = sp.sparse.linalg.eigsh(L, k=dim + 1, which="SM")
 
-    # Return coordinates
+    # Exclude trivial eigenvector
     order = np.argsort(vals)
-    raw_coordinates = vecs[:, order[1 : dim + 1]]
+    selection = order[1 : dim + 1]
+    raw_coordinates = vecs[:, selection]
+
+    if normalize:
+        # De-normalize
+        raw_coordinates = diag_inv_sqrt @ raw_coordinates
 
     return raw_coordinates
 
 
 def _spectral_layout_psvd(g, nodes, dim, normalize, seed):
     """Compute the spectral layout coordinates by partial singular value decomposition 
-    of the (optionally degree-normalized) biadjacency matrix."""
+    of the degree-normalized biadjacency matrix."""
 
     # Identify and order node sets, check partitioning
     pixel_type = nx.get_node_attributes(g, "pixel_type")
@@ -1137,7 +1151,7 @@ def _spectral_layout_psvd(g, nodes, dim, normalize, seed):
 def spectral_layout(
     g: nx.Graph,
     dim: Literal[2, 3] = 3,
-    normalize: bool = False,
+    normalize: bool = True,
     seed: Optional[int] = None,
     method: Literal["eigen", "psvd"] = "psvd",
 ):
@@ -1153,16 +1167,16 @@ def spectral_layout(
     nodes = list(g.nodes)
 
     # Determine method and compute raw coordinates
-    if method == "eigen":
-        raw_coordinates = _spectral_layout_eigen(
+    if method == "psvd":
+        raw_coordinates = _spectral_layout_psvd(
             g,
             nodes=nodes,
             dim=dim,
             normalize=normalize,
             seed=seed,
         )
-    elif method == "psvd":
-        raw_coordinates = _spectral_layout_psvd(
+    elif method == "eigen":
+        raw_coordinates = _spectral_layout_eigen(
             g,
             nodes=nodes,
             dim=dim,
@@ -1171,7 +1185,6 @@ def spectral_layout(
         )
 
     # Return normalized coordinates
-    # (Note that this step is unrelated to the parameter "normalize")
     coordinates = normalize_layout_coordinates(raw_coordinates)
 
     return {nodes[i]: coordinates[i,  :] for i in range(len(nodes))}

--- a/src/pixelator/common/graph/backends/implementations/_networkx.py
+++ b/src/pixelator/common/graph/backends/implementations/_networkx.py
@@ -401,6 +401,7 @@ class NetworkXGraphBackend(GraphBackend):
         - pmds
         - pmds_3d
         - wpmds_3d
+        - spectral_3d
 
         For most cases the `coarsened_pmds_3d`, `wpmds_3d`, and `pmds` options should be
         preferred. On PNA data they are faster and produce better results.
@@ -1054,9 +1055,9 @@ def coarsened_pmds_layout(
 
 
 def _spectral_layout_eigen(g, nodes, dim, normalize, seed):
-    """Compute the spectral layout coordinates by eigendecomposition of the 
-    (optionally) symmetrically normalized graph Laplacian"""
-
+    """Compute the spectral layout coordinates by eigendecomposition of the
+    (optionally) symmetrically normalized graph Laplacian
+    """
     # Get the (sparse) adjacency matrix A
     A = nx.to_scipy_sparse_array(g, nodelist=nodes, weight=None, format="csr")
 
@@ -1092,9 +1093,9 @@ def _spectral_layout_eigen(g, nodes, dim, normalize, seed):
 
 
 def _spectral_layout_psvd(g, nodes, dim, normalize, seed):
-    """Compute the spectral layout coordinates by partial singular value decomposition 
-    of the degree-normalized biadjacency matrix."""
-
+    """Compute the spectral layout coordinates by partial singular value decomposition
+    of the degree-normalized biadjacency matrix.
+    """
     # Identify and order node sets, check partitioning
     pixel_type = nx.get_node_attributes(g, "pixel_type")
     nodes_u = [node for node in nodes if pixel_type.get(node) == "A"]
@@ -1164,7 +1165,6 @@ def spectral_layout(
     method: Literal["eigen", "psvd"] = "psvd",
 ):
     """Use a spectral layout algorithm to compute coordinates from a graph."""
-
     # Validate inputs
     if g.is_directed():
         raise ValueError("g must be an undirected graph.")

--- a/src/pixelator/common/graph/backends/implementations/_networkx.py
+++ b/src/pixelator/common/graph/backends/implementations/_networkx.py
@@ -1072,8 +1072,12 @@ def _spectral_layout_eigen(g, nodes, dim, normalize, seed):
         # Non-normalized Laplacian
         L = sp.sparse.csgraph.laplacian(A, normed=False)
     
+    # Build starting vector from seed
+    rng = np.random.default_rng(seed)
+    v0 = rng.standard_normal(L.shape[0])
+    
     # Compute eigenpairs (k=dim + 1 to account for trivial 0-eigenvalue)
-    vals, vecs = sp.sparse.linalg.eigsh(L, k=dim + 1, which="SM")
+    vals, vecs = sp.sparse.linalg.eigsh(L, k=dim + 1, which="SM", v0=v0, tol=0)
 
     # Exclude trivial eigenvector
     order = np.argsort(vals)
@@ -1122,10 +1126,14 @@ def _spectral_layout_psvd(g, nodes, dim, normalize, seed):
         @ B
         @ diag_inv_sqrt_v
     )
+    
+    # Get starting vector from seed
+    rng = np.random.default_rng(seed)
+    v0 = rng.standard_normal(min(B_norm.shape))
 
     # Do partial singular value decomposition
     # (k=dim + 1 to account for trivial 0-eigenvalue)
-    vecs_u, s, vecs_v_t = sp.sparse.linalg.svds(B_norm, k=dim + 1, random_state=seed)
+    vecs_u, s, vecs_v_t = sp.sparse.linalg.svds(B_norm, k=dim + 1, v0=v0, tol=0)
 
     # Sort by descending and exclude trivial value, transpose
     selection = np.argsort(s)[::-1][1 : dim + 1]
@@ -1162,6 +1170,12 @@ def spectral_layout(
         raise ValueError("g must be an undirected graph.")
     if not nx.is_connected(g):
         raise ValueError("g must be connected.")
+    if method == "psvd" and not normalize:
+        raise ValueError(
+            "normalize=False is not supported for method='psvd'. "
+            "Use normalize=True or switch to method='eigen' "
+            "and keep normalize=False for non-normalized."
+        )
 
     # Get nodes
     nodes = list(g.nodes)

--- a/src/pixelator/common/graph/backends/implementations/_networkx.py
+++ b/src/pixelator/common/graph/backends/implementations/_networkx.py
@@ -334,7 +334,7 @@ class NetworkXGraphBackend(GraphBackend):
         if layout_algorithm == "coarsened_pmds_3d":
             layout_inst = coarsened_pmds_layout(raw, seed=random_seed, **kwargs)
         if layout_algorithm == "spectral_3d":
-            layout_inst = spectral_layout(raw)
+            layout_inst = spectral_layout(raw, seed=random_seed, **kwargs)
 
         coordinates = pd.DataFrame.from_dict(
             layout_inst,
@@ -1053,38 +1053,125 @@ def coarsened_pmds_layout(
     return {nodes[i]: xyz_full[i] for i in range(n_nodes)}
 
 
+def _spectral_layout_eigen(g, nodes, dim, normalize, seed):
+    """Compute the spectral layout coordinates by eigendecomposition of the 
+    (optionally degree-normalized) graph Laplacian"""
+
+    # Get the (sparse) adjacency matrix A
+    A = nx.to_scipy_sparse_array(g, nodelist=nodes, weight=None, format="csr")
+
+    # Build the Laplacian
+    L = sp.sparse.csgraph.laplacian(A)
+
+    # Compute eigenpairs (k=dim + 1 to account for trivial 0-eigenvalue)
+    vals, vecs = sp.sparse.linalg.eigsh(L, k=dim + 1, which="SM")
+
+    # Return coordinates
+    order = np.argsort(vals)
+    raw_coordinates = vecs[:, order[1 : dim + 1]]
+
+    return raw_coordinates
+
+
+def _spectral_layout_psvd(g, nodes, dim, normalize, seed):
+    """Compute the spectral layout coordinates by partial singular value decomposition 
+    of the (optionally degree-normalized) biadjacency matrix."""
+
+    # Identify and order node sets, check partitioning
+    pixel_type = nx.get_node_attributes(g, "pixel_type")
+    nodes_u = [node for node in nodes if pixel_type.get(node) == "A"]
+    nodes_v = [node for node in nodes if pixel_type.get(node) == "B"]
+
+    if len(nodes_u) + len(nodes_v) != len(nodes):
+        raise ValueError(
+            "The 'psvd' spectral method requires a bipartite graph whose "
+            "nodes are partitioned exactly into 'A' and 'B' via the "
+            "'pixel_type' attribute."
+        )
+
+    # Compute the biadjacency matrix
+    B = nx_bipartite.biadjacency_matrix(
+        g, row_order=nodes_u, column_order=nodes_v, weight=None, format="csr"
+    )
+
+    # Get node degrees by summing in the biadjacency matrix
+    degrees_u = np.asarray(B.sum(axis=1)).ravel()
+    degrees_v = np.asarray(B.sum(axis=0)).ravel()
+
+    # Define the inverse square root diagonal matrices
+    diag_inv_sqrt_u = sp.sparse.diags(1.0 / np.sqrt(degrees_u))
+    diag_inv_sqrt_v = sp.sparse.diags(1.0 / np.sqrt(degrees_v))
+
+    # Compute the normalized biadjacency matrix
+    B_norm = (
+        diag_inv_sqrt_u
+        @ B
+        @ diag_inv_sqrt_v
+    )
+
+    # Do partial singular value decomposition
+    # (k=dim + 1 to account for trivial 0-eigenvalue)
+    vecs_u, s, vecs_v_t = sp.sparse.linalg.svds(B_norm, k=dim + 1, random_state=seed)
+
+    # Sort by descending and exclude trivial value, transpose
+    selection = np.argsort(s)[::-1][1 : dim + 1]
+
+    vecs_v = vecs_v_t.T
+
+    # De-normalize (random-walk rescale)
+    raw_coords_u = diag_inv_sqrt_u @ vecs_u[:, selection]
+    raw_coords_v = diag_inv_sqrt_v @ vecs_v[:, selection]
+
+    # Return coordinates by initial node order
+    raw_coords_unord = np.concatenate([raw_coords_u, raw_coords_v], axis=0)
+
+    nodes_uv = nodes_u + nodes_v
+    position = {node: i for i, node in enumerate(nodes_uv)}
+    order = [position[node] for node in nodes]
+
+    raw_coordinates = raw_coords_unord[order]
+
+    return raw_coordinates
+
+
 def spectral_layout(
     g: nx.Graph,
     dim: Literal[2, 3] = 3,
     normalize: bool = False,
-    tolerance: float=0,
+    seed: Optional[int] = None,
+    method: Literal["eigen", "psvd"] = "psvd",
 ):
     """Use a spectral layout algorithm to compute coordinates from a graph."""
 
-    # validate input
+    # Validate inputs
     if g.is_directed():
         raise ValueError("g must be an undirected graph.")
     if not nx.is_connected(g):
         raise ValueError("g must be connected.")
 
-    if dim not in (2, 3):
-        raise ValueError("dim must be an integer that's either 2 or 3.")
-
-    # get node-list and define the (sparse) adjacency matrix A
+    # Get nodes
     nodes = list(g.nodes)
-    A = nx.to_scipy_sparse_array(g, nodelist=nodes, weight=None, format="csr")
 
-    # build the Laplacian
-    L = sp.sparse.csgraph.laplacian(A)
+    # Determine method and compute raw coordinates
+    if method == "eigen":
+        raw_coordinates = _spectral_layout_eigen(
+            g,
+            nodes=nodes,
+            dim=dim,
+            normalize=normalize,
+            seed=seed,
+        )
+    elif method == "psvd":
+        raw_coordinates = _spectral_layout_psvd(
+            g,
+            nodes=nodes,
+            dim=dim,
+            normalize=normalize,
+            seed=seed,
+        )
 
-    # compute eigenpairs (k=dim + 1 to account for trivial 0-eigenvalue)
-    vals, vecs = sp.sparse.linalg.eigsh(L, k=dim + 1, which="SM", tol=tolerance)
-
-    # get coordinates
-    order = np.argsort(vals)
-    raw_coordinates = vecs[:, order[1 : dim + 1]]
-
-    # normalize
+    # Return normalized coordinates
+    # (Note that this step is unrelated to the parameter "normalize")
     coordinates = normalize_layout_coordinates(raw_coordinates)
 
     return {nodes[i]: coordinates[i,  :] for i in range(len(nodes))}

--- a/src/pixelator/common/graph/backends/implementations/_networkx.py
+++ b/src/pixelator/common/graph/backends/implementations/_networkx.py
@@ -334,7 +334,7 @@ class NetworkXGraphBackend(GraphBackend):
         if layout_algorithm == "coarsened_pmds_3d":
             layout_inst = coarsened_pmds_layout(raw, seed=random_seed, **kwargs)
         if layout_algorithm == "spectral_3d":
-            layout_inst = spectral_layout(raw, seed=random_seed, **kwargs)
+            layout_inst = spectral_layout(raw, dim=3, seed=random_seed, **kwargs)
 
         coordinates = pd.DataFrame.from_dict(
             layout_inst,
@@ -1055,8 +1055,10 @@ def coarsened_pmds_layout(
 
 
 def _spectral_layout_eigen(g, nodes, dim, normalize, seed):
-    """Compute the spectral layout coordinates by eigendecomposition of the
-    (optionally) symmetrically normalized graph Laplacian
+    """Compute spectral layout coordinates via eigendecomposition of the graph Laplacian.
+
+    Compute the spectral layout coordinates by eigendecomposition of the
+    (optionally) symmetrically normalized graph Laplacian.
     """
     # Get the (sparse) adjacency matrix A
     A = nx.to_scipy_sparse_array(g, nodelist=nodes, weight=None, format="csr")
@@ -1072,18 +1074,28 @@ def _spectral_layout_eigen(g, nodes, dim, normalize, seed):
     else:
         # Non-normalized Laplacian
         L = sp.sparse.csgraph.laplacian(A, normed=False)
-    
+
+    # Get matrix dimension
+    N = L.shape[0]
+
     # Build starting vector from seed
     rng = np.random.default_rng(seed)
-    v0 = rng.standard_normal(L.shape[0])
-    
+    v0 = rng.standard_normal(N)
+
+    # Check condition for k vs N
+    k = dim + 1
+    if not k < N:
+        raise ValueError(
+            f"method='eigen' with dim={dim} requires a component "
+            f"with more than {k} nodes, but got {N}"
+        )
+
     # Compute eigenpairs (k=dim + 1 to account for trivial 0-eigenvalue)
-    vals, vecs = sp.sparse.linalg.eigsh(L, k=dim + 1, which="SM", v0=v0, tol=0)
+    vals, vecs = sp.sparse.linalg.eigsh(L, k=k, which="SM", v0=v0, tol=0)
 
     # Exclude trivial eigenvector
     order = np.argsort(vals)
-    selection = order[1 : dim + 1]
-    raw_coordinates = vecs[:, selection]
+    raw_coordinates = vecs[:, order[1:k]]
 
     if normalize:
         # De-normalize
@@ -1092,8 +1104,10 @@ def _spectral_layout_eigen(g, nodes, dim, normalize, seed):
     return raw_coordinates
 
 
-def _spectral_layout_psvd(g, nodes, dim, normalize, seed):
-    """Compute the spectral layout coordinates by partial singular value decomposition
+def _spectral_layout_psvd(g, nodes, dim, seed):
+    """Compute spectral layout coordinates via partial SVD of the biadjacency matrix.
+
+    Compute the spectral layout coordinates by partial singular value decomposition
     of the degree-normalized biadjacency matrix.
     """
     # Identify and order node sets, check partitioning
@@ -1101,11 +1115,11 @@ def _spectral_layout_psvd(g, nodes, dim, normalize, seed):
     nodes_u = [node for node in nodes if pixel_type.get(node) == "A"]
     nodes_v = [node for node in nodes if pixel_type.get(node) == "B"]
 
-    if len(nodes_u) + len(nodes_v) != len(nodes):
+    if any({pixel_type.get(u), pixel_type.get(v)} != {"A", "B"} for u, v in g.edges()):
         raise ValueError(
             "The 'psvd' spectral method requires a bipartite graph whose "
             "nodes are partitioned exactly into 'A' and 'B' via the "
-            "'pixel_type' attribute."
+            "'pixel_type' attribute. Try method='eigen'."
         )
 
     # Compute the biadjacency matrix
@@ -1122,22 +1136,34 @@ def _spectral_layout_psvd(g, nodes, dim, normalize, seed):
     diag_inv_sqrt_v = sp.sparse.diags(1.0 / np.sqrt(degrees_v))
 
     # Compute the normalized biadjacency matrix
-    B_norm = (
-        diag_inv_sqrt_u
-        @ B
-        @ diag_inv_sqrt_v
-    )
-    
+    B_norm = diag_inv_sqrt_u @ B @ diag_inv_sqrt_v
+
+    # Get matrix order
+    M, N = B_norm.shape
+
     # Get starting vector from seed
     rng = np.random.default_rng(seed)
-    v0 = rng.standard_normal(min(B_norm.shape))
+    v0 = rng.standard_normal(min(M, N))
+
+    # Check condition for k vs matrix size
+    # (Note: k is guaranteed greater or equal to 1 because of input validation of "dim")
+    # (Note: using kmax=min(M, N)-1 covers all cases for the condition [SciPy 1.18.0])
+    k = dim + 1
+    kmax = min(M, N) - 1
+    if not k <= kmax:
+        raise ValueError(
+            f"method='psvd' with dim={dim} requires a bipartite graph "
+            f"whose partition sizes M, N satisfy {k} <= min(M, N) - 1, "
+            f"but got M = {M}, N = {N} (gives min(M, N) - 1 = {kmax}). "
+            f"Try method='eigen'."
+        )
 
     # Do partial singular value decomposition
     # (k=dim + 1 to account for trivial 0-eigenvalue)
-    vecs_u, s, vecs_v_t = sp.sparse.linalg.svds(B_norm, k=dim + 1, v0=v0, tol=0)
+    vecs_u, s, vecs_v_t = sp.sparse.linalg.svds(B_norm, k=k, v0=v0, tol=0)
 
     # Sort by descending and exclude trivial value, transpose
-    selection = np.argsort(s)[::-1][1 : dim + 1]
+    selection = np.argsort(s)[::-1][1:k]
 
     vecs_v = vecs_v_t.T
 
@@ -1159,17 +1185,23 @@ def _spectral_layout_psvd(g, nodes, dim, normalize, seed):
 
 def spectral_layout(
     g: nx.Graph,
-    dim: Literal[2, 3] = 3,
+    dim: int = 3,
     normalize: bool = True,
     seed: Optional[int] = None,
     method: Literal["eigen", "psvd"] = "psvd",
 ):
     """Use a spectral layout algorithm to compute coordinates from a graph."""
     # Validate inputs
+    if g.number_of_nodes() in (0, 1):
+        raise ValueError("g must have more than 1 node.")
     if g.is_directed():
         raise ValueError("g must be an undirected graph.")
     if not nx.is_connected(g):
         raise ValueError("g must be connected.")
+    if dim not in (2, 3):
+        raise ValueError("dim must be 2 or 3.")
+    if method not in ("eigen", "psvd"):
+        raise ValueError("method must be 'eigen' or 'psvd'.")
     if method == "psvd" and not normalize:
         raise ValueError(
             "normalize=False is not supported for method='psvd'. "
@@ -1186,7 +1218,6 @@ def spectral_layout(
             g,
             nodes=nodes,
             dim=dim,
-            normalize=normalize,
             seed=seed,
         )
     elif method == "eigen":
@@ -1201,7 +1232,7 @@ def spectral_layout(
     # Return normalized coordinates
     coordinates = normalize_layout_coordinates(raw_coordinates)
 
-    return {nodes[i]: coordinates[i,  :] for i in range(len(nodes))}
+    return {nodes[i]: coordinates[i, :] for i in range(len(nodes))}
 
 
 def _prob_edge_weights(

--- a/src/pixelator/common/graph/backends/implementations/_networkx.py
+++ b/src/pixelator/common/graph/backends/implementations/_networkx.py
@@ -333,6 +333,8 @@ class NetworkXGraphBackend(GraphBackend):
             )
         if layout_algorithm == "coarsened_pmds_3d":
             layout_inst = coarsened_pmds_layout(raw, seed=random_seed, **kwargs)
+        if layout_algorithm == "spectral_3d":
+            layout_inst = spectral_layout(raw)
 
         coordinates = pd.DataFrame.from_dict(
             layout_inst,
@@ -1049,6 +1051,43 @@ def coarsened_pmds_layout(
     xyz_full = normalize_layout_coordinates(xyz_full)
 
     return {nodes[i]: xyz_full[i] for i in range(n_nodes)}
+
+
+def spectral_layout(
+    g: nx.Graph,
+    dim: Literal[2, 3] = 3,
+    normalize: bool = False,
+    tolerance: float=0,
+):
+    """Use a spectral layout algorithm to compute coordinates from a graph."""
+
+    # validate input
+    if g.is_directed():
+        raise ValueError("g must be an undirected graph.")
+    if not nx.is_connected(g):
+        raise ValueError("g must be connected.")
+
+    if dim not in (2, 3):
+        raise ValueError("dim must be an integer that's either 2 or 3.")
+
+    # get node-list and define the (sparse) adjacency matrix A
+    nodes = list(g.nodes)
+    A = nx.to_scipy_sparse_array(g, nodelist=nodes, weight=None, format="csr")
+
+    # build the Laplacian
+    L = sp.sparse.csgraph.laplacian(A)
+
+    # compute eigenpairs (k=dim + 1 to account for trivial 0-eigenvalue)
+    vals, vecs = sp.sparse.linalg.eigsh(L, k=dim + 1, which="SM", tol=tolerance)
+
+    # get coordinates
+    order = np.argsort(vals)
+    raw_coordinates = vecs[:, order[1 : dim + 1]]
+
+    # normalize
+    coordinates = normalize_layout_coordinates(raw_coordinates)
+
+    return {nodes[i]: coordinates[i,  :] for i in range(len(nodes))}
 
 
 def _prob_edge_weights(

--- a/src/pixelator/common/graph/backends/protocol.py
+++ b/src/pixelator/common/graph/backends/protocol.py
@@ -168,6 +168,7 @@ class GraphBackend(Protocol):
         - pmds
         - pmds_3d
         - wpmds_3d
+        - spectral_3d
 
         For most cases the `coarsened_pmds_3d`, `wpmds_3d`, and `pmds` options should be
         preferred. On PNA data they are faster and produce better results.

--- a/src/pixelator/common/graph/backends/protocol.py
+++ b/src/pixelator/common/graph/backends/protocol.py
@@ -36,6 +36,7 @@ SupportedLayoutAlgorithm = Literal[
     "pmds_3d",
     "wpmds_3d",
     "coarsened_pmds_3d",
+    "spectral_3d",
 ]
 
 

--- a/src/pixelator/common/graph/graph.py
+++ b/src/pixelator/common/graph/graph.py
@@ -191,6 +191,7 @@ class Graph:
         - pmds
         - pmds_3d
         - wpmds_3d
+        - spectral_3d
 
         For most cases the `coarsened_pmds_3d`, `wpmds_3d`, and `pmds` options should be
         preferred. On PNA data they are faster and produce better results.

--- a/src/pixelator/pna/graph/__init__.py
+++ b/src/pixelator/pna/graph/__init__.py
@@ -80,6 +80,7 @@ class PNAGraph(BaseGraph):
         - pmds
         - pmds_3d
         - wpmds_3d
+        - spectral_3d
 
         For most cases the `coarsened_pmds_3d`, `wpmds_3d`, and `pmds` options should be
         preferred. On PNA data they are faster and produce better results.
@@ -216,6 +217,7 @@ class PNAGraphBackend(NetworkXGraphBackend):
         - pmds
         - pmds_3d
         - wpmds_3d
+        - spectral_3d
 
 
         For most cases the `coarsened_pmds_3d`, `wpmds_3d`, and `pmds` options should be


### PR DESCRIPTION
## Description

Implemented a basic spectral layout algorithm and integrated it into the codebase according to the current dependency chain structure.

**NOTE**: this PR is for the initial implementation of the algorithm, and there are still things to do in order to get this layout option to a level where it can be exposed publicly. Most necessary improvements are mentioned in the [designated ticket](https://linear.app/pixelgen-technologies/issue/PNA-3153/spectral-layouts-robustness-and-further-improvements) and specifically [this sub-issue](https://linear.app/pixelgen-technologies/issue/PNA-3154/implement-the-spectral-layout-method-in-pixelator-python)

Fixes:

Sub-issues of [PNA-3154](https://linear.app/pixelgen-technologies/issue/PNA-3154/implement-the-spectral-layout-method-in-pixelator-python):

- [PNA-3231](https://linear.app/pixelgen-technologies/issue/PNA-3231/base-implementation)
- Some of [PNA-3228](https://linear.app/pixelgen-technologies/issue/PNA-3228/speedup)
- Some of [PNA-3227](https://linear.app/pixelgen-technologies/issue/PNA-3227/documentation)
- Some of [PNA-3226](https://linear.app/pixelgen-technologies/issue/PNA-3226/handling-errors)

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

The algorithm has mainly been tested by calling it via `PNAGraph.layout_coordinates("spectral_3d")` with different arguments (other than "spectral_3d") and analyzing the output by plotting the 3d layout, and using `scipy.spatial.procrustes`.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive layout path with validation and clear fallbacks to `eigen`; no changes to default layout or existing algorithms.
> 
> **Overview**
> Adds a **spectral layout** for graph coordinates and exposes it as the **`spectral_3d`** layout option on the NetworkX graph backend and PNA/MPX `layout_coordinates` APIs.
> 
> `spectral_layout` supports **`psvd`** (default): partial SVD on a degree-normalized biadjacency matrix for bipartite graphs with `pixel_type` A/B. **`eigen`**: smallest-magnitude eigenvectors of the (optionally normalized) Laplacian for general connected undirected graphs. Coordinates are passed through existing **`normalize_layout_coordinates`**; **`kwargs`** (e.g. `method`, `normalize`) flow from `layout_coordinates` like other layouts.
> 
> Docs and **`SupportedLayoutAlgorithm`** are updated; CHANGELOG notes the new algorithm. PR description states this is an initial implementation not yet fully public-ready.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be73cac03c04ee8a8c6834ad8fa88090aa5f2afc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->