### PR TITLE
[DON'T MERGE] Add config variable to display names shorter

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -150,6 +150,7 @@ html_static_path = ["_static"]
 html_css_files = ["custom.css"]
 
 python_maximum_signature_line_length = 40
+python_use_unqualified_type_names = True
 
 autodoc_member_order = "alphabetical"
 autodoc_typehints = "signature"


### PR DESCRIPTION
## Description

Added a config variable for displaying names shorter where possible. This change contributes to nicer looking and more user-friendly docs. See [Sphinx documentation](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-python_use_unqualified_type_names).

Fixes: [PNA-3215](https://linear.app/pixelgen-technologies/issue/PNA-3215/references-to-names-appear-too-long)

Before:
<img width="731" height="194" alt="before" src="https://github.com/user-attachments/assets/13f1195e-3caf-4d4b-988a-a0b3e146e117" />

After:
<img width="694" height="174" alt="after" src="https://github.com/user-attachments/assets/f4ee013d-5218-4514-9785-5a05800c9265" />

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

By building the docs and making sure there are no new warnings.

`rm -rf docs/_build docs/api/generated && uv run sphinx-build -b html docs docs/_build/html --keep-going -n -w docs/_build/sphinx-warnings.log`

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation build configuration only; no application or runtime code is modified.
> 
> **Overview**
> Enables Sphinx’s **`python_use_unqualified_type_names`** in `docs/conf.py` so generated API signatures and type references use shorter, unqualified type names where possible instead of long fully qualified paths.
> 
> This is a documentation-only tweak alongside the existing `python_maximum_signature_line_length` setting and does not change library behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79c3d1a10e8fe4850d512da0108e9b082378b565. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->