### PR TITLE
Upgrade configure-aws-credentials to v4

### DIFF
--- a/.github/actions/setup-image-build-env/action.yml
+++ b/.github/actions/setup-image-build-env/action.yml
@@ -27,11 +27,11 @@ runs:
       uses: docker/setup-buildx-action@v2
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-region: eu-north-1
         role-to-assume: ${{ inputs.aws-role-to-assume }}
-        role-session-name: ${{ inputs.aws-session-name }}
+        role-session-name: ${{ inputs.aws-role-session-name }}
 
     - name: Login to AWS ECR
       uses: docker/login-action@v2

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - name: Configure AWS credentials
         id: configure-aws-credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: eu-north-1
           role-to-assume: arn:aws:iam::890888997283:role/GithubActionsRole


### PR DESCRIPTION
## Description

Upgrade `aws-actions/configure-aws-credentials` from v2 to v4 in the image build env composite action and in `workflow-tests.yml`. Also fix `role-session-name` in `setup-image-build-env` to use the declared input `aws-role-session-name` instead of the non-existent `aws-session-name`.

This addresses the `Cannot read properties of undefined (reading 'message')` crash in the “Set up build environment” step on `dev`.

Fixes: N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Not run against live CI yet; verify by re-running the Build containers workflow on this branch (OIDC + ECR login in `setup-image-build-env` and `workflow-tests`).

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [x] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)

Made with [Cursor](https://cursor.com)