### PR TITLE
Include Click positional arguments in parameters JSON.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - The graph stage now raises an error instead of an internal DuckDB crash when a component-size threshold discards every component in the input.
 - `single-cell-pna graph` no longer crashes with a `polars.exceptions.SchemaError` on `n_edges` (`Int64` vs `UInt32`) when calculating post-recovery component statistics with `--multiplet-recovery` and a `--component-size-max-threshold` that discards large components.
+- `write_parameters_file` now includes Click positional arguments (e.g. multi-file inputs) under `cli.arguments` in `*.meta.json`, not only options.
 
 ## [0.29.0] - 2026-06-15
 

--- a/src/pixelator/common/utils/__init__.py
+++ b/src/pixelator/common/utils/__init__.py
@@ -372,6 +372,24 @@ def timer(func):
     return wrapper
 
 
+def _serialize_parameter_value(param: click.Parameter, value):
+    """Serialize a Click parameter value for the parameters JSON file."""
+    if value is None:
+        return None
+
+    # NB: that this checks the type of the parameter, not the value
+    is_path = isinstance(param.type, click.Path)
+    if isinstance(value, (list, tuple)):
+        if is_path:
+            return [str(Path(v).resolve()) for v in value]
+        return list(value)
+
+    if is_path:
+        return str(Path(value).resolve())
+
+    return value
+
+
 def write_parameters_file(
     click_context: click.Context, output_file: Path, command_path: Optional[str] = None
 ) -> None:
@@ -386,23 +404,22 @@ def write_parameters_file(
     parameters = click_context.command.params
     parameter_values = click_context.params
 
-    param_data = {}
+    options_data = {}
+    arguments_data = {}
 
     for param in parameters:
-        if not isinstance(param, click.core.Option):
-            continue
+        value = _serialize_parameter_value(param, parameter_values.get(str(param.name)))
 
-        name = param.opts[0]
-        value = parameter_values.get(str(param.name))
-        if value is not None and param.type == click.Path:
-            value = str(Path(value).resolve())
-
-        param_data[name] = value
+        if isinstance(param, click.core.Option):
+            options_data[param.opts[0]] = value
+        elif isinstance(param, click.core.Argument):
+            arguments_data[str(param.name)] = value
 
     data = {
         "cli": {
             "command": command_path_fixed,
-            "options": param_data,
+            "options": options_data,
+            "arguments": arguments_data,
         }
     }
 

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -1,8 +1,12 @@
 """Copyright © 2023 Pixelgen Technologies AB."""
 
-import pytest
+import json
 
-from pixelator.common.utils import flatten
+import click
+import pytest
+from click.testing import CliRunner
+
+from pixelator.common.utils import flatten, write_parameters_file
 
 
 @pytest.mark.parametrize(
@@ -22,3 +26,62 @@ def test_flatten(input, expected):
         expected: expected.
     """
     assert list(flatten(input)) == expected
+
+
+def test_write_parameters_file_includes_multi_file_arguments(tmp_path):
+    """Multi-file Click arguments are listed under cli.arguments."""
+    input_a = tmp_path / "a.parquet"
+    input_b = tmp_path / "b.parquet"
+    input_a.write_text("a")
+    input_b.write_text("b")
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    meta_file = tmp_path / "meta.json"
+
+    @click.command()
+    @click.argument(
+        "input_files",
+        nargs=-1,
+        required=True,
+        type=click.Path(exists=True),
+    )
+    @click.option("--output", required=True, type=click.Path())
+    @click.pass_context
+    def fake_command(ctx, input_files, output):
+        write_parameters_file(ctx, meta_file)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        fake_command,
+        [str(input_a), str(input_b), "--output", str(output_dir)],
+    )
+    assert result.exit_code == 0, result.output
+
+    data = json.loads(meta_file.read_text())
+    assert data["cli"]["options"]["--output"] == str(output_dir.resolve())
+    assert data["cli"]["arguments"]["input_files"] == [
+        str(input_a.resolve()),
+        str(input_b.resolve()),
+    ]
+
+
+def test_write_parameters_file_includes_single_file_argument(tmp_path):
+    """Single-file Click arguments are listed under cli.arguments."""
+    input_file = tmp_path / "input.pxl"
+    input_file.write_text("x")
+    meta_file = tmp_path / "meta.json"
+
+    @click.command()
+    @click.argument("pxl_file", nargs=1, required=True, type=click.Path(exists=True))
+    @click.option("--flag", is_flag=True, default=False)
+    @click.pass_context
+    def fake_command(ctx, pxl_file, flag):
+        write_parameters_file(ctx, meta_file)
+
+    runner = CliRunner()
+    result = runner.invoke(fake_command, [str(input_file), "--flag"])
+    assert result.exit_code == 0, result.output
+
+    data = json.loads(meta_file.read_text())
+    assert data["cli"]["options"]["--flag"] is True
+    assert data["cli"]["arguments"]["pxl_file"] == str(input_file.resolve())


### PR DESCRIPTION
## Description

`write_parameters_file` previously skipped non-Option params, so multi-file inputs never appeared in meta.json.

Fixes: N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added new unit tests.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive metadata JSON change with no pipeline logic changes; only affects CLI parameter recording for reproducibility and QC.
> 
> **Overview**
> **`write_parameters_file`** now records Click **positional arguments** in `*.meta.json` under **`cli.arguments`**, alongside existing **`cli.options`**. Multi-file inputs and single input paths (e.g. `pxl_file`) were previously omitted because only `Option` parameters were serialized.
> 
> Serialization is centralized in **`_serialize_parameter_value`**, which resolves **`click.Path`** values to absolute paths for both options and arguments, including lists/tuples of paths.
> 
> Unit tests cover multi-file (`nargs=-1`) and single-file arguments via `CliRunner`; **CHANGELOG** documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2edd508faf0d12cd6c1e489ed2546c04a24032c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->