### PR TITLE
Docs maintenance

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -90,6 +90,9 @@ jobs:
       - name: Regenerate switcher.json
         run: python3 docs/_scripts/update_switcher.py
 
+      - name: Ensure .nojekyll exists
+        run: touch ./switcher-out/.nojekyll
+
       - uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,97 @@
+# Docs handbook
+
+## Overview
+
+This document describes how the Pixelator documentation is generated, what is
+included, how it is maintained, and how it is built and deployed.
+
+Key files:
+
+- `docs/conf.py` — Sphinx configuration (extensions, AutoAPI, theme, cross-referencing, warning handling).
+- `docs/index.rst` — landing page and the root table of contents.
+- `docs/api/index.rst` — API reference table of contents (AutoAPI-generated tree).
+- `docs/api/overview.rst` — curated list of primary API entry points.
+- `docs/cli/index.rst` — CLI reference.
+- `docs/_static/` — custom CSS and logo.
+- `docs/_scripts/update_switcher.py` — regenerates the version switcher during deployment.
+- `.github/workflows/deploy-docs.yml` — the workflow that builds and deploys the docs.
+
+## Documentation generator
+
+- The generation of the docs is implemented using [Sphinx](https://www.sphinx-doc.org/en/master/) with extensions listed in `extensions` in `docs/conf.py`.
+- Documentation is automatically generated from docstrings and help-text (CLI) in the source code of `pixelator`.
+- Docstrings are formatted according to [Google conventions for docstrings](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings).
+- Where possible, internal names have cross-referencing pointing to a page in the docs, and external names map to the public external documentation site. Links to stable external documentation are kept in `intersphinx_mapping` in `docs/conf.py`.
+- The `__all__` lists in the package `__init__.py` files determine which name-links are shown on the parent package page in the API reference.
+- The CLI docs use [sphinx-click](https://sphinx-click.readthedocs.io/en/latest/). Only the `single-cell-pna` command tree is rendered, selected via `:commands: single-cell-pna` in `docs/cli/index.rst`.
+- The site uses the [PyData Sphinx theme](https://pydata-sphinx-theme.readthedocs.io/) with a version switcher, configured in `html_theme_options` in `docs/conf.py` (the switcher reads `switcher.json`; see "Deployment").
+
+
+
+## Inclusion
+
+`autoapi` inclusion is mainly determined by `autoapi_options` and `autoapi_ignore` in `docs/conf.py`. Some options worth mentioning include:
+
+- Imported members (`imported-members`) are intentionally included in the docs generation via `autoapi_options`.
+- Private members (`private-members`) are not included via `autoapi_options`.
+- Parts of the codebase, e.g. names related to MPX, are ignored via `autoapi_ignore`.
+
+
+
+## Warnings and strict builds
+
+- Builds run in nitpicky mode (`nitpicky = True` in `docs/conf.py`, and the `-n` flag), so unresolved cross-references are reported as warnings. CI builds additionally pass `--fail-on-warning`, which means any warning fails the build.
+- Known-acceptable warnings are suppressed:
+  - `nitpick_ignore_regex` silences specific cross-reference targets that cannot be resolved (e.g. MPX names).
+  - `suppress_warnings` silences whole Sphinx warning categories (`ref.python`, `autoapi.python_import_resolution`).
+  - A logging filter (`_keep_warning`) drops a small set of warnings that are emitted without a Sphinx type/subtype and so cannot be matched by `suppress_warnings`.
+- When new code introduces a cross-reference warning, prefer fixing the reference.
+
+
+
+## Maintenance
+
+- Update or add docstrings and CLI help-text in the source code as the code changes.
+- The overview page (`overview.rst`) lists some primary entry points of the API. Additions to this page are made manually.
+- `intersphinx_mapping` in `docs/conf.py` lists the URLs for documentation of external names used for cross-referencing. This list is maintained manually.
+- Keep this handbook (`docs/README.md`) up to date when the docs setup changes.
+
+
+
+## Deployment
+
+- Building and deploying the docs is handled by the "Docs" workflow (`.github/workflows/deploy-docs.yml`).
+- The workflow runs on three triggers: published releases, manual dispatch (`workflow_dispatch`, which requires a `tag` input), and pull requests.
+- The build job runs for all three triggers and builds with `sphinx-build ... --fail-on-warning -n`, so warnings fail the build (see "Warnings and strict builds").
+- The deploy job only runs for manual dispatch and non-prerelease releases. It does not run on pull requests, and prereleases are built but not deployed.
+- Deployment publishes the built HTML to the `gh-pages` branch under `docs/<version>/` via [GitHub Pages](https://docs.github.com/en/pages) (using `peaceiris/actions-gh-pages`). The version is the release tag without the leading `v` (or the dispatch `tag`), defaulting to `latest` when unset.
+- After publishing, `docs/_scripts/update_switcher.py` regenerates `switcher.json` (the version list used by the theme's version switcher) and a redirect at `docs/index.html` that points to the newest version.
+- GitHub Pages must be configured to serve from the `gh-pages` branch with the `/docs` folder as the source (repo Settings → Pages).
+
+
+
+## Development
+
+1. Install the docs dependency group: `uv sync --group docs`.
+2. Build the HTML from a clean state (logging warnings to a file):
+
+```
+rm -rf docs/_build docs/api/generated && uv run sphinx-build -b html docs docs/_build/html --keep-going -n -w docs/_build/sphinx-warnings.log
+```
+
+3. Open `docs/_build/html/index.html`.
+
+Notes:
+
+- The command above uses `--keep-going` and logs warnings to `docs/_build/sphinx-warnings.log` so you can review them. CI instead uses `--fail-on-warning`.
+- For a live-reloading preview while editing, `sphinx-autobuild` is included in the docs dependency group: `uv run sphinx-autobuild docs docs/_build/html`.
+
+
+
+## References
+
+- [Sphinx documentation](https://www.sphinx-doc.org/en/master/)
+- [AutoAPI documentation](https://sphinx-autoapi.readthedocs.io/en/latest/index.html)
+- [sphinx-click](https://sphinx-click.readthedocs.io/en/latest/)
+- [PyData Sphinx theme](https://pydata-sphinx-theme.readthedocs.io/)
+- [Google docstrings](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,7 +63,7 @@ Key files:
 - Building and deploying the docs is handled by the "Docs" workflow (`.github/workflows/deploy-docs.yml`).
 - The workflow runs on three triggers: published releases, manual dispatch (`workflow_dispatch`, which requires a `tag` input), and pull requests.
 - The build job runs for all three triggers and builds with `sphinx-build ... --fail-on-warning -n`, so warnings fail the build (see "Warnings and strict builds").
-- The deploy job only runs for manual dispatch and non-prerelease releases. It does not run on pull requests, and prereleases are built but not deployed.
+- The deploy job only runs for manual dispatch and stable releases. It does not run on pull requests nor prereleases.
 - Deployment publishes the built HTML to the `gh-pages` branch under `docs/<version>/` via [GitHub Pages](https://docs.github.com/en/pages) (using `peaceiris/actions-gh-pages`). The version is the release tag without the leading `v` (or the dispatch `tag`), defaulting to `latest` when unset.
 - After publishing, `docs/_scripts/update_switcher.py` regenerates `switcher.json` (the version list used by the theme's version switcher) and a redirect at `docs/index.html` that points to the newest version.
 - GitHub Pages must be configured to serve from the `gh-pages` branch with the `/docs` folder as the source (repo Settings → Pages).


### PR DESCRIPTION
## Description

* Made an addition to the deploy-workflow for ensuring the existence of `.nojekyll` for robustness.
* Added a README.md with information about the docs.

Fixes: [PNA-3209](https://linear.app/pixelgen-technologies/issue/PNA-3209/create-nojekyll-file-on-every-deploy-via-workflow)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Built the docs locally:

```
rm -rf docs/_build docs/api/generated && uv run sphinx-build -b html docs docs/_build/html --keep-going -n -w docs/_build/sphinx-warnings.log
```

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [x] I have checked my code and documentation and corrected any misspellings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a small CI deploy hardening step; no runtime or application code changes.
> 
> **Overview**
> Adds a **docs handbook** (`docs/README.md`) that documents how Pixelator docs are built with Sphinx (AutoAPI, CLI, theme), what gets included, strict warning handling, maintenance expectations, the **Docs** GitHub workflow (triggers, deploy to `gh-pages`, version switcher), and local dev commands.
> 
> The **deploy workflow** now creates an empty `.nojekyll` in `switcher-out` after `update_switcher.py` runs, so the second publish to `gh-pages` under `docs/` reliably disables Jekyll processing on GitHub Pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 462eaa8ae75db366539218a9ea32e87276da0b46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->