### PR TITLE
Prepare 0.30.0 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,29 +5,56 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.30.0] - 2026-08-04
 
 ### Added
-- `pixelator.pna.analysis.comparison.compare_sample_pairs` and `compare_sample_pairs_by_gate` to check that pairs of PNA samples are similar in terms of abundance (mean marker CLR) and proximity (mean marker-pair proximity score) patterns, reporting the correlation between each pair. In case of gating (e.g. `["+CD3e", "+CD4", "-CD19"]`), components are first filtered with positive/negative thresholds determined automatically from each marker's CLR distribution.
-- `pixelator.pna.analysis.gating.determine_marker_threshold` to determine a positive/negative CLR threshold for a marker, warning and skipping markers whose distribution appears unimodal.
-- `pixelator.pna.plot.plot_sample_pair_comparison` and `write_sample_pair_comparison_report` to plot and collect sample pair abundance/proximity comparisons into an HTML report.
-- Setup for generating API documentation pages from source files, and a workflow for building and deploying the docs automatically.
+- `pixelator.pna.analysis.comparison.compare_sample_pairs` and `compare_sample_pairs_by_gate` 
+   to check that pairs of PNA samples are similar in terms of abundance (mean marker CLR) and 
+   proximity (mean marker-pair proximity score) patterns, reporting the correlation between 
+   each pair. In case of gating (e.g. `["+CD3e", "+CD4", "-CD19"]`), components are first filtered
+   with positive/negative thresholds determined automatically from each marker's CLR distribution.
+- `pixelator.pna.analysis.gating.determine_marker_threshold` to determine a positive/negative CLR 
+   threshold for a marker, warning and skipping markers whose distribution appears unimodal.
+- `pixelator.pna.plot.plot_sample_pair_comparison` and `write_sample_pair_comparison_report` to plot
+   and collect sample pair abundance/proximity comparisons into an HTML report.
+- Setup for generating API documentation pages from source files, and a workflow for building and 
+  deploying the docs automatically.
 - `PNAAssay` and `PNAAntibodyPanel` now hold an optional path to the path they were parsed from.
-- `pixelator.common.plot` with Pixelgen's brand colors, gradients, palettes, and theme (`PIXELGEN_ACCENT_COLORS`, `PIXELGEN_CELL_PALETTE`, `pixelgen_gradient`, `pixelgen_palette`, `pixelgen_accent_colors`, `pixelgen_discrete_colors`, `create_discrete_palette`, `pixelgen_colorscale`/`pixelgen_sequential_colormap`/`pixelgen_divergent_colormap`/`pixelgen_colormap`, `set_pixelgen_theme`/`pixelgen_theme`, `style_facet_strips`).
+- `pixelator.common.plot` with Pixelgen's brand colors, gradients, palettes, and theme 
+  (`PIXELGEN_ACCENT_COLORS`, `PIXELGEN_CELL_PALETTE`, `pixelgen_gradient`, `pixelgen_palette`, 
+  `pixelgen_accent_colors`, `pixelgen_discrete_colors`, `create_discrete_palette`, 
+  `pixelgen_colorscale`/`pixelgen_sequential_colormap`/`pixelgen_divergent_colormap`/`pixelgen_colormap`,
+   `set_pixelgen_theme`/`pixelgen_theme`, `style_facet_strips`).
 - Spectral layout algorithm
-- `single-cell-pna denoise` and `single-cell-pna sample-calling` now report `input_reads` and `output_reads` in `report.json`.
+- `single-cell-pna denoise` and `single-cell-pna sample-calling` now report `input_reads` and 
+  `output_reads` in `report.json`.
 
 ### Changed
-- The default `min_allowed_nodes_pct` in `adaptive_core_expansion` has been changed from 0.8 to 0.9, meaning that a valid "high" core partition must include at least 90% of all nodes. Components that don't meet this criteria will not be denoised by ACE.
-- `pixelator.mpx.plot` and `pixelator.pna.plot` functions now use the Pixelgen brand theme and color palettes from `pixelator.common.plot` by default.
-- `pixelgen_divergent_colormap` and the `plot_colocalization_heatmap`/`plot_colocalization_diff_volcano`/`plot_polarity_diff_volcano` plots that use it now center on a light Pixelgen grey rather than white, and use a `min_level` floor on both hues, so values near zero stay visible against a white background instead of fading out.
-- Color scales for signed metrics (`abundance_colocalization_plot`'s hue mapping, `plot_colocalization_heatmap`'s `center=0`, and the `CenteredNorm` used by the volcano plots) are now correctly centered on zero, instead of on the (potentially skewed) 10th-90th percentile midpoint or raw data min/max.
-- `single-cell-pna graph` now discards components above the max size threshold before the refinement step instead of only at the end, reducing peak memory usage. This only applies when `--component-size-max-threshold` is set.
+- The default `min_allowed_nodes_pct` in `adaptive_core_expansion` has been changed from 0.8 to 0.9,
+  meaning that a valid "high" core partition must include at least 90% of all nodes. Components that
+  don't meet this criterion will not be denoised by ACE.
+- `pixelator.mpx.plot` and `pixelator.pna.plot` functions now use the Pixelgen brand theme and color
+  palettes from `pixelator.common.plot` by default.
+- `pixelgen_divergent_colormap` and the `plot_colocalization_heatmap`/
+  `plot_colocalization_diff_volcano`/`plot_polarity_diff_volcano` plots that use it now center on a
+  light Pixelgen grey rather than white, and use a `min_level` floor on both hues, so values near
+  zero stay visible against a white background instead of fading out.
+- Color scales for signed metrics (`abundance_colocalization_plot`'s hue mapping,
+  `plot_colocalization_heatmap`'s `center=0`, and the `CenteredNorm` used by the volcano plots) are
+  now correctly centered on zero, instead of on the (potentially skewed) 10th-90th percentile midpoint
+  or raw data min/max.
+- `single-cell-pna graph` now discards components above the max size threshold before the refinement
+  step instead of only at the end, reducing peak memory usage. This only applies when
+  `--component-size-max-threshold` is set.
 
 ### Fixed
-- The graph stage now raises an error instead of an internal DuckDB crash when a component-size threshold discards every component in the input.
-- `single-cell-pna graph` no longer crashes with a `polars.exceptions.SchemaError` on `n_edges` (`Int64` vs `UInt32`) when calculating post-recovery component statistics with `--multiplet-recovery` and a `--component-size-max-threshold` that discards large components.
-- `write_parameters_file` now includes Click positional arguments (e.g. multi-file inputs) under `cli.arguments` in `*.meta.json`, not only options.
+- The graph stage now raises an error instead of an internal DuckDB crash when a component-size
+  threshold discards every component in the input.
+- `single-cell-pna graph` no longer crashes with a `polars.exceptions.SchemaError` on `n_edges`
+  (`Int64` vs `UInt32`) when calculating post-recovery component statistics with
+  `--multiplet-recovery` and a `--component-size-max-threshold` that discards large components.
+- `write_parameters_file` now includes Click positional arguments (e.g. multi-file inputs) under
+  `cli.arguments` in `*.meta.json`, not only options.
 
 ## [0.29.0] - 2026-06-15
 


### PR DESCRIPTION
## Description

Prepare 0.30.0 for release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edit with no runtime or dependency changes.
> 
> **Overview**
> Finalizes the **0.30.0** release notes by replacing the `[Unreleased]` heading with **`[0.30.0] - 2026-08-04`** and publishing the accumulated feature, behavior, and fix entries under that version.
> 
> The listed changes cover PNA sample-pair comparison and gating APIs, docs build/deploy setup, Pixelgen plotting theme defaults, ACE/graph/denoise reporting tweaks, and several `single-cell-pna graph` robustness fixes. This PR only updates **`CHANGELOG.md`** (including minor line wrapping and grouping the **Fixed** bullets separately from **Changed**); it does not modify application code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a01443badda127c611039598c86da5cb49ca924. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->