### PR TITLE
add `input_reads` and `output_reads` in `report.json` for `single-cell-pna denoise` and `single-cell-pna sample-calling`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `pixelator.pna.analysis.comparison.compare_sample_pairs` to check that pairs of PNA samples are similar in terms of abundance (mean marker CLR) and proximity (mean marker-pair proximity score) patterns, reporting the correlation between each pair.
-- `pixelator.pna.analysis.compare_sample_pairs_by_gate` to run the same comparison restricted to components matching a cell-type gate (e.g. `["+CD3e", "+CD4", "-CD19"]`), with positive/negative thresholds determined automatically from each marker's CLR distribution.
+- `pixelator.pna.analysis.comparison.compare_sample_pairs` and `compare_sample_pairs_by_gate` to check that pairs of PNA samples are similar in terms of abundance (mean marker CLR) and proximity (mean marker-pair proximity score) patterns, reporting the correlation between each pair. In case of gating (e.g. `["+CD3e", "+CD4", "-CD19"]`), components are first filtered with positive/negative thresholds determined automatically from each marker's CLR distribution.
 - `pixelator.pna.analysis.gating.determine_marker_threshold` to determine a positive/negative CLR threshold for a marker, warning and skipping markers whose distribution appears unimodal.
 - `pixelator.pna.plot.plot_sample_pair_comparison` and `write_sample_pair_comparison_report` to plot and collect sample pair abundance/proximity comparisons into an HTML report.
 - Setup for generating API documentation pages from source files, and a workflow for building and deploying the docs automatically.
 - `PNAAssay` and `PNAAntibodyPanel` now hold an optional path to the path they were parsed from.
-- `pixelator.common.plot` with Pixelgen's brand colors, gradients, palettes, and theme (`PIXELGEN_ACCENT_COLORS`, `PIXELGEN_CELL_PALETTE`, `pixelgen_gradient`, `pixelgen_palette`, `pixelgen_accent_colors`, `pixelgen_discrete_colors`, `create_discrete_palette`, `pixelgen_colorscale`/`pixelgen_sequential_colormap`/`pixelgen_divergent_colormap`/`pixelgen_colormap`, `set_pixelgen_theme`/`pixelgen_theme`, `style_facet_strips`), ported from the internal `themes_and_palettes.R` ggplot2 helpers.
+- `pixelator.common.plot` with Pixelgen's brand colors, gradients, palettes, and theme (`PIXELGEN_ACCENT_COLORS`, `PIXELGEN_CELL_PALETTE`, `pixelgen_gradient`, `pixelgen_palette`, `pixelgen_accent_colors`, `pixelgen_discrete_colors`, `create_discrete_palette`, `pixelgen_colorscale`/`pixelgen_sequential_colormap`/`pixelgen_divergent_colormap`/`pixelgen_colormap`, `set_pixelgen_theme`/`pixelgen_theme`, `style_facet_strips`).
 - Spectral layout algorithm
 - `single-cell-pna denoise` and `single-cell-pna sample-calling` now report `input_reads` and `output_reads` in `report.json`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `PNAAssay` and `PNAAntibodyPanel` now hold an optional path to the path they were parsed from.
 - `pixelator.common.plot` with Pixelgen's brand colors, gradients, palettes, and theme (`PIXELGEN_ACCENT_COLORS`, `PIXELGEN_CELL_PALETTE`, `pixelgen_gradient`, `pixelgen_palette`, `pixelgen_accent_colors`, `pixelgen_discrete_colors`, `create_discrete_palette`, `pixelgen_colorscale`/`pixelgen_sequential_colormap`/`pixelgen_divergent_colormap`/`pixelgen_colormap`, `set_pixelgen_theme`/`pixelgen_theme`, `style_facet_strips`), ported from the internal `themes_and_palettes.R` ggplot2 helpers.
 - Spectral layout algorithm
+- `single-cell-pna denoise` and `single-cell-pna sample-calling` now report `input_reads` and `output_reads` in `report.json`.
 
 ### Changed
 - The default `min_allowed_nodes_pct` in `adaptive_core_expansion` has been changed from 0.8 to 0.9, meaning that a valid "high" core partition must include at least 90% of all nodes. Components that don't meet this criteria will not be denoised by ACE.

--- a/src/pixelator/pna/analysis/report.py
+++ b/src/pixelator/pna/analysis/report.py
@@ -44,3 +44,5 @@ class DenoiseSampleReport(SampleReport):
     report_type: str = "denoise"
     number_of_umis_removed: int | None
     ratio_of_umis_removed: float | None
+    input_reads: int
+    output_reads: int

--- a/src/pixelator/pna/cli/denoise.py
+++ b/src/pixelator/pna/cli/denoise.py
@@ -253,6 +253,9 @@ def denoise(
     )
     metrics = denoise_output / f"{sample_name}.report.json"
 
+    pxl_dataset = read(pxl_file.path)
+    input_reads = int(pxl_dataset.adata().obs["reads_in_component"].sum())
+
     if (
         not run_one_core_graph_denoising
         and not run_ace_denoising
@@ -263,6 +266,8 @@ def denoise(
             product_id="single-cell-pna",
             number_of_umis_removed=None,
             ratio_of_umis_removed=None,
+            input_reads=input_reads,
+            output_reads=input_reads,
         )
         report.write_json_file(metrics, indent=4)
         return
@@ -291,7 +296,6 @@ def denoise(
     ]
     logging_setup = LoggingSetup.from_logger(ctx.obj.get("LOGGER"))
     manager = AnalysisManager(analysis_to_run, logging_setup=logging_setup)
-    pxl_dataset = read(pxl_file.path)
 
     pxl_dataset_denoised = manager.execute(pxl_dataset, output_pxl_file_target)
 
@@ -302,11 +306,16 @@ def denoise(
         number_of_umis_removed
         / (pxl_dataset.adata().obs["n_umi"].sum() + number_of_umis_removed)
     )
+    output_reads = int(
+        pxl_dataset_denoised.adata().obs["reads_in_component"].sum()
+    )
     report = DenoiseSampleReport(
         sample_id=sample_name,
         product_id="single-cell-pna",
         number_of_umis_removed=number_of_umis_removed,
         ratio_of_umis_removed=ratio_of_umis_removed,
+        input_reads=input_reads,
+        output_reads=output_reads,
     )
 
     report.write_json_file(metrics, indent=4)

--- a/src/pixelator/pna/cli/denoise.py
+++ b/src/pixelator/pna/cli/denoise.py
@@ -266,6 +266,7 @@ def denoise(
             product_id="single-cell-pna",
             number_of_umis_removed=None,
             ratio_of_umis_removed=None,
+            # When denoising is turned off input_reads=output_reads
             input_reads=input_reads,
             output_reads=input_reads,
         )

--- a/src/pixelator/pna/cli/denoise.py
+++ b/src/pixelator/pna/cli/denoise.py
@@ -306,9 +306,7 @@ def denoise(
         number_of_umis_removed
         / (pxl_dataset.adata().obs["n_umi"].sum() + number_of_umis_removed)
     )
-    output_reads = int(
-        pxl_dataset_denoised.adata().obs["reads_in_component"].sum()
-    )
+    output_reads = int(pxl_dataset_denoised.adata().obs["reads_in_component"].sum())
     report = DenoiseSampleReport(
         sample_id=sample_name,
         product_id="single-cell-pna",

--- a/src/pixelator/pna/cli/sample_calling.py
+++ b/src/pixelator/pna/cli/sample_calling.py
@@ -123,9 +123,9 @@ def sample_calling_cli(
         pool_name=pool_name,
     )
 
-    pxl = read(Path(input_pxl_file))
+    input_pxl_dataset = read(Path(input_pxl_file))
     output_files = sample_calling(
-        input_pxl=pxl,
+        input_pxl=input_pxl_dataset,
         hashing_antibody_mapping=hashed_antibodies,
         output_folder=sample_calling_output,
         remove_incompatible=remove_incompatible,
@@ -135,20 +135,29 @@ def sample_calling_cli(
 
     for pxl_file in output_files:
         sample_name = get_sample_name(pxl_file)
-        pxl = read(pxl_file)
+        sample_pxl = read(pxl_file)
         write_parameters_file(
             ctx,
             sample_calling_output / f"{sample_name}.meta.json",
             command_path="pixelator single-cell-pna sample-calling",
         )
         metrics = sample_calling_output / f"{sample_name}.report.json"
+        output_reads = int(sample_pxl.adata().obs["reads_in_component"].sum())
+        input_reads = int(
+            input_pxl_dataset.filter(components=sample_pxl.adata().obs.index.tolist())
+            .adata()
+            .obs["reads_in_component"]
+            .sum()
+        )
         report = SampleCallingSampleReport(
             sample_id=sample_name,
             product_id="single-cell-pna",
-            number_of_components=len(pxl.components()),
+            number_of_components=len(sample_pxl.components()),
             number_of_incompatible_hashes_removed=(
-                pxl.adata().obs["removed_incompatible_hashes"].sum()
+                sample_pxl.adata().obs["removed_incompatible_hashes"].sum()
             ),
+            input_reads=input_reads,
+            output_reads=output_reads,
         )
         report.write_json_file(metrics, indent=4)
 
@@ -156,6 +165,7 @@ def sample_calling_cli(
     final_dataset = read(output_files)
     total_report = create_final_report(
         final_dataset=final_dataset,
+        input_reads=int(input_pxl_dataset.adata().obs["reads_in_component"].sum()),
         undetermined_sample_name=undetermined_sample_name,
     )
     total_report.write_json_file(

--- a/src/pixelator/pna/sample_calling/__init__.py
+++ b/src/pixelator/pna/sample_calling/__init__.py
@@ -500,12 +500,15 @@ class HashedSampleAnalysisManager(AnalysisManager):
 
 
 def create_final_report(
-    final_dataset: PNAPixelDataset, undetermined_sample_name: str = "undetermined"
+    final_dataset: PNAPixelDataset,
+    input_reads: int,
+    undetermined_sample_name: str = "undetermined",
 ) -> SampleCallingTotalReport:
     """Create the final report for the sample calling.
 
     Args:
         final_dataset: The final dataset after sample calling.
+        input_reads: Total number of reads across all samples before sample calling.
         undetermined_sample_name: Name to use for undetermined components. Defaults to
             "undetermined".
 
@@ -535,6 +538,17 @@ def create_final_report(
         for sample_name in final_dataset.sample_names()
     }
 
+    output_reads = sum(
+        int(
+            final_dataset.filter(samples=sample_name)
+            .adata()
+            .obs["reads_in_component"]
+            .sum()
+        )
+        for sample_name in final_dataset.sample_names()
+        if sample_name != undetermined_sample_name
+    )
+
     total_report = SampleCallingTotalReport(
         sample_id="all",
         product_id="single-cell-pna",
@@ -544,6 +558,8 @@ def create_final_report(
             sample: enrichment_factors.to_list()
             for sample, enrichment_factors in hash_enrichment_factors_per_sample.items()
         },
+        input_reads=input_reads,
+        output_reads=output_reads,
     )
     return total_report
 

--- a/src/pixelator/pna/sample_calling/report.py
+++ b/src/pixelator/pna/sample_calling/report.py
@@ -12,6 +12,8 @@ class SampleCallingSampleReport(SampleReport):
     report_type: str = "sample_calling"
     number_of_components: int
     number_of_incompatible_hashes_removed: int | None
+    input_reads: int
+    output_reads: int
 
 
 class SampleCallingTotalReport(SampleReport):
@@ -21,3 +23,5 @@ class SampleCallingTotalReport(SampleReport):
     number_of_components: int
     percentage_of_components_successfully_called: float
     hash_enrichment_factors_per_sample: dict[str, list[float]]
+    input_reads: int
+    output_reads: int

--- a/tests/pna/denoise/test_denoise_cli.py
+++ b/tests/pna/denoise/test_denoise_cli.py
@@ -69,6 +69,13 @@ def test_denoise_cli_writes_outputs_and_report(synthetic_denoise_pxl_file):
         assert report["number_of_umis_removed"] > 0
         assert 0.0 <= report["ratio_of_umis_removed"] <= 1.0
 
+        input_obs = read(synthetic_denoise_pxl_file).adata().obs
+        expected_input_reads = int(input_obs["reads_in_component"].sum())
+        expected_output_reads = int(obs["reads_in_component"].sum())
+        assert report["input_reads"] == expected_input_reads
+        assert report["output_reads"] == expected_output_reads
+        assert report["output_reads"] <= report["input_reads"]
+
         # The parameters file records the command and the flags we passed, which
         # confirms the CLI options are threaded into the DenoiseGraph task.
         meta_path = Path(output_dir) / "denoise" / f"{stem}.meta.json"
@@ -112,6 +119,13 @@ def test_denoise_cli_no_denoising_method(synthetic_denoise_pxl_file):
         assert report["report_type"] == "denoise"
         assert report["number_of_umis_removed"] is None
         assert report["ratio_of_umis_removed"] is None
+
+        # No denoising happened, so input and output read counts are identical.
+        expected_reads = int(
+            read(synthetic_denoise_pxl_file).adata().obs["reads_in_component"].sum()
+        )
+        assert report["input_reads"] == expected_reads
+        assert report["output_reads"] == expected_reads
 
         # The output pxl is a verbatim copy of the input: denoising was skipped.
         out_pxl = _denoised_output(output_dir, synthetic_denoise_pxl_file)

--- a/tests/pna/sample_calling/test_sample_calling.py
+++ b/tests/pna/sample_calling/test_sample_calling.py
@@ -621,15 +621,18 @@ class _FakeFilteredDataset:
         *,
         component_ids: set[str],
         hash_enrichment_factors: list[float] | None = None,
+        reads_in_component: list[int] | None = None,
     ):
         """Initialize the instance.
 
         Args:
             component_ids: Component ids.
             hash_enrichment_factors: Hash enrichment factors.
+            reads_in_component: Reads in component.
         """
         self._component_ids = component_ids
         self._hash_enrichment_factors = hash_enrichment_factors
+        self._reads_in_component = reads_in_component
 
     def components(self) -> set[str]:
         """Components.
@@ -654,12 +657,13 @@ class _FakeFilteredDataset:
         n = len(self._hash_enrichment_factors)
         # Explicit string obs index avoids AnnData ImplicitModificationWarning on index coercion.
         obs_index = [f"comp_{i}" for i in range(n)]
+        obs = {"hash_enrichment_factor": self._hash_enrichment_factors}
+        if self._reads_in_component is not None:
+            assert len(self._reads_in_component) == n
+            obs["reads_in_component"] = self._reads_in_component
         return anndata.AnnData(
             X=np.zeros((n, 1)),
-            obs=pd.DataFrame(
-                {"hash_enrichment_factor": self._hash_enrichment_factors},
-                index=obs_index,
-            ),
+            obs=pd.DataFrame(obs, index=obs_index),
         )
 
 
@@ -672,6 +676,7 @@ class _FakeMergedDataset:
         all_components: set[str],
         undetermined_components: set[str] | None,
         enrichment_factors_per_sample: dict[str, list[float]],
+        reads_in_component_per_sample: dict[str, list[int]] | None = None,
     ):
         """Initialize the instance.
 
@@ -679,10 +684,12 @@ class _FakeMergedDataset:
             all_components: All components.
             undetermined_components: Undetermined components.
             enrichment_factors_per_sample: Hash enrichment factors per sample.
+            reads_in_component_per_sample: Reads in component, per sample.
         """
         self._all_components = all_components
         self._undetermined_components = undetermined_components
         self._enrichment_factors_per_sample = enrichment_factors_per_sample
+        self._reads_in_component_per_sample = reads_in_component_per_sample or {}
 
     def components(self) -> set[str]:
         """Components.
@@ -723,6 +730,9 @@ class _FakeMergedDataset:
                 hash_enrichment_factors=self._enrichment_factors_per_sample.get(
                     "undetermined"
                 ),
+                reads_in_component=self._reads_in_component_per_sample.get(
+                    "undetermined"
+                ),
             )
         if samples not in self._enrichment_factors_per_sample:
             raise ValueError(
@@ -731,11 +741,12 @@ class _FakeMergedDataset:
         return _FakeFilteredDataset(
             component_ids=set(),
             hash_enrichment_factors=self._enrichment_factors_per_sample[samples],
+            reads_in_component=self._reads_in_component_per_sample.get(samples),
         )
 
 
 def test_create_final_report_works_when_no_undetermined_sample():
-    """When ``undetermined`` is not a sample, the success rate is 100%."""
+    """When ``undetermined`` is not a sample, the success rate is 100% and all reads count as output."""
     ds = _FakeMergedDataset(
         all_components={"c1", "c2", "c3"},
         undetermined_components=None,
@@ -743,8 +754,12 @@ def test_create_final_report_works_when_no_undetermined_sample():
             "PBMC": [10.0, 9.5],
             "Raji": [8.0],
         },
+        reads_in_component_per_sample={
+            "PBMC": [30, 20],
+            "Raji": [15],
+        },
     )
-    report = create_final_report(ds)  # type: ignore[arg-type]
+    report = create_final_report(ds, input_reads=30 + 20 + 15)  # type: ignore[arg-type]
 
     assert report.sample_id == "all"
     assert report.product_id == "single-cell-pna"
@@ -755,10 +770,15 @@ def test_create_final_report_works_when_no_undetermined_sample():
         "PBMC": [10.0, 9.5],
         "Raji": [8.0],
     }
+    assert report.input_reads == 30 + 20 + 15
+    assert report.output_reads == 30 + 20 + 15
 
 
 def test_create_final_report_percentage_excludes_undetermined_components():
-    """Success rate is 1 minus the fraction of components in the undetermined sample."""
+    """Success rate is 1 minus the fraction of components in the undetermined sample.
+
+    Reads in the undetermined sample must not count toward output_reads.
+    """
     ds = _FakeMergedDataset(
         all_components={"a", "b", "c", "d"},
         undetermined_components={"d"},
@@ -766,27 +786,37 @@ def test_create_final_report_percentage_excludes_undetermined_components():
             "PBMC": [10.0, 10.0, 10.0],
             "undetermined": [1.2],
         },
+        reads_in_component_per_sample={
+            "PBMC": [10, 20, 30],
+            "undetermined": [100],
+        },
     )
-    report = create_final_report(ds)  # type: ignore[arg-type]
+    report = create_final_report(ds, input_reads=10 + 20 + 30 + 100)  # type: ignore[arg-type]
 
     assert report.number_of_components == 4
     assert report.percentage_of_components_successfully_called == pytest.approx(0.75)
     assert report.hash_enrichment_factors_per_sample["PBMC"] == [10.0, 10.0, 10.0]
     assert report.hash_enrichment_factors_per_sample["undetermined"] == [1.2]
+    assert report.input_reads == 10 + 20 + 30 + 100
+    assert report.output_reads == 10 + 20 + 30
 
 
 def test_create_final_report_zero_success_when_all_components_undetermined():
-    """When every component belongs to ``undetermined``, the success rate is 0."""
+    """When every component belongs to ``undetermined``, the success rate and output reads are 0."""
     ds = _FakeMergedDataset(
         all_components={"x", "y"},
         undetermined_components={"x", "y"},
         enrichment_factors_per_sample={"undetermined": [1.1, 1.2]},
+        reads_in_component_per_sample={"undetermined": [500, 700]},
     )
-    report = create_final_report(ds)  # type: ignore[arg-type]
+    report = create_final_report(ds, input_reads=1200)  # type: ignore[arg-type]
 
     assert report.number_of_components == 2
     assert report.percentage_of_components_successfully_called == 0.0
     assert report.hash_enrichment_factors_per_sample["undetermined"] == [1.1, 1.2]
+    assert report.input_reads == 1200
+    # Every read ended up in undetermined, so none count as output.
+    assert report.output_reads == 0
 
 
 def test_warn_if_undetermined_has_high_enrichment_logs_when_fraction_above_five_percent(

--- a/tests/pna/sample_calling/test_sample_calling_cli.py
+++ b/tests/pna/sample_calling/test_sample_calling_cli.py
@@ -61,6 +61,9 @@ def test_runs_ok(pna_data_root):
             assert report_data["report_type"] == "sample_calling"
             assert report_data["sample_id"] == sample_name
             assert "number_of_components" in report_data
+            assert report_data["input_reads"] > 0
+            assert report_data["output_reads"] > 0
+            assert report_data["output_reads"] <= report_data["input_reads"]
 
             meta_data = json.loads(meta_json.read_text())
             assert (
@@ -76,6 +79,19 @@ def test_runs_ok(pna_data_root):
         assert total_data["sample_id"] == "all"
         assert "hash_enrichment_factors_per_sample" in total_data
         assert "percentage_of_components_successfully_called" in total_data
+        input_pxl = read(str(pna_data_root / f"sample_calling/{pool_name}.pxl"))
+        expected_input_reads = int(input_pxl.adata().obs["reads_in_component"].sum())
+        assert total_data["input_reads"] == expected_input_reads
+
+        expected_output_reads = 0
+        for output in outputs:
+            if get_sample_name(output) == f"{pool_name}_undetermined":
+                continue
+            expected_output_reads += int(
+                read(output).adata().obs["reads_in_component"].sum()
+            )
+        assert total_data["output_reads"] == expected_output_reads
+        assert total_data["output_reads"] < total_data["input_reads"]
         assert (
             np.abs(total_data["percentage_of_components_successfully_called"] - 12 / 15)
             < 1e-6


### PR DESCRIPTION
input_reads and output_reads are typically reported for all steps of the PNA pipeline but they were missing in denoise and sample calling.

Fixes: PNA-2715

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce it when relevant.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-count reporting only in JSON reports and tests; no changes to denoising or sample-calling algorithms or data paths.
> 
> **Overview**
> Adds **`input_reads`** and **`output_reads`** to `report.json` for **`single-cell-pna denoise`** and **`single-cell-pna sample-calling`**, matching other PNA pipeline stages.
> 
> For **denoise**, counts come from summing `reads_in_component` on the input PXL and on the written output (when denoising is off, both values are equal). For **sample-calling**, each per-sample report compares reads attributed to that sample’s components in the pool input vs the dehashed output; the pooled **`sample_calling_total`** report uses full-pool input reads and sums output reads **excluding** the undetermined sample.
> 
> Report models, CLI wiring, `create_final_report`, and tests are updated accordingly; **CHANGELOG** documents the addition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b94712662eb06f02f98927ef1dbaf6b734fb5988. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->