### PR TITLE
fix html_baseurl

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -125,7 +125,7 @@ _docs_base_url = os.environ.get(
     "https://PixelgenTechnologies.github.io/pixelator",
 ).rstrip("/")
 
-html_baseurl = f"{_docs_base_url}/"
+html_baseurl = f"{_docs_base_url}/{_docs_version}/"
 html_theme = "pydata_sphinx_theme"
 html_theme_options = {
     "icon_links": [


### PR DESCRIPTION
## Description

Small fix to set a configuration variable correctly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

No tests.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line Sphinx configuration change for documentation URLs; no runtime or application logic affected.
> 
> **Overview**
> Updates Sphinx **`html_baseurl`** in `docs/conf.py` so it includes the **`DOCS_VERSION`** path segment (e.g. `…/pixelator/latest/`), matching how the deploy workflow publishes HTML under `docs/${DOCS_VERSION}` on GitHub Pages.
> 
> Previously the base URL pointed at the site root without the version folder, which could misalign canonical URLs and metadata with the actual published paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec7f67b2ba5f2a4243b648069121cccc0f4ad583. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->