### PR TITLE
Make uei_count optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- `uei_count` is now optional on PNA edgelists in `sample_calling` and the graph component
+  recovery path. When the column is absent, sample calling skips it and graph molecule
+  statistics use the number of edges.
+
 ## [0.30.0] - 2026-08-05
 
 ### Added

--- a/src/pixelator/pna/graph/component_recovery.py
+++ b/src/pixelator/pna/graph/component_recovery.py
@@ -18,6 +18,10 @@ from pixelator.pna.graph.community_detection import (
     StagedRefinementOptions,
     find_components,
 )
+from pixelator.pna.graph.component_recovery_utils import (
+    has_uei_count,
+    n_molecules_sql,
+)
 from pixelator.pna.graph.report import GraphStatistics
 from pixelator.pna.pixeldataset import PNAPixelDataset
 from pixelator.pna.pixeldataset.io import PixelFileWriter
@@ -113,8 +117,9 @@ def build_pxl_file_with_components(
             )
             logger.debug("Counting molecules")
 
+            molecules_sql = n_molecules_sql(has_uei_count(pxl_connection, "edgelist"))
             sums = pxl_connection.execute(
-                "SELECT SUM(uei_count) as uei_count FROM edgelist"
+                f"SELECT {molecules_sql} as uei_count FROM edgelist"
             ).pl()
 
             component_stats.molecules_output = int(sums["uei_count"][0])

--- a/src/pixelator/pna/graph/component_recovery_utils.py
+++ b/src/pixelator/pna/graph/component_recovery_utils.py
@@ -26,6 +26,18 @@ from pixelator.pna.graph.report import GraphStatistics
 logger = logging.getLogger(__name__)
 
 
+def has_uei_count(con, relation: str) -> bool:
+    """Return True if ``relation`` has a ``uei_count`` column."""
+    return "uei_count" in {
+        row[0] for row in con.execute(f"DESCRIBE {relation}").fetchall()
+    }
+
+
+def n_molecules_sql(has_uei_count: bool) -> str:
+    """SQL expression for molecule count; defaults to edge count when absent."""
+    return "SUM(uei_count)" if has_uei_count else "COUNT(*)"
+
+
 class ConnectedComponentException(PixelatorBaseException):
     """Raised when connected-component computation or filtering fails."""
 
@@ -170,11 +182,12 @@ def get_count_statistics(edgelist_path: Path) -> dict:
         con.execute(
             f"CREATE VIEW edgelist AS SELECT * FROM parquet_scan('{str(edgelist_path)}')"
         )
-        n_edges, n_reads, n_molecules, n_umi = con.execute("""
+        n_molecules_expr = n_molecules_sql(has_uei_count(con, "edgelist"))
+        n_edges, n_reads, n_molecules, n_umi = con.execute(f"""
             SELECT
                 COUNT(*) AS n_edges,
                 SUM(read_count) AS n_reads,
-                SUM(uei_count) AS n_molecules,
+                {n_molecules_expr} AS n_molecules,
                 (
                     SELECT COUNT(DISTINCT umi)
                     FROM (
@@ -412,14 +425,14 @@ def create_working_edgelist(
             FROM all_umis
         """)
 
-        con.execute("""
+        uei_count_sql = "ie.uei_count, " if has_uei_count(con, "input_edgelist") else ""
+        con.execute(f"""
             CREATE VIEW working_edgelist AS
             SELECT
                 nm1.working_name AS umi1,
                 nm2.working_name AS umi2,
                 ie.read_count,
-                ie.uei_count,
-                ie.marker_1,
+                {uei_count_sql}ie.marker_1,
                 ie.marker_2
             FROM input_edgelist ie
             JOIN node_map nm1 ON ie.umi1 = nm1.original_name

--- a/src/pixelator/pna/graph/component_recovery_utils.py
+++ b/src/pixelator/pna/graph/component_recovery_utils.py
@@ -425,14 +425,15 @@ def create_working_edgelist(
             FROM all_umis
         """)
 
-        uei_count_sql = "ie.uei_count, " if has_uei_count(con, "input_edgelist") else ""
+        uei_count_sql = "ie.uei_count," if has_uei_count(con, "input_edgelist") else ""
         con.execute(f"""
             CREATE VIEW working_edgelist AS
             SELECT
                 nm1.working_name AS umi1,
                 nm2.working_name AS umi2,
                 ie.read_count,
-                {uei_count_sql}ie.marker_1,
+                {uei_count_sql}
+                ie.marker_1,
                 ie.marker_2
             FROM input_edgelist ie
             JOIN node_map nm1 ON ie.umi1 = nm1.original_name

--- a/src/pixelator/pna/sample_calling/__init__.py
+++ b/src/pixelator/pna/sample_calling/__init__.py
@@ -404,8 +404,12 @@ def sample_calling(
 
             marker_1_sql = "COALESCE(hm1.base_marker, e.marker_1) AS marker_1"
             marker_2_sql = "COALESCE(hm2.base_marker, e.marker_2) AS marker_2"
+            edgelist_columns = {
+                row[0] for row in con.execute("DESCRIBE edgelist").fetchall()
+            }
+            uei_count_sql = "e.uei_count, " if "uei_count" in edgelist_columns else ""
             select_cols = (
-                "e.umi1, e.umi2, e.read_count, e.uei_count, "
+                f"e.umi1, e.umi2, e.read_count, {uei_count_sql}"
                 f"{marker_1_sql}, {marker_2_sql}, e.component"
             )
 

--- a/tests/pna/graph/test_component_recovery_utils.py
+++ b/tests/pna/graph/test_component_recovery_utils.py
@@ -7,6 +7,7 @@ import pytest
 
 from pixelator.pna.graph.component_recovery_utils import (
     create_component_size_data_frame,
+    create_working_edgelist,
     filter_connected_components_by_size,
     get_count_statistics,
     name_components_with_umi_hashes,
@@ -39,6 +40,57 @@ def test_get_count_statistics(tmp_path: Path) -> None:
         "n_reads": 60,
         "n_molecules": 6,
         "n_umi": 4,
+    }
+
+
+def test_get_count_statistics_without_uei_count(tmp_path: Path) -> None:
+    """When uei_count is absent, molecule count defaults to edge count."""
+    path = tmp_path / "edgelist.parquet"
+    pl.DataFrame(
+        {
+            "umi1": ["a", "b", "a"],
+            "umi2": ["d", "c", "d"],
+            "read_count": [10, 20, 30],
+        }
+    ).write_parquet(path)
+
+    stats = get_count_statistics(path)
+
+    assert stats == {
+        "n_edges": 3,
+        "n_reads": 60,
+        "n_molecules": 3,
+        "n_umi": 4,
+    }
+
+
+def test_create_working_edgelist_without_uei_count(tmp_path: Path) -> None:
+    """Working edgelist omits uei_count when the input column is missing."""
+    path = tmp_path / "edgelist.parquet"
+    pl.DataFrame(
+        {
+            "umi1": [1, 2],
+            "umi2": [3, 4],
+            "read_count": [10, 20],
+            "marker_1": ["A", "B"],
+            "marker_2": ["C", "D"],
+        }
+    ).cast(
+        {"umi1": pl.UInt64, "umi2": pl.UInt64, "read_count": pl.UInt32}
+    ).write_parquet(path)
+
+    working_edgelist_path, _ = create_working_edgelist(
+        input_edgelist_path=path, working_dir=tmp_path
+    )
+    working = pl.read_parquet(working_edgelist_path)
+
+    assert "uei_count" not in working.columns
+    assert set(working.columns) >= {
+        "umi1",
+        "umi2",
+        "read_count",
+        "marker_1",
+        "marker_2",
     }
 
 

--- a/tests/pna/sample_calling/test_sample_calling.py
+++ b/tests/pna/sample_calling/test_sample_calling.py
@@ -521,6 +521,109 @@ def test_sample_calling_does_not_strip_suffix_from_non_hash_markers(
 
 
 @pytest.mark.slow
+def test_sample_calling_without_uei_count(tmp_path: Path):
+    """sample_calling succeeds when the input edgelist has no uei_count column."""
+    panel_df = pd.DataFrame(
+        [
+            {
+                "marker_id": "PD-1",
+                "control": False,
+                "uniprot_id": "P00001",
+                "sequence_1": "ATCGATCGAA",
+                "sequence_2": "ATCGATCGAC",
+            },
+            {
+                "marker_id": "HashA",
+                "control": False,
+                "uniprot_id": "P00002",
+                "sequence_1": "ATCGATCGAT",
+                "sequence_2": "ATCGATCGAG",
+            },
+            {
+                "marker_id": "HashA-1",
+                "control": False,
+                "uniprot_id": "P00003",
+                "sequence_1": "ATCGATCGTT",
+                "sequence_2": "ATCGATCGTG",
+            },
+            {
+                "marker_id": "HashB-2",
+                "control": False,
+                "uniprot_id": "P00004",
+                "sequence_1": "ATCGATCGTA",
+                "sequence_2": "ATCGATCGTC",
+            },
+        ]
+    ).set_index("marker_id")
+
+    panel = PNAAntibodyPanel(
+        df=panel_df,
+        metadata=AntibodyPanelMetadata(
+            name="test-panel",
+            version="0.1.0",
+            aliases=["test-panel"],
+            description="Synthetic panel for sample-calling without uei_count.",
+        ),
+    )
+
+    edgelist = pl.DataFrame(
+        {
+            "umi1": pl.Series([1, 2, 3], dtype=pl.UInt64),
+            "umi2": pl.Series([2, 3, 4], dtype=pl.UInt64),
+            "read_count": pl.Series([10, 10, 10], dtype=pl.UInt32),
+            "marker_1": ["PD-1", "PD-1", "HashA-1"],
+            "marker_2": ["PD-1", "HashA-1", "HashA-1"],
+            "component": ["c1", "c1", "c1"],
+        }
+    )
+    assert "uei_count" not in edgelist.columns
+
+    target = tmp_path / "input.pxl"
+    with PixelFileWriter(target) as writer:
+        writer.write_edgelist(edgelist)
+        con = writer.get_connection()
+        adata = pna_edgelist_to_anndata(con, panel=panel)
+        writer.write_adata(adata)
+        writer.write_metadata(
+            {
+                "sample_name": "input",
+                "version": "0.1.0",
+                "panel_name": "custom_panel",
+            }
+        )
+
+    input_pxl = read(target)
+    hashing_antibodies = HashedAntibodyMapping(
+        mapping={"S1": ["HashA-1"]},
+        all_hashing_antibodies=["HashA-1", "HashB-2"],
+    )
+
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    sample_calling(
+        input_pxl=input_pxl,
+        hashing_antibody_mapping=hashing_antibodies,
+        output_folder=out_dir,
+        remove_incompatible=True,
+        enrichment_threshold=1.5,
+    )
+
+    output_files = list(out_dir.glob("*.dehashed.pxl"))
+    assert len(output_files) == 1
+
+    dehashed_edgelist = read(output_files[0]).edgelist().to_polars()
+    assert "uei_count" not in dehashed_edgelist.columns
+    assert set(dehashed_edgelist.columns) >= {
+        "umi1",
+        "umi2",
+        "read_count",
+        "marker_1",
+        "marker_2",
+        "component",
+    }
+
+
+@pytest.mark.slow
 def test_sample_calling_with_undetermined(sample_hashed_pixel_files, tmp_path):
     """Test the sample calling functionality.
 


### PR DESCRIPTION
## Description

Make the `uei_count` column optional.

Fixes: pna-3264

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

With the associated unit tests.

## PR checklist:

- [ ] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible schema relaxation with localized DuckDB/SQL branching; behavior when `uei_count` is present is unchanged, and molecule counts without it use edge count as documented.
> 
> **Overview**
> **`uei_count` is now optional** on PNA edgelists in **sample calling** and **graph component recovery**. Edgelists that omit the column no longer fail on hard-coded `SUM(uei_count)` or `SELECT` lists.
> 
> Shared helpers **`has_uei_count`** (DuckDB `DESCRIBE`) and **`n_molecules_sql`** (`SUM(uei_count)` vs `COUNT(*)`) drive the behavior. **Graph recovery** uses them for molecule totals in `get_count_statistics`, PXL build stats, and **`create_working_edgelist`** (the column is dropped from the working parquet when missing). **Sample calling** builds the dehashed edgelist `COPY` without `uei_count` when it is not present.
> 
> **CHANGELOG** documents the change under Unreleased. **Unit tests** cover stats, working edgelist shape, and end-to-end sample calling without `uei_count`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f4277f6fe3f2e25041d62744825193725e065ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->