### PR TITLE
Remove last mentions of MPX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,3 @@ ENV/
 .task
 
 pytest-results
-
-# Exclude test data run for report integration testing
-tests/pixelator/mpx/report/assets/full_run

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ docker pull quay.io/pixelgen-technologies/pixelator:latest
 docker run quay.io/pixelgen-technologies/pixelator:latest pixelator --help
 ```
 
-For MPX workflows, pin an image tag from a release prior to 0.31.0 (for example `0.30.0`) instead of `latest`.
+For deprecated MPX workflows, pin an image tag from a release prior to 0.31.0 (for example `0.30.0`) instead of `latest`.
 
 ## Usage
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ Key files:
 
 - Imported members (`imported-members`) are intentionally included in the docs generation via `autoapi_options`.
 - Private members (`private-members`) are not included via `autoapi_options`.
-- Parts of the codebase, e.g. names related to MPX, are ignored via `autoapi_ignore`.
+- Parts of the codebase, e.g. cli related functions, are ignored via `autoapi_ignore`.
 
 
 
@@ -42,7 +42,7 @@ Key files:
 
 - Builds run in nitpicky mode (`nitpicky = True` in `docs/conf.py`, and the `-n` flag), so unresolved cross-references are reported as warnings. CI builds additionally pass `--fail-on-warning`, which means any warning fails the build.
 - Known-acceptable warnings are suppressed:
-  - `nitpick_ignore_regex` silences specific cross-reference targets that cannot be resolved (e.g. MPX names).
+  - `nitpick_ignore_regex` silences specific cross-reference targets that cannot be resolved (e.g. external dependencies).
   - `suppress_warnings` silences whole Sphinx warning categories (`ref.python`, `autoapi.python_import_resolution`).
   - A logging filter (`_keep_warning`) drops a small set of warnings that are emitted without a Sphinx type/subtype and so cannot be matched by `suppress_warnings`.
 - When new code introduces a cross-reference warning, prefer fixing the reference.

--- a/docs/cli/index.rst
+++ b/docs/cli/index.rst
@@ -6,9 +6,3 @@ This section documents the Pixelator command-line interface.
 .. click:: pixelator.cli.main:main_cli
    :prog: pixelator
    :nested: full
-   :commands: single-cell-pna
-
-.. .. use the following (more robust) when MPX is removed from the codebase
-.. .. click:: pixelator.cli.main:main_cli
-..    :prog: pixelator
-..    :nested: full

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,8 +18,6 @@ author = "Pixelgen Technologies"
 
 nitpicky = True
 nitpick_ignore_regex = [
-    # --- MPX excluded ---
-    (r"py:.*", r"pixelator\.mpx\..*"),
     # --- Unable to resolve intersphinx inventory ---
     (r"py:.*", r"polars\..*"),
     (r"py:.*", r"cutadapt\..*"),
@@ -84,8 +82,6 @@ autoapi_root = "api/generated"
 autoapi_add_toctree_entry = False
 
 autoapi_ignore = [
-    "*/pixelator/mpx/*",
-    "*/pixelator/mpx/**/*",
     "*/pixelator/cli/*",
     "*/pixelator/cli/**/*",
     "*/pixelator/pna/cli/*",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,9 +3,8 @@ Pixelator documentation
 
 `Pixelgen Technologies <https://www.pixelgen.com/>`_ provides Pixelator, a suite of open source
 software solutions that empower users working with
-`Molecular Pixelation (MPX) <https://software.pixelgen.com/common/glossary/#mpx>`_
-and `Proximity Network (PNA) <https://software.pixelgen.com/common/glossary/#pna>`_
-assays in data processing and analysis.
+`Proximity Network Assays (PNA) <https://software.pixelgen.com/common/glossary/#pna>`_
+in data processing and analysis.
 
 Pixelator can be used in two ways: as a `data processing pipeline
 (nf-core/pixelator) <https://software.pixelgen.com/nf-core-pixelator/introduction/>`_
@@ -13,7 +12,7 @@ and as a programming library (pixelator).
 The pipeline nf-core/pixelator consists of several steps and will produce
 ready-to-analyze outputs from your initial FASTQ sequencing libraries.
 Usage of Pixelator as a programming library is covered in the API reference and in
-our data analysis sections for MPX and PNA (see "Pixelgen software site" below).
+our data analysis sections for PNA (see "Pixelgen software site" below).
 
 
 .. grid:: 1 1 2 2

--- a/src/pixelator/__init__.py
+++ b/src/pixelator/__init__.py
@@ -14,8 +14,8 @@ except metadata.PackageNotFoundError:
 
 
 # Adding imports here as shortcuts to be able to import like
-# import pixelator as mpx
-# mpx.read("<file path>")
+# import pixelator.pna as pna
+# pna.read("<file path>")
 # and similar
 
 from pixelator.pna import DownloadableDatasets


### PR DESCRIPTION
@elhb I found a couple mentions of MPX in files that were not touched by #439 , so I figured it would me easier to just remove them myself and merge the result into your PR :)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, comments, and ignore-list tweaks only; no runtime logic or API surface changes beyond doc generation scope.
> 
> **Overview**
> Cleans up **leftover MPX mentions** after the main MPX removal: drops a `.gitignore` entry for MPX report test assets, tightens README wording to **deprecated MPX** Docker pinning, and reframes docs landing/overview text around **PNA only**.
> 
> **Sphinx / AutoAPI** no longer special-cases MPX: `nitpick_ignore_regex` and `autoapi_ignore` entries for `pixelator.mpx` are removed, and handbook notes now describe CLI ignores and external-deps nitpick silencing instead of MPX.
> 
> The **CLI docs** (`docs/cli/index.rst`) document the full `pixelator` click tree again (no `:commands: single-cell-pna` filter or MPX-removal placeholder comments).
> 
> `src/pixelator/__init__.py` shortcut comment is updated to **`pixelator.pna`** instead of the old `mpx` import example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d743ebc7dbfe1d3d26b3e04834b0825fdd90ea33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->