### PR TITLE
Use affinity- and cgroup-quota-aware core count instead of host cpu_count() (PNA-2021)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - The default number of cores and the fallbacks used when `--cores` is not set now respect the
-  CPU affinity and cgroup/container limits of the running process (via `os.process_cpu_count()`
-  or `os.sched_getaffinity()`) instead of always reporting the host machine's core count. This
-  prevents multiprocessing oversubscription and slowdowns when running inside a container or pod
-  with a restricted CPU allocation.
+  CPU affinity of the running process (via `os.process_cpu_count()` or `os.sched_getaffinity()`)
+  as well as the cgroup CPU bandwidth quota used by container CPU limits such as
+  `docker run --cpus` and Kubernetes `limits.cpu` (via `cpu.max` on cgroup v2 and
+  `cpu.cfs_quota_us`/`cpu.cfs_period_us` on cgroup v1), instead of always reporting the host
+  machine's core count. This prevents multiprocessing oversubscription and slowdowns when running
+  inside a container or pod with a restricted CPU allocation.
 
 ## [0.30.0] - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recovery path. When the column is absent, sample calling skips it and graph molecule
   statistics use the number of edges.
 
+### Fixed
+- The default number of cores and the fallbacks used when `--cores` is not set now respect the
+  CPU affinity and cgroup/container limits of the running process (via `os.process_cpu_count()`
+  or `os.sched_getaffinity()`) instead of always reporting the host machine's core count. This
+  prevents multiprocessing oversubscription and slowdowns when running inside a container or pod
+  with a restricted CPU allocation.
+
 ## [0.30.0] - 2026-08-05
 
 ### Added

--- a/src/pixelator/cli/main.py
+++ b/src/pixelator/cli/main.py
@@ -4,7 +4,6 @@ Copyright © 2022 Pixelgen Technologies AB.
 """
 
 import atexit
-import multiprocessing
 import sys
 
 import click
@@ -18,7 +17,7 @@ from pixelator.common.duckdb_utils import (
     get_duckdb_max_temp_dir_size_from_env,
     get_duckdb_temp_dir_from_env,
 )
-from pixelator.common.utils import click_echo
+from pixelator.common.utils import click_echo, get_available_cpu_count
 
 
 @click.group(cls=AliasedOrderedGroup, name="pixelator")
@@ -46,7 +45,7 @@ from pixelator.common.utils import click_echo
 )
 @click.option(
     "--cores",
-    default=max(1, multiprocessing.cpu_count() - 1),
+    default=max(1, get_available_cpu_count() - 1),
     required=False,
     type=click.INT,
     show_default=True,

--- a/src/pixelator/common/utils/__init__.py
+++ b/src/pixelator/common/utils/__init__.py
@@ -11,6 +11,7 @@ import itertools
 import json
 import logging
 import multiprocessing
+import os
 import re
 import tempfile
 import textwrap
@@ -393,6 +394,39 @@ def _add_handlers_to_root_logger(port, log_level):
     root_logger.addHandler(socket_handler)
 
 
+def get_available_cpu_count() -> int:
+    """Return the number of CPU cores available to the current process.
+
+    Prefer CPU counts that respect the process' CPU affinity and cgroup or
+    container limits over the total number of cores on the host machine. When
+    running inside a constrained environment such as a container or a scheduler
+    pod, ``multiprocessing.cpu_count()`` reports the host core count rather than
+    the cores actually assigned to the process, which leads to oversubscription
+    and slower multiprocessing.
+
+    Returns:
+        The number of usable CPU cores, always at least 1.
+    """
+    # os.process_cpu_count() (Python 3.13+) already accounts for CPU affinity.
+    process_cpu_count = getattr(os, "process_cpu_count", None)
+    if process_cpu_count is not None:
+        count = process_cpu_count()
+        if count:
+            return count
+
+    # os.sched_getaffinity() accounts for CPU affinity but is only available on
+    # some Unix platforms (e.g. Linux); this covers the pre-3.13 pod use case.
+    sched_getaffinity = getattr(os, "sched_getaffinity", None)
+    if sched_getaffinity is not None:
+        try:
+            return len(sched_getaffinity(0))
+        except OSError:
+            pass
+
+    # Fall back to the total number of cores on the machine (e.g. on Windows).
+    return os.cpu_count() or 1
+
+
 def _pre_multiprocessing_args(
     nbr_cores=None, logging_setup=None, context="spawn", **kwargs
 ):
@@ -405,9 +439,7 @@ def _pre_multiprocessing_args(
         click_logging_setup = current_click_context.obj.get("LOGGER")
         click_nbr_cores = current_click_context.obj.get("CORES")
 
-    nbr_cores = (
-        nbr_cores if nbr_cores else click_nbr_cores or multiprocessing.cpu_count()
-    )
+    nbr_cores = nbr_cores if nbr_cores else click_nbr_cores or get_available_cpu_count()
     args_dict = {
         "max_workers": nbr_cores,
         "mp_context": multiprocessing.get_context(context),

--- a/src/pixelator/common/utils/__init__.py
+++ b/src/pixelator/common/utils/__init__.py
@@ -10,6 +10,7 @@ import gzip
 import itertools
 import json
 import logging
+import math
 import multiprocessing
 import os
 import re
@@ -394,19 +395,11 @@ def _add_handlers_to_root_logger(port, log_level):
     root_logger.addHandler(socket_handler)
 
 
-def get_available_cpu_count() -> int:
-    """Return the number of CPU cores available to the current process.
+_CGROUP_ROOT = Path("/sys/fs/cgroup")
 
-    Prefer CPU counts that respect the process' CPU affinity and cgroup or
-    container limits over the total number of cores on the host machine. When
-    running inside a constrained environment such as a container or a scheduler
-    pod, ``multiprocessing.cpu_count()`` reports the host core count rather than
-    the cores actually assigned to the process, which leads to oversubscription
-    and slower multiprocessing.
 
-    Returns:
-        The number of usable CPU cores, always at least 1.
-    """
+def _affinity_cpu_count() -> int:
+    """Return the number of CPU cores the current process may be scheduled on."""
     # os.process_cpu_count() (Python 3.13+) already accounts for CPU affinity.
     process_cpu_count = getattr(os, "process_cpu_count", None)
     if process_cpu_count is not None:
@@ -425,6 +418,68 @@ def get_available_cpu_count() -> int:
 
     # Fall back to the total number of cores on the machine (e.g. on Windows).
     return os.cpu_count() or 1
+
+
+def _cgroup_cpu_quota_count() -> Optional[int]:
+    """Return the number of CPU cores allowed by the cgroup CPU bandwidth limit.
+
+    Container CPU limits (``docker run --cpus``, Kubernetes ``limits.cpu``) are
+    usually enforced with a CFS bandwidth quota rather than a cpuset, and are
+    therefore invisible to the CPU affinity APIs. Inside a container the
+    container's own cgroup is what is mounted at ``/sys/fs/cgroup``, so the quota
+    can be read from the cgroup v2 or v1 files there.
+
+    Returns:
+        The number of cores the quota corresponds to, rounded up, or None if no
+        quota is set or it cannot be read.
+    """
+    cpu_max_file = _CGROUP_ROOT / "cpu.max"
+    quota_file = _CGROUP_ROOT / "cpu" / "cpu.cfs_quota_us"
+    period_file = _CGROUP_ROOT / "cpu" / "cpu.cfs_period_us"
+
+    try:
+        if cpu_max_file.is_file():
+            quota, period = cpu_max_file.read_text().split()
+        elif quota_file.is_file() and period_file.is_file():
+            quota = quota_file.read_text().strip()
+            period = period_file.read_text().strip()
+        else:
+            return None
+
+        # "max" (cgroup v2) and a negative quota (cgroup v1) mean "no limit".
+        if quota == "max":
+            return None
+        quota_us = int(quota)
+        period_us = int(period)
+    except (OSError, ValueError):
+        return None
+
+    if quota_us <= 0 or period_us <= 0:
+        return None
+
+    return max(1, math.ceil(quota_us / period_us))
+
+
+def get_available_cpu_count() -> int:
+    """Return the number of CPU cores available to the current process.
+
+    Prefer CPU counts that respect the process' CPU affinity and cgroup or
+    container limits over the total number of cores on the host machine. When
+    running inside a constrained environment such as a container or a scheduler
+    pod, ``multiprocessing.cpu_count()`` reports the host core count rather than
+    the cores actually assigned to the process, which leads to oversubscription
+    and slower multiprocessing.
+
+    Returns:
+        The number of usable CPU cores, always at least 1.
+    """
+    count = _affinity_cpu_count()
+
+    quota_count = _cgroup_cpu_quota_count()
+    if quota_count is not None:
+        count = min(count, quota_count)
+
+    return max(1, count)
 
 
 def _pre_multiprocessing_args(

--- a/src/pixelator/pna/amplicon/process.py
+++ b/src/pixelator/pna/amplicon/process.py
@@ -1,7 +1,6 @@
 """Copyright © 2024 Pixelgen Technologies AB."""
 
 import logging
-import multiprocessing as mp
 import sys
 from pathlib import Path
 from typing import Sequence
@@ -17,6 +16,7 @@ from cutadapt.modifiers import (
 from cutadapt.steps import PairedEndStep, SingleEndFilter, SingleEndSink, SingleEndStep
 from cutadapt.utils import DummyProgress, Progress
 
+from pixelator.common.utils import get_available_cpu_count
 from pixelator.common.utils.log_progress import LogProgress
 from pixelator.pna.amplicon.build_amplicon import (
     PairedEndAmpliconBuilder,
@@ -78,7 +78,7 @@ def amplicon_fastq(
     Returns:
         An `AmpliconStatistics` instance.
     """
-    threads = threads if threads > 0 else mp.cpu_count()
+    threads = threads if threads > 0 else get_available_cpu_count()
 
     if len(inputs) not in [1, 2]:
         raise ValueError("Expected one or two input files, got %s" % len(inputs))

--- a/src/pixelator/pna/analysis_engine.py
+++ b/src/pixelator/pna/analysis_engine.py
@@ -5,7 +5,6 @@ Copyright © 2024 Pixelgen Technologies AB.
 
 import itertools
 import logging
-import multiprocessing
 import typing
 from collections import defaultdict
 from dataclasses import dataclass
@@ -19,6 +18,7 @@ import pandas as pd
 import polars as pl
 from joblib import Parallel, delayed
 
+from pixelator.common.utils import get_available_cpu_count
 from pixelator.pna import read
 from pixelator.pna.graph import PNAGraph
 from pixelator.pna.pixeldataset import Component, PNAPixelDataset
@@ -74,9 +74,7 @@ def _get_joblib_executor(nbr_cores=None, **kwargs) -> Parallel:
     if current_click_context:
         click_nbr_cores = current_click_context.obj.get("CORES")
 
-    nbr_cores = (
-        nbr_cores if nbr_cores else click_nbr_cores or multiprocessing.cpu_count()
-    )
+    nbr_cores = nbr_cores if nbr_cores else click_nbr_cores or get_available_cpu_count()
     return _ParallelWithLogging(n_jobs=nbr_cores, **kwargs)
 
 

--- a/src/pixelator/pna/collapse/independent/collapser.py
+++ b/src/pixelator/pna/collapse/independent/collapser.py
@@ -6,7 +6,6 @@ Copyright © 2024 Pixelgen Technologies AB.
 import dataclasses
 import logging
 import math
-import multiprocessing
 import os
 import time
 import typing
@@ -26,6 +25,7 @@ import pyarrow.compute
 import pyarrow.parquet
 import pydantic
 
+from pixelator.common.utils import get_available_cpu_count
 from pixelator.pna.collapse.adjacency import (
     build_network_cluster,
     build_network_directional,
@@ -489,7 +489,7 @@ class RegionCollapser:
     @cached_property
     def _effective_threads(self):
         if self.threads <= -1:
-            return multiprocessing.cpu_count() + 1 - abs(self.threads)
+            return get_available_cpu_count() + 1 - abs(self.threads)
 
         return self.threads
 

--- a/src/pixelator/pna/collapse/paired/collapser.py
+++ b/src/pixelator/pna/collapse/paired/collapser.py
@@ -6,7 +6,6 @@ Copyright © 2024 Pixelgen Technologies AB.
 import dataclasses
 import logging
 import math
-import multiprocessing
 import time
 import typing
 from contextlib import contextmanager
@@ -26,6 +25,7 @@ import pyarrow.compute
 import pyarrow.parquet
 
 from pixelator.common.report.models import SummaryStatistics
+from pixelator.common.utils import get_available_cpu_count
 from pixelator.pna.collapse.adjacency import (
     build_network_cluster,
     build_network_directional,
@@ -228,7 +228,7 @@ class MoleculeCollapser:
     @cached_property
     def _effective_threads(self):
         if self.threads <= -1:
-            return multiprocessing.cpu_count() + 1 - abs(self.threads)
+            return get_available_cpu_count() + 1 - abs(self.threads)
 
         return self.threads
 

--- a/src/pixelator/pna/demux/process.py
+++ b/src/pixelator/pna/demux/process.py
@@ -18,7 +18,7 @@ from cutadapt.steps import SingleEndSink
 from cutadapt.utils import DummyProgress, Progress
 
 from pixelator.common.exceptions import PixelatorBaseException
-from pixelator.common.utils import get_sample_name
+from pixelator.common.utils import get_available_cpu_count, get_sample_name
 from pixelator.common.utils.log_progress import LogProgress
 from pixelator.pna.config import PNAAntibodyPanel, PNAAssay
 from pixelator.pna.demux.barcode_demuxer import (
@@ -41,8 +41,6 @@ from pixelator.pna.read_processing.runners import ParallelPipelineRunner
 from pixelator.pna.utils import clean_suffixes, init_duckdb_conn
 
 logger = logging.getLogger("demux")
-
-import multiprocessing as mp
 
 
 def correct_marker_barcodes(
@@ -71,7 +69,7 @@ def correct_marker_barcodes(
         threads: The number of threads to use for processing. By default all available cores are
             used.
     """
-    threads = threads if threads > 0 else mp.cpu_count()
+    threads = threads if threads > 0 else get_available_cpu_count()
 
     # Open file handles for input files
     input_files = InputPaths(str(input))
@@ -169,7 +167,7 @@ def demux_barcode_groups(
     """
     # Open file handles for input files
 
-    threads = threads if threads > 0 else max(mp.cpu_count(), 1)
+    threads = threads if threads > 0 else max(get_available_cpu_count(), 1)
 
     input_files = InputPaths(str(corrected_reads))
 

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -1,12 +1,17 @@
 """Copyright © 2023 Pixelgen Technologies AB."""
 
 import json
+import os
 
 import click
 import pytest
 from click.testing import CliRunner
 
-from pixelator.common.utils import flatten, write_parameters_file
+from pixelator.common.utils import (
+    flatten,
+    get_available_cpu_count,
+    write_parameters_file,
+)
 
 
 @pytest.mark.parametrize(
@@ -85,3 +90,39 @@ def test_write_parameters_file_includes_single_file_argument(tmp_path):
     data = json.loads(meta_file.read_text())
     assert data["cli"]["options"]["--flag"] is True
     assert data["cli"]["arguments"]["pxl_file"] == str(input_file.resolve())
+
+
+def test_get_available_cpu_count_prefers_process_cpu_count(monkeypatch):
+    """process_cpu_count (affinity-aware, Python 3.13+) is used when available."""
+    monkeypatch.setattr(os, "process_cpu_count", lambda: 4, raising=False)
+    monkeypatch.setattr(os, "sched_getaffinity", lambda pid: {0, 1}, raising=False)
+    monkeypatch.setattr(os, "cpu_count", lambda: 128)
+
+    assert get_available_cpu_count() == 4
+
+
+def test_get_available_cpu_count_falls_back_to_sched_getaffinity(monkeypatch):
+    """sched_getaffinity is used when process_cpu_count is unavailable or None."""
+    monkeypatch.setattr(os, "process_cpu_count", lambda: None, raising=False)
+    monkeypatch.setattr(os, "sched_getaffinity", lambda pid: {0, 1, 2}, raising=False)
+    monkeypatch.setattr(os, "cpu_count", lambda: 128)
+
+    assert get_available_cpu_count() == 3
+
+
+def test_get_available_cpu_count_falls_back_to_cpu_count(monkeypatch):
+    """os.cpu_count is used when no affinity-aware API is available (e.g. Windows)."""
+    monkeypatch.setattr(os, "process_cpu_count", None, raising=False)
+    monkeypatch.delattr(os, "sched_getaffinity", raising=False)
+    monkeypatch.setattr(os, "cpu_count", lambda: 8)
+
+    assert get_available_cpu_count() == 8
+
+
+def test_get_available_cpu_count_is_always_at_least_one(monkeypatch):
+    """The count never drops below 1, even when every source returns None."""
+    monkeypatch.setattr(os, "process_cpu_count", lambda: None, raising=False)
+    monkeypatch.delattr(os, "sched_getaffinity", raising=False)
+    monkeypatch.setattr(os, "cpu_count", lambda: None)
+
+    assert get_available_cpu_count() == 1

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -7,6 +7,7 @@ import click
 import pytest
 from click.testing import CliRunner
 
+from pixelator.common import utils
 from pixelator.common.utils import (
     flatten,
     get_available_cpu_count,
@@ -92,7 +93,16 @@ def test_write_parameters_file_includes_single_file_argument(tmp_path):
     assert data["cli"]["arguments"]["pxl_file"] == str(input_file.resolve())
 
 
-def test_get_available_cpu_count_prefers_process_cpu_count(monkeypatch):
+@pytest.fixture(name="cgroup_root")
+def cgroup_root_fixture(tmp_path, monkeypatch):
+    """Point the cgroup lookup at an empty directory, i.e. no CPU quota set."""
+    root = tmp_path / "cgroup"
+    (root / "cpu").mkdir(parents=True)
+    monkeypatch.setattr(utils, "_CGROUP_ROOT", root)
+    return root
+
+
+def test_get_available_cpu_count_prefers_process_cpu_count(cgroup_root, monkeypatch):
     """process_cpu_count (affinity-aware, Python 3.13+) is used when available."""
     monkeypatch.setattr(os, "process_cpu_count", lambda: 4, raising=False)
     monkeypatch.setattr(os, "sched_getaffinity", lambda pid: {0, 1}, raising=False)
@@ -101,7 +111,9 @@ def test_get_available_cpu_count_prefers_process_cpu_count(monkeypatch):
     assert get_available_cpu_count() == 4
 
 
-def test_get_available_cpu_count_falls_back_to_sched_getaffinity(monkeypatch):
+def test_get_available_cpu_count_falls_back_to_sched_getaffinity(
+    cgroup_root, monkeypatch
+):
     """sched_getaffinity is used when process_cpu_count is unavailable or None."""
     monkeypatch.setattr(os, "process_cpu_count", lambda: None, raising=False)
     monkeypatch.setattr(os, "sched_getaffinity", lambda pid: {0, 1, 2}, raising=False)
@@ -110,7 +122,7 @@ def test_get_available_cpu_count_falls_back_to_sched_getaffinity(monkeypatch):
     assert get_available_cpu_count() == 3
 
 
-def test_get_available_cpu_count_falls_back_to_cpu_count(monkeypatch):
+def test_get_available_cpu_count_falls_back_to_cpu_count(cgroup_root, monkeypatch):
     """os.cpu_count is used when no affinity-aware API is available (e.g. Windows)."""
     monkeypatch.setattr(os, "process_cpu_count", None, raising=False)
     monkeypatch.delattr(os, "sched_getaffinity", raising=False)
@@ -119,10 +131,83 @@ def test_get_available_cpu_count_falls_back_to_cpu_count(monkeypatch):
     assert get_available_cpu_count() == 8
 
 
-def test_get_available_cpu_count_is_always_at_least_one(monkeypatch):
+def test_get_available_cpu_count_is_always_at_least_one(cgroup_root, monkeypatch):
     """The count never drops below 1, even when every source returns None."""
     monkeypatch.setattr(os, "process_cpu_count", lambda: None, raising=False)
     monkeypatch.delattr(os, "sched_getaffinity", raising=False)
     monkeypatch.setattr(os, "cpu_count", lambda: None)
 
     assert get_available_cpu_count() == 1
+
+
+def test_get_available_cpu_count_respects_cgroup_v2_quota(cgroup_root, monkeypatch):
+    """A cgroup v2 CFS quota limits the count even when all host cores are allowed."""
+    monkeypatch.setattr(os, "process_cpu_count", lambda: 128, raising=False)
+    monkeypatch.setattr(os, "sched_getaffinity", lambda pid: set(range(128)))
+    (cgroup_root / "cpu.max").write_text("200000 100000\n")
+
+    assert get_available_cpu_count() == 2
+
+
+def test_get_available_cpu_count_rounds_up_fractional_cgroup_v2_quota(
+    cgroup_root, monkeypatch
+):
+    """A fractional quota (e.g. `--cpus=1.5`) is rounded up to a whole core."""
+    monkeypatch.setattr(os, "process_cpu_count", lambda: 128, raising=False)
+    (cgroup_root / "cpu.max").write_text("150000 100000\n")
+
+    assert get_available_cpu_count() == 2
+
+    (cgroup_root / "cpu.max").write_text("50000 100000\n")
+
+    assert get_available_cpu_count() == 1
+
+
+def test_get_available_cpu_count_ignores_unlimited_cgroup_v2_quota(
+    cgroup_root, monkeypatch
+):
+    """`cpu.max` set to "max" means no quota, so the affinity count is used."""
+    monkeypatch.setattr(os, "process_cpu_count", lambda: 8, raising=False)
+    (cgroup_root / "cpu.max").write_text("max 100000\n")
+
+    assert get_available_cpu_count() == 8
+
+
+def test_get_available_cpu_count_respects_cgroup_v1_quota(cgroup_root, monkeypatch):
+    """A cgroup v1 CFS quota limits the count."""
+    monkeypatch.setattr(os, "process_cpu_count", lambda: 128, raising=False)
+    (cgroup_root / "cpu" / "cpu.cfs_quota_us").write_text("300000\n")
+    (cgroup_root / "cpu" / "cpu.cfs_period_us").write_text("100000\n")
+
+    assert get_available_cpu_count() == 3
+
+
+def test_get_available_cpu_count_ignores_unlimited_cgroup_v1_quota(
+    cgroup_root, monkeypatch
+):
+    """A negative cgroup v1 quota means no limit, so the affinity count is used."""
+    monkeypatch.setattr(os, "process_cpu_count", lambda: 8, raising=False)
+    (cgroup_root / "cpu" / "cpu.cfs_quota_us").write_text("-1\n")
+    (cgroup_root / "cpu" / "cpu.cfs_period_us").write_text("100000\n")
+
+    assert get_available_cpu_count() == 8
+
+
+def test_get_available_cpu_count_uses_the_most_restrictive_limit(
+    cgroup_root, monkeypatch
+):
+    """A cpuset narrower than the quota still wins."""
+    monkeypatch.setattr(os, "process_cpu_count", lambda: 2, raising=False)
+    (cgroup_root / "cpu.max").write_text("800000 100000\n")
+
+    assert get_available_cpu_count() == 2
+
+
+def test_get_available_cpu_count_ignores_unreadable_cgroup_files(
+    cgroup_root, monkeypatch
+):
+    """Unexpected cgroup file contents do not break the core count."""
+    monkeypatch.setattr(os, "process_cpu_count", lambda: 8, raising=False)
+    (cgroup_root / "cpu.max").write_text("this is not a quota\n")
+
+    assert get_available_cpu_count() == 8

--- a/tests/common/utils/test_utils.py
+++ b/tests/common/utils/test_utils.py
@@ -15,6 +15,7 @@ import pytest
 
 from pixelator import __version__
 from pixelator.common.utils import (
+    get_available_cpu_count,
     get_pool_executor,
     get_process_pool_executor,
     get_read_sample_name,
@@ -207,7 +208,7 @@ def test_get_process_pool_executor():
     # Test with default parameters
     executor = get_process_pool_executor()
     assert isinstance(executor, ProcessPoolExecutor)
-    assert executor._max_workers == multiprocessing.cpu_count()
+    assert executor._max_workers == get_available_cpu_count()
     assert executor._mp_context == multiprocessing.get_context("spawn")
 
     # Test with specified number of cores
@@ -227,7 +228,7 @@ def test_get_pool_executor():
     # Test with default parameters
     pool = get_pool_executor()
     assert isinstance(pool, Pool)
-    assert pool._processes == multiprocessing.cpu_count()
+    assert pool._processes == get_available_cpu_count()
     assert pool._ctx == multiprocessing.get_context("spawn")
 
     # Test with specified number of cores


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

`pixelator` determined the number of usable CPU cores with `multiprocessing.cpu_count()`, which returns the number of cores on the **host machine** rather than the cores actually **assigned** to the process. When running inside a container or scheduler pod with a restricted CPU allocation, this reported the full host count (e.g. 128), causing multiprocessing steps to oversubscribe the assigned cores and run slower. This is the root cause behind `click_context.obj.get("CORES")` returning a too-high value, since `CORES` is populated from the `--cores` default.

This PR adds a `get_available_cpu_count()` helper in `pixelator.common.utils` that combines the CPU affinity mask with the cgroup CPU bandwidth quota and takes the most restrictive of the two.

CPU affinity, preferring affinity-aware sources and falling back gracefully:

1. `os.process_cpu_count()` — Python 3.13+, respects CPU affinity.
2. `os.sched_getaffinity(0)` — Linux, respects CPU affinity (covers the pre-3.13 pod case).
3. `os.cpu_count()` — fallback (e.g. on Windows), always at least `1`.

cgroup CPU bandwidth quota, which is how container CPU limits (`docker run --cpus`, Kubernetes `limits.cpu`) are normally enforced. Those limits set a CFS quota and leave the cpuset untouched, so they are invisible to the affinity APIs above and would otherwise still yield the host core count:

- cgroup v2: `/sys/fs/cgroup/cpu.max` (`max` means no limit).
- cgroup v1: `/sys/fs/cgroup/cpu/cpu.cfs_quota_us` and `cpu.cfs_period_us` (a negative quota means no limit).
- Fractional quotas are rounded up, the result is never below `1`, and unreadable or unexpected file contents are ignored.

All previous `multiprocessing.cpu_count()` / `mp.cpu_count()` usages that determine the default worker count are routed through this helper:

- `cli/main.py` — the `--cores` default (root cause).
- `common/utils/_pre_multiprocessing_args` and `pna/analysis_engine._get_joblib_executor` — the `CORES` fallback path.
- `pna/demux/process.py`, `pna/amplicon/process.py`, `pna/collapse/{paired,independent}/collapser.py` — per-step `threads` fallbacks.

Now-unused `multiprocessing` imports were removed from the affected modules.

This replaces #441, which targeted `dev` before the MPX removal. The branch has been rebased onto the MPX-free `dev`, so the pool-executor assertions now land in `tests/common/utils/test_utils.py` (where the MPX removal moved them) instead of `tests/mpx/utils/test_utils.py`.

Fixes: PNA-2021

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Added unit tests for `get_available_cpu_count()` covering each affinity source and the fall-through order, cgroup v2 and v1 quotas, unlimited quotas, fractional quotas, a cpuset narrower than the quota, and malformed cgroup files (`tests/common/test_utils.py`).
- Updated the pool-executor assertions in `tests/common/utils/test_utils.py` to the affinity-aware default.
- Ran `tests/common` plus the touched PNA suites (analysis engine, denoise CLI) after the rebase: 193 passed.
- `ruff format --check src tests` and `ruff check src tests` clean.
- `pixelator --help` on the rebased branch shows `--cores` defaulting to `3` on this 4-core machine, and `1` under `taskset -c 0,1` (a simulated 2-CPU pod).
- Demonstration of the quota path against a simulated container cgroup view on a 128-core host: with `cpu.max = 200000 100000` (`--cpus=2`) the affinity-only implementation reports `128` while the new implementation reports `2`; with `cpu.max = max` both report `128`.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and cited it properly
- [x] I have checked my code and documentation and corrected any misspellings
- [x] I have documented any significant changes to the code in CHANGELOG.md
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d7f5886-c999-4d20-835a-cfc8da153e22?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d7f5886-c999-4d20-835a-cfc8da153e22&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

