### PR TITLE
fix(tests): repair CI on dev — stale graph_legacy CLI check and flaky wilcoxon test

### DIFF
--- a/tests/cli/test_integration.py
+++ b/tests/cli/test_integration.py
@@ -38,7 +38,6 @@ def test_command_line_interface():
         "demux",
         "collapse",
         "graph",
-        "graph_legacy",
         "sample-calling",
         "denoise",
         "analysis",

--- a/tests/common/test_statistics.py
+++ b/tests/common/test_statistics.py
@@ -181,10 +181,11 @@ def test_rel_normalization():
 
 def test_wilcoxon_test():
     """Verify wilcoxon test."""
+    rng = np.random.default_rng(0)
     same_dist_df = pd.DataFrame(
         {
             "group": ["A"] * 50 + ["B"] * 50,
-            "value": np.random.normal(size=100),
+            "value": rng.normal(size=100),
         }
     )
     same_dist_result = wilcoxon_test(same_dist_df, "A", "B", "group", "value")
@@ -192,9 +193,7 @@ def test_wilcoxon_test():
     diff_dist_df = pd.DataFrame(
         {
             "group": ["A"] * 50 + ["B"] * 50,
-            "value": np.concatenate(
-                [np.random.normal(size=50), np.random.normal(loc=1, size=50)]
-            ),
+            "value": np.concatenate([rng.normal(size=50), rng.normal(loc=1, size=50)]),
         }
     )
     diff_dist_result = wilcoxon_test(diff_dist_df, "A", "B", "group", "value")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `Test` workflow has been failing on `dev` since the merge of #443 ([run 31793949637](https://github.com/PixelgenTechnologies/pixelator/actions/runs/31793949637)). Investigating it surfaced two independent problems.

### 1. Stale `graph_legacy` entry in the CLI smoke test (the breakage on `dev`)

All five test jobs (Python 3.10–3.13 plus coverage) failed on the same assertion:

```
FAILED tests/cli/test_integration.py::test_command_line_interface - AssertionError: graph_legacy
assert 2 == 0
 +  where 2 = <Result SystemExit(2)>.exit_code
```

#443 removed the deprecated `pixelator single-cell-pna graph_legacy` command and its underlying implementation, and documented the removal in `CHANGELOG.md`, but `tests/cli/test_integration.py` still iterated over `graph_legacy` when smoke-testing `--help` for every subcommand. Click exits with code 2 for an unknown subcommand, so the assertion fails.

Fix: remove `graph_legacy` from the command list in `test_command_line_interface`. The remaining entries now match exactly the commands registered on `single_cell_pna` in `src/pixelator/cli/main.py`. This was the only stale source reference to the removed command; the other matches are historical `CHANGELOG.md` entries.

### 2. Flaky `test_wilcoxon_test`

The first CI run on this branch surfaced a second, unrelated failure in the coverage job:

```
FAILED tests/common/test_statistics.py::test_wilcoxon_test - assert np.float64(0.020729426457321738) > 0.05
```

`test_wilcoxon_test` drew unseeded samples from a single normal distribution and asserted that the resulting p-value exceeds 0.05. Under the null hypothesis that assertion fails about 5% of the time by construction, so the test was destined to fail intermittently. Notably the Python 3.13 matrix job passed in the same run, confirming this is randomness rather than a version-specific problem.

Fix: seed a local generator with `np.random.default_rng(0)`, matching the convention already used in `tests/pna/analysis/test_gating.py` and `tests/common/data_generator`. With this seed the p-values are 0.598 for the same-distribution case and 6.7e-5 for the different-distribution case, both far from the 0.05 thresholds rather than marginal.

## Verification

The full suite passes locally (`644 passed, 3 skipped`, versus `643 passed, 1 failed` on `dev`), `test_wilcoxon_test` passes on five consecutive runs, and `ruff check` / `ruff format` are clean.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afd6f139-ac33-48c5-87bd-b7dc7bef6eec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afd6f139-ac33-48c5-87bd-b7dc7bef6eec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

