### PR TITLE
Rebase pna 2661 remove working edgelist c4ca

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - The deprecated `pixelator single-cell-pna graph_legacy` command and its underlying
   `pixelator.pna.graph_legacy` implementation. Use `pixelator single-cell-pna graph` instead.
+- The PNA graph step no longer densifies UMI node ids in Python before community detection.
+  The native `run_hybrid_community_detection` already builds a dense node index internally and
+  returns the original UMIs, so the redundant `create_working_edgelist` /
+  `map_working_to_original_umi_names` round-trip has been removed (replaced by a lightweight
+  `write_community_detection_input` column projection). The recovered components are unchanged.
 
 ## [0.30.0] - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The PNA graph step no longer densifies UMI node ids in Python before community detection.
   The native `run_hybrid_community_detection` already builds a dense node index internally and
   returns the original UMIs, so the redundant `create_working_edgelist` /
-  `map_working_to_original_umi_names` round-trip has been removed (replaced by a lightweight
-  `write_community_detection_input` column projection). The recovered components are unchanged.
+  `map_working_to_original_umi_names` round-trip has been removed. The filtered edgelist is now
+  passed directly to native community detection, and the recovered components are unchanged.
 
 ## [0.30.0] - 2026-08-05
 

--- a/src/pixelator/pna/graph/community_detection.py
+++ b/src/pixelator/pna/graph/community_detection.py
@@ -30,7 +30,6 @@ from pixelator.pna.graph.component_recovery_utils import (
     name_components_with_umi_hashes_from_parquet,
     populate_component_stats_from_hybrid_detection,
     remove_clashing_umis,
-    write_community_detection_input,
     write_hive_partitioned_edgelist_without_out_of_size_bound_components,
 )
 from pixelator.pna.graph.constants import (
@@ -501,12 +500,6 @@ def find_components(
         working_dir=working_dir,
     )
 
-    logger.info("Preparing edgelist for community detection.")
-    community_detection_edgelist_path = write_community_detection_input(
-        input_edgelist_path=filtered_edgelist_path,
-        working_dir=working_dir,
-    )
-
     logger.info("Running FLP + Leiden native step")
     (
         partitioned_edgelist_path,
@@ -514,7 +507,7 @@ def find_components(
         post_flp_stats,
         post_recovery_stats,
     ) = run_hybrid_community_detection(
-        parquet_file=str(community_detection_edgelist_path),
+        parquet_file=str(filtered_edgelist_path),
         resolution=refinement_options.initial_stage_options.leiden_resolution,
         output=str(working_dir / "partitioned_edgelist.parquet"),
         flp_epochs=2,

--- a/src/pixelator/pna/graph/community_detection.py
+++ b/src/pixelator/pna/graph/community_detection.py
@@ -23,7 +23,6 @@ from pixelator.common.utils import get_process_pool_executor
 from pixelator.pna.cli.common import logger
 from pixelator.pna.graph.component_recovery_utils import (
     ConnectedComponentException,
-    create_working_edgelist,
     filter_connected_components_by_size,
     filter_edgelist_by_read_count,
     initialize_graph_statistics,
@@ -31,6 +30,7 @@ from pixelator.pna.graph.component_recovery_utils import (
     name_components_with_umi_hashes_from_parquet,
     populate_component_stats_from_hybrid_detection,
     remove_clashing_umis,
+    write_community_detection_input,
     write_hive_partitioned_edgelist_without_out_of_size_bound_components,
 )
 from pixelator.pna.graph.constants import (
@@ -84,40 +84,6 @@ class MultipletRecoveryStats:
     crossing_edges_removed: int = 0
     crossing_edges_removed_in_initial_stage: int = 0
     max_recursion_depth: int = 0
-
-
-def map_working_to_original_umi_names(
-    input_edgelist_path: Path, node_map_path: Path, working_dir: Path
-) -> Path:
-    """Replace working UMI names in an edgelist with original names and write parquet."""
-    output_path = working_dir / "edgelist_with_original_umis.parquet"
-    with connect_duckdb() as con:
-        missing_count_row = con.execute(f"""
-            SELECT COUNT(*) AS n_missing
-            FROM parquet_scan('{str(input_edgelist_path)}') e
-            LEFT JOIN read_parquet('{str(node_map_path)}') m1 ON e.umi1 = m1.working_name
-            LEFT JOIN read_parquet('{str(node_map_path)}') m2 ON e.umi2 = m2.working_name
-            WHERE m1.original_name IS NULL OR m2.original_name IS NULL
-        """).fetchone()
-        if missing_count_row is None:
-            msg = "Failed to compute missing UMI mapping count"
-            raise RuntimeError(msg)
-        missing_count = int(missing_count_row[0])
-        if missing_count > 0:
-            raise ValueError("Missing UMI mapping for one or more edges")
-
-        con.execute(f"""
-            COPY (
-                SELECT
-                    e.* EXCLUDE (umi1, umi2),
-                    m1.original_name AS umi1,
-                    m2.original_name AS umi2
-                FROM parquet_scan('{str(input_edgelist_path)}') e
-                JOIN read_parquet('{str(node_map_path)}') m1 ON e.umi1 = m1.working_name
-                JOIN read_parquet('{str(node_map_path)}') m2 ON e.umi2 = m2.working_name
-            ) TO '{str(output_path)}' (FORMAT PARQUET)
-        """)
-    return output_path
 
 
 def calculate_post_recovery_component_statistics(
@@ -535,8 +501,8 @@ def find_components(
         working_dir=working_dir,
     )
 
-    logger.info("Starting component finding process.")
-    working_edgelist_path, node_map_path = create_working_edgelist(
+    logger.info("Preparing edgelist for community detection.")
+    community_detection_edgelist_path = write_community_detection_input(
         input_edgelist_path=filtered_edgelist_path,
         working_dir=working_dir,
     )
@@ -548,7 +514,7 @@ def find_components(
         post_flp_stats,
         post_recovery_stats,
     ) = run_hybrid_community_detection(
-        parquet_file=str(working_edgelist_path),
+        parquet_file=str(community_detection_edgelist_path),
         resolution=refinement_options.initial_stage_options.leiden_resolution,
         output=str(working_dir / "partitioned_edgelist.parquet"),
         flp_epochs=2,
@@ -678,12 +644,6 @@ def find_components(
         working_dir=working_dir,
     )
 
-    logger.info("Mapping UMIs to original names.")
-    latest_working_edgelist_path = map_working_to_original_umi_names(
-        input_edgelist_path=latest_working_edgelist_path,
-        node_map_path=node_map_path,
-        working_dir=working_dir,
-    )
     logger.info("Creating component names from UMIs.")
     final_edgelist_with_components = name_components_with_umi_hashes_from_parquet(
         input_edgelist_path=latest_working_edgelist_path,

--- a/src/pixelator/pna/graph/component_recovery_utils.py
+++ b/src/pixelator/pna/graph/component_recovery_utils.py
@@ -391,63 +391,47 @@ def remove_clashing_umis(
     return no_clash_edgelist_path, updated_stats
 
 
-def create_working_edgelist(
+def write_community_detection_input(
     input_edgelist_path: Path,
     working_dir: Path = DEFAULT_WORKING_DIR,
-) -> tuple[Path, Path]:
-    """Build a dense node-id edgelist and a map from original to working node names.
+) -> Path:
+    """Project an edgelist to the columns consumed by native community detection.
+
+    The native ``run_hybrid_community_detection`` builds a dense node index from the ``umi1``
+    and ``umi2`` values internally, so no Python-side densification is required; the original
+    UMI values are passed through unchanged. Only the columns used downstream are kept, and any
+    pre-existing ``component`` column is dropped so the native code can add its own.
 
     Args:
         input_edgelist_path: Path to the input edgelist in Parquet format.
-        working_dir: Directory for ``node_map.parquet`` and ``working_edgelist.parquet``; defaults
-            to ``DEFAULT_WORKING_DIR`` (``/tmp``).
+        working_dir: Directory for ``community_detection_edgelist.parquet``; defaults to
+            ``DEFAULT_WORKING_DIR`` (``/tmp``).
 
     Returns:
-        ``(working_edgelist_path, node_map_path)``.
+        Path to the written ``community_detection_edgelist.parquet``.
     """
-    node_map_path = working_dir / "node_map.parquet"
-    working_edgelist_path = working_dir / "working_edgelist.parquet"
+    community_detection_edgelist_path = (
+        working_dir / "community_detection_edgelist.parquet"
+    )
     with connect_duckdb() as con:
         con.execute(
             f"CREATE VIEW input_edgelist AS SELECT * FROM parquet_scan('{str(input_edgelist_path)}')"
         )
-
-        con.execute("""
-            CREATE VIEW node_map AS
-            WITH all_umis AS (
-                SELECT umi1 AS original_name FROM input_edgelist
-                UNION
-                SELECT umi2 AS original_name FROM input_edgelist
-            )
-            SELECT
-                original_name,
-                CAST(ROW_NUMBER() OVER (ORDER BY original_name) - 1 AS UINT64) AS working_name
-            FROM all_umis
-        """)
-
-        uei_count_sql = "ie.uei_count," if has_uei_count(con, "input_edgelist") else ""
+        uei_count_sql = "uei_count," if has_uei_count(con, "input_edgelist") else ""
         con.execute(f"""
-            CREATE VIEW working_edgelist AS
-            SELECT
-                nm1.working_name AS umi1,
-                nm2.working_name AS umi2,
-                ie.read_count,
-                {uei_count_sql}
-                ie.marker_1,
-                ie.marker_2
-            FROM input_edgelist ie
-            JOIN node_map nm1 ON ie.umi1 = nm1.original_name
-            JOIN node_map nm2 ON ie.umi2 = nm2.original_name
+            COPY (
+                SELECT
+                    umi1,
+                    umi2,
+                    read_count,
+                    {uei_count_sql}
+                    marker_1,
+                    marker_2
+                FROM input_edgelist
+            ) TO '{str(community_detection_edgelist_path)}' (FORMAT PARQUET)
         """)
 
-        con.execute(
-            f"COPY (SELECT * FROM node_map) TO '{str(node_map_path)}' (FORMAT PARQUET)"
-        )
-        con.execute(
-            f"COPY (SELECT * FROM working_edgelist) TO '{str(working_edgelist_path)}' (FORMAT PARQUET)"
-        )
-
-    return working_edgelist_path, node_map_path
+    return community_detection_edgelist_path
 
 
 def filter_edgelist_by_read_count(

--- a/src/pixelator/pna/graph/component_recovery_utils.py
+++ b/src/pixelator/pna/graph/component_recovery_utils.py
@@ -391,49 +391,6 @@ def remove_clashing_umis(
     return no_clash_edgelist_path, updated_stats
 
 
-def write_community_detection_input(
-    input_edgelist_path: Path,
-    working_dir: Path = DEFAULT_WORKING_DIR,
-) -> Path:
-    """Project an edgelist to the columns consumed by native community detection.
-
-    The native ``run_hybrid_community_detection`` builds a dense node index from the ``umi1``
-    and ``umi2`` values internally, so no Python-side densification is required; the original
-    UMI values are passed through unchanged. Only the columns used downstream are kept, and any
-    pre-existing ``component`` column is dropped so the native code can add its own.
-
-    Args:
-        input_edgelist_path: Path to the input edgelist in Parquet format.
-        working_dir: Directory for ``community_detection_edgelist.parquet``; defaults to
-            ``DEFAULT_WORKING_DIR`` (``/tmp``).
-
-    Returns:
-        Path to the written ``community_detection_edgelist.parquet``.
-    """
-    community_detection_edgelist_path = (
-        working_dir / "community_detection_edgelist.parquet"
-    )
-    with connect_duckdb() as con:
-        con.execute(
-            f"CREATE VIEW input_edgelist AS SELECT * FROM parquet_scan('{str(input_edgelist_path)}')"
-        )
-        uei_count_sql = "uei_count," if has_uei_count(con, "input_edgelist") else ""
-        con.execute(f"""
-            COPY (
-                SELECT
-                    umi1,
-                    umi2,
-                    read_count,
-                    {uei_count_sql}
-                    marker_1,
-                    marker_2
-                FROM input_edgelist
-            ) TO '{str(community_detection_edgelist_path)}' (FORMAT PARQUET)
-        """)
-
-    return community_detection_edgelist_path
-
-
 def filter_edgelist_by_read_count(
     input_edgelist_path: Path,
     min_read_count: int,

--- a/tests/pna/graph/test_community_detection.py
+++ b/tests/pna/graph/test_community_detection.py
@@ -10,7 +10,6 @@ import pytest
 from pixelator.pna.graph.community_detection import (
     StagedRefinementOptions,
     calculate_post_recovery_component_statistics,
-    map_working_to_original_umi_names,
     run_leiden_refinement,
 )
 from pixelator.pna.graph.component_recovery_utils import (
@@ -124,60 +123,6 @@ def test_calculate_post_recovery_component_statistics_with_real_discarded_frame(
 
     assert out.component_count_post_recovery == 3
     assert out.edge_count_post_recovery == 5
-
-
-def test_map_working_to_original_umi_names(tmp_path: Path) -> None:
-    """Working UMI names in umi1 and umi2 are replaced with original names."""
-    node_map_path = tmp_path / "node_map.parquet"
-    edgelist_path = tmp_path / "edgelist.parquet"
-    pl.DataFrame(
-        {
-            "working_name": ["w1", "w2", "w3", "w4"],
-            "original_name": ["o1", "o2", "o3", "o4"],
-        }
-    ).write_parquet(node_map_path)
-    pl.DataFrame(
-        {
-            "component": ["c1", "c1"],
-            "umi1": ["w1", "w3"],
-            "umi2": ["w2", "w4"],
-            "read_count": [1, 2],
-        }
-    ).write_parquet(edgelist_path)
-
-    mapped_path = map_working_to_original_umi_names(
-        edgelist_path, node_map_path, tmp_path
-    )
-    mapped = pl.read_parquet(mapped_path)
-
-    assert mapped["umi1"].to_list() == ["o1", "o3"]
-    assert mapped["umi2"].to_list() == ["o2", "o4"]
-    assert mapped["component"].to_list() == ["c1", "c1"]
-    assert mapped["read_count"].to_list() == [1, 2]
-
-
-def test_map_working_to_original_umi_names_raises_for_missing_mapping(
-    tmp_path: Path,
-) -> None:
-    """Mapping fails when an UMI in input is missing in the node map."""
-    node_map_path = tmp_path / "node_map.parquet"
-    edgelist_path = tmp_path / "edgelist.parquet"
-    pl.DataFrame(
-        {
-            "working_name": ["w1"],
-            "original_name": ["o1"],
-        }
-    ).write_parquet(node_map_path)
-    pl.DataFrame(
-        {
-            "component": ["c1"],
-            "umi1": ["w1"],
-            "umi2": ["w_missing"],
-        }
-    ).write_parquet(edgelist_path)
-
-    with pytest.raises(ValueError, match="Missing UMI mapping"):
-        map_working_to_original_umi_names(edgelist_path, node_map_path, tmp_path)
 
 
 @patch("pixelator.pna.utils.duckdb_utils.duckdb.connect")

--- a/tests/pna/graph/test_component_recovery_pipeline.py
+++ b/tests/pna/graph/test_component_recovery_pipeline.py
@@ -95,7 +95,7 @@ def random_graph_path():
             schema={
                 "umi1": pl.UInt64,
                 "umi2": pl.UInt64,
-                "component": pl.String,
+                "expected_component": pl.String,
                 "read_count": pl.UInt32,
                 "uei_count": pl.UInt16,
                 "marker_1": pl.String,
@@ -120,8 +120,9 @@ def test_find_components_small(
     ground_truth_umi_map = (
         (
             pl.read_parquet(random_graph_path)
-            .group_by("component")
+            .group_by("expected_component")
             .agg(pl.col("umi1").append(pl.col("umi2")).unique().alias("umi"))
+            .rename({"expected_component": "component"})
         )
         .explode("umi")
         .filter(pl.col("component") != "crossing")
@@ -322,7 +323,6 @@ def test_find_components_empty_parquet_file():
     empty_schema = {
         "umi1": pl.UInt64,
         "umi2": pl.UInt64,
-        "component": pl.String,
         "read_count": pl.UInt32,
         "uei_count": pl.UInt16,
         "marker_1": pl.String,
@@ -382,8 +382,12 @@ def test_find_components_big(
 
     with tempfile.TemporaryDirectory() as temp_dir:
         working_dir = Path(temp_dir)
+        input_path = working_dir / "input.parquet"
+        pl.scan_parquet(testdata_3pc_crossing_parquet).drop("component").sink_parquet(
+            input_path
+        )
         component_stats, resolved_edgelist_path = find_components(
-            input_edgelist_path=Path(testdata_3pc_crossing_parquet),
+            input_edgelist_path=input_path,
             working_dir=working_dir,
             multiplet_recovery=True,
             edge_cycle_verification=edge_cycle_verification,

--- a/tests/pna/graph/test_component_recovery_utils.py
+++ b/tests/pna/graph/test_component_recovery_utils.py
@@ -11,7 +11,6 @@ from pixelator.pna.graph.component_recovery_utils import (
     get_count_statistics,
     name_components_with_umi_hashes,
     name_components_with_umi_hashes_from_parquet,
-    write_community_detection_input,
     write_hive_partitioned_edgelist_without_out_of_size_bound_components,
 )
 from pixelator.pna.graph.report import GraphStatistics
@@ -62,79 +61,6 @@ def test_get_count_statistics_without_uei_count(tmp_path: Path) -> None:
         "n_molecules": 3,
         "n_umi": 4,
     }
-
-
-def test_write_community_detection_input_without_uei_count(tmp_path: Path) -> None:
-    """Community-detection input omits uei_count when the input column is missing."""
-    path = tmp_path / "edgelist.parquet"
-    pl.DataFrame(
-        {
-            "umi1": [1, 2],
-            "umi2": [3, 4],
-            "read_count": [10, 20],
-            "marker_1": ["A", "B"],
-            "marker_2": ["C", "D"],
-        }
-    ).cast(
-        {"umi1": pl.UInt64, "umi2": pl.UInt64, "read_count": pl.UInt32}
-    ).write_parquet(path)
-
-    community_detection_edgelist_path = write_community_detection_input(
-        input_edgelist_path=path, working_dir=tmp_path
-    )
-    result = pl.read_parquet(community_detection_edgelist_path)
-
-    assert "uei_count" not in result.columns
-    assert set(result.columns) == {
-        "umi1",
-        "umi2",
-        "read_count",
-        "marker_1",
-        "marker_2",
-    }
-
-
-def test_write_community_detection_input_keeps_original_umis_and_drops_component(
-    tmp_path: Path,
-) -> None:
-    """Original UMI values pass through unchanged and any component column is dropped."""
-    path = tmp_path / "edgelist.parquet"
-    pl.DataFrame(
-        {
-            "umi1": [111, 222],
-            "umi2": [333, 444],
-            "component": ["c1", "c2"],
-            "read_count": [10, 20],
-            "uei_count": [1, 2],
-            "marker_1": ["A", "B"],
-            "marker_2": ["C", "D"],
-        }
-    ).cast(
-        {
-            "umi1": pl.UInt64,
-            "umi2": pl.UInt64,
-            "read_count": pl.UInt32,
-            "uei_count": pl.UInt16,
-        }
-    ).write_parquet(path)
-
-    community_detection_edgelist_path = write_community_detection_input(
-        input_edgelist_path=path, working_dir=tmp_path
-    )
-    result = pl.read_parquet(community_detection_edgelist_path)
-
-    assert "component" not in result.columns
-    assert set(result.columns) == {
-        "umi1",
-        "umi2",
-        "read_count",
-        "uei_count",
-        "marker_1",
-        "marker_2",
-    }
-    # UMIs are passed through unchanged (no densification to 0..n-1).
-    assert result["umi1"].to_list() == [111, 222]
-    assert result["umi2"].to_list() == [333, 444]
 
 
 def test_write_hive_partitioned_edgelist_without_out_of_size_bound_components_prunes(

--- a/tests/pna/graph/test_component_recovery_utils.py
+++ b/tests/pna/graph/test_component_recovery_utils.py
@@ -7,11 +7,11 @@ import pytest
 
 from pixelator.pna.graph.component_recovery_utils import (
     create_component_size_data_frame,
-    create_working_edgelist,
     filter_connected_components_by_size,
     get_count_statistics,
     name_components_with_umi_hashes,
     name_components_with_umi_hashes_from_parquet,
+    write_community_detection_input,
     write_hive_partitioned_edgelist_without_out_of_size_bound_components,
 )
 from pixelator.pna.graph.report import GraphStatistics
@@ -64,8 +64,8 @@ def test_get_count_statistics_without_uei_count(tmp_path: Path) -> None:
     }
 
 
-def test_create_working_edgelist_without_uei_count(tmp_path: Path) -> None:
-    """Working edgelist omits uei_count when the input column is missing."""
+def test_write_community_detection_input_without_uei_count(tmp_path: Path) -> None:
+    """Community-detection input omits uei_count when the input column is missing."""
     path = tmp_path / "edgelist.parquet"
     pl.DataFrame(
         {
@@ -79,19 +79,62 @@ def test_create_working_edgelist_without_uei_count(tmp_path: Path) -> None:
         {"umi1": pl.UInt64, "umi2": pl.UInt64, "read_count": pl.UInt32}
     ).write_parquet(path)
 
-    working_edgelist_path, _ = create_working_edgelist(
+    community_detection_edgelist_path = write_community_detection_input(
         input_edgelist_path=path, working_dir=tmp_path
     )
-    working = pl.read_parquet(working_edgelist_path)
+    result = pl.read_parquet(community_detection_edgelist_path)
 
-    assert "uei_count" not in working.columns
-    assert set(working.columns) >= {
+    assert "uei_count" not in result.columns
+    assert set(result.columns) == {
         "umi1",
         "umi2",
         "read_count",
         "marker_1",
         "marker_2",
     }
+
+
+def test_write_community_detection_input_keeps_original_umis_and_drops_component(
+    tmp_path: Path,
+) -> None:
+    """Original UMI values pass through unchanged and any component column is dropped."""
+    path = tmp_path / "edgelist.parquet"
+    pl.DataFrame(
+        {
+            "umi1": [111, 222],
+            "umi2": [333, 444],
+            "component": ["c1", "c2"],
+            "read_count": [10, 20],
+            "uei_count": [1, 2],
+            "marker_1": ["A", "B"],
+            "marker_2": ["C", "D"],
+        }
+    ).cast(
+        {
+            "umi1": pl.UInt64,
+            "umi2": pl.UInt64,
+            "read_count": pl.UInt32,
+            "uei_count": pl.UInt16,
+        }
+    ).write_parquet(path)
+
+    community_detection_edgelist_path = write_community_detection_input(
+        input_edgelist_path=path, working_dir=tmp_path
+    )
+    result = pl.read_parquet(community_detection_edgelist_path)
+
+    assert "component" not in result.columns
+    assert set(result.columns) == {
+        "umi1",
+        "umi2",
+        "read_count",
+        "uei_count",
+        "marker_1",
+        "marker_2",
+    }
+    # UMIs are passed through unchanged (no densification to 0..n-1).
+    assert result["umi1"].to_list() == [111, 222]
+    assert result["umi2"].to_list() == [333, 444]
 
 
 def test_write_hive_partitioned_edgelist_without_out_of_size_bound_components_prunes(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

The PNA graph step used to densify UMI node ids in Python (`create_working_edgelist`) before native community detection and map the dense ids back afterward (`map_working_to_original_umi_names`).

This round-trip is redundant. Native `run_hybrid_community_detection` already builds a dense node index internally (`UmiToNodeIndexMapping::from_umi_pairs`) and writes the original UMI values back out. The graph step receives collapse output whose `umi1`/`umi2` columns are already `UInt64` and which has no pre-existing `component` column.

This PR:
- Removes `create_working_edgelist` and `map_working_to_original_umi_names`.
- Passes the read-count-filtered edgelist directly to `run_hybrid_community_detection`; no replacement projection or intermediate parquet is needed.
- Preserves other collapse columns such as `corrected_read_count` through the graph output.
- Updates pipeline fixtures to match the collapse-output contract while retaining their ground-truth labels separately.
- Updates affected tests and the changelog.

Fixes: PNA-2661

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) — internal cleanup, no intended component-recovery behavior change

## How Has This Been Tested?

- `tests/pna/graph/` passes, and the full non-slow suite passes locally (609 passed).
- End-to-end graph CLI run against the real full-run collapse parquet succeeds, producing a valid `.graph.pxl` that preserves original large `UInt64` UMI values and the collapse-stage `corrected_read_count` column.
- `ruff check` and `ruff format --check` pass.

## Note on the current CI failure (pre-existing on `dev`, unrelated to this PR)

`tests/cli/test_integration.py::test_command_line_interface` fails with `AssertionError: graph_legacy`. This is **not** caused by this PR:

- This PR's own commit (`9d36a191`, before merging `dev`) passed the full Test workflow.
- `dev` HEAD (`9656c6c7`) fails this exact test on its own, with none of this PR's changes present, and its Test workflow is red.
- Cause: PR #443 removed the `graph_legacy` command from `src/`, while the MPX-removal commit relocated the integration test to `tests/cli/test_integration.py` with `"graph_legacy"` still in its command list. Neither PR's CI caught the combination, so the merge broke `dev`.
- After merging latest `dev` here, CI reports `1 failed, 640 passed`, and that single failure is this stale assertion.

The fix is to drop the stale `"graph_legacy"` entry from that test list, but that is outside this PR's scope and affects every open PR, so it should land as its own small change on `dev` rather than being buried here.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added or updated tests that prove the change is effective
- [x] I have documented the significant change in `CHANGELOG.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the core PNA graph community-detection data path (UMI identity through native detection), though tests assert equivalent recovery; risk is moderate rather than high because behavior is intended to be unchanged.
> 
> **Overview**
> **Removes redundant UMI densification** in the PNA `graph` / `find_components` path. The filtered edgelist is passed straight to `run_hybrid_community_detection` instead of building a dense `working_edgelist` and mapping UMIs back with `map_working_to_original_umi_names`. The changelog states recovered components are unchanged because the native step already indexes nodes internally and returns original UMIs.
> 
> **Cleanup:** `create_working_edgelist` and `map_working_to_original_umi_names` are deleted from `component_recovery_utils` and `community_detection`, along with their unit tests. Integration tests drop `graph_legacy` from the CLI help list and adjust fixtures so inputs no longer carry a pre-assigned `component` column where the pipeline should infer components.
> 
> **Minor:** `spectral_layout` in the NetworkX backend gets expanded docstrings (args, returns, validation errors). `test_wilcoxon_test` uses a seeded `numpy.random.Generator` for reproducibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 214d99f2843a3d8f396c81a37f7366468c508f8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->