### PR TITLE
Add summarize_proximity_scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `pixelator.pna.analysis.summarize_proximity_scores` to collapse a per-component proximity score table into one row per marker pair.
+
 ### Removed
 - Molecular Pixelation (MPX) support, including the `pixelator.mpx` package, the
   `single-cell-mpx` CLI and MPX assay/panel configuration. To process MPX data,

--- a/docs/api/overview.rst
+++ b/docs/api/overview.rst
@@ -30,3 +30,4 @@ for usage examples.
 **Analysis**
 
 * :func:`pixelator.pna.analysis.calculate_differential_proximity`
+* :func:`pixelator.pna.analysis.summarize_proximity_scores`

--- a/src/pixelator/pna/analysis/__init__.py
+++ b/src/pixelator/pna/analysis/__init__.py
@@ -3,9 +3,12 @@
 Copyright © 2024 Pixelgen Technologies AB.
 """
 
-from pixelator.pna.analysis.proximity import calculate_differential_proximity
+from pixelator.pna.analysis.proximity import (
+    calculate_differential_proximity,
+    summarize_proximity_scores,
+)
 
-__all__ = ["calculate_differential_proximity"]
+__all__ = ["calculate_differential_proximity", "summarize_proximity_scores"]
 
 # Note: pixelator.pna.analysis.comparison is intentionally not imported here.
 # It depends on pixelator.pna.pixeldataset, which itself imports

--- a/src/pixelator/pna/analysis/proximity.py
+++ b/src/pixelator/pna/analysis/proximity.py
@@ -14,6 +14,12 @@ from statsmodels.stats.multitest import multipletests
 from pixelator.pna.analysis.permute import edgelist_permutations
 from pixelator.pna.utils.utils import normalize_input_to_list
 
+_PROXIMITY_METRICS = ("log2_ratio", "join_count_z")
+_SUMMARY_STATS: dict[str, Callable[[np.ndarray], float]] = {
+    "mean": np.mean,
+    "median": np.median,
+}
+
 
 def get_join_counts(edgelist: pl.DataFrame) -> pd.DataFrame:
     """Compute the number of edges for each marker pair in the given edgelist.
@@ -170,6 +176,162 @@ def jcs_with_permute_stats(
         min_std=1.0,
         min_marker_count=min_marker_count,
     )
+
+
+def summarize_proximity_scores(
+    proximity_df: pd.DataFrame,
+    proximity_metric: Literal["log2_ratio", "join_count_z"] = "log2_ratio",
+    group_vars: str | List[str] | None = None,
+    include_missing_obs: bool = True,
+    summary_stat: Literal["mean", "median"] = "mean",
+    detailed: bool = False,
+) -> pd.DataFrame:
+    """Summarize per-component proximity scores across components, for each marker pair.
+
+    Collapses a long-format proximity score table (one row per component and
+    marker pair) into one row per marker pair (optionally stratified by
+    ``group_vars``, e.g. sample or cell type), reporting the number of
+    components the pair was detected in and a summary statistic of
+    ``proximity_metric`` across those components.
+
+    A marker pair is only present for a component if it passed detection in
+    that component's proximity analysis. When ``include_missing_obs`` is
+    ``True`` (the default), components where a pair was not detected are
+    treated as having a ``proximity_metric`` value of 0 and are included when
+    computing the summary statistic, since an undetected pair corresponds to
+    no deviation from the expected join count.
+
+    Args:
+        proximity_df: A long-format proximity score table, e.g. from
+            `Proximity.to_df`, with one row per ``component`` and marker
+            pair. Must contain the columns ``component``, ``marker_1``,
+            ``marker_2``, ``proximity_metric``, and (if ``detailed`` is
+            ``True``) ``join_count`` and ``join_count_expected_mean``.
+        proximity_metric: The proximity score column to summarize, either
+            ``"log2_ratio"`` or ``"join_count_z"``. Defaults to
+            ``"log2_ratio"``.
+        group_vars: Additional column(s) to stratify the summary by, e.g.
+            ``"sample"`` or ``["sample", "cell_type"]``. Each component must
+            map to a single, consistent value of every ``group_vars`` column.
+            Defaults to ``None``, which summarizes across all components in
+            ``proximity_df``.
+        include_missing_obs: If ``True``, pad the values used to compute the
+            summary statistic with a 0 for every component where the marker
+            pair was not detected. Defaults to ``True``.
+        summary_stat: The summary statistic to compute, either ``"mean"`` or
+            ``"median"``. Defaults to ``"mean"``.
+        detailed: If ``True``, also return the per-component values that went
+            into the summary statistic (``{proximity_metric}_list``,
+            ``join_count_list``, and ``join_count_expected_mean_list``), so
+            that other statistics (e.g. standard deviation or quantiles) can
+            be computed downstream. Defaults to ``False``.
+
+    Returns:
+        A DataFrame with one row per unique combination of ``group_vars``,
+        ``marker_1`` and ``marker_2``, containing ``n_cells_detected`` (the
+        number of components the pair was detected in), ``n_cells`` (the
+        total number of components in that ``group_vars`` stratum),
+        ``n_cells_missing``, ``pct_detected``, and
+        ``{summary_stat}_{proximity_metric}`` (e.g. ``mean_log2_ratio``). If
+        ``detailed`` is ``True``, the per-component value list columns
+        described above are also included.
+
+    Raises:
+        ValueError: If ``proximity_metric`` or ``summary_stat`` is not one of
+            the supported options, if a required column is missing from
+            ``proximity_df``, or if ``proximity_df`` has more than one row for
+            some combination of ``component``, ``marker_1``, ``marker_2`` and
+            ``group_vars``.
+    """
+    if proximity_metric not in _PROXIMITY_METRICS:
+        raise ValueError(
+            f"proximity_metric must be one of {_PROXIMITY_METRICS}, "
+            f"got {proximity_metric!r}."
+        )
+    if summary_stat not in _SUMMARY_STATS:
+        raise ValueError(
+            f"summary_stat must be one of {tuple(_SUMMARY_STATS)}, "
+            f"got {summary_stat!r}."
+        )
+
+    group_vars = normalize_input_to_list(group_vars) or []
+    detail_columns = ["join_count", "join_count_expected_mean"] if detailed else []
+
+    required_columns = {
+        "component",
+        "marker_1",
+        "marker_2",
+        proximity_metric,
+        *detail_columns,
+        *group_vars,
+    }
+    missing_columns = required_columns - set(proximity_df.columns)
+    if missing_columns:
+        raise ValueError(
+            f"proximity_df is missing required column(s): {sorted(missing_columns)}."
+        )
+
+    pair_group_vars = [*group_vars, "marker_1", "marker_2"]
+    duplicate_key = ["component", *pair_group_vars]
+    duplicates = proximity_df.duplicated(subset=duplicate_key, keep=False)
+    if duplicates.any():
+        example = proximity_df.loc[duplicates, duplicate_key].iloc[0].to_dict()
+        raise ValueError(
+            "proximity_df must have at most one row per component, marker "
+            "pair and group_vars combination, found duplicate rows, e.g. "
+            f"{example}."
+        )
+
+    if group_vars:
+        n_cells = proximity_df.groupby(group_vars)["component"].nunique()
+        n_cells = n_cells.rename("n_cells").reset_index()
+    else:
+        n_cells = proximity_df["component"].nunique()
+
+    value_columns = [proximity_metric, *detail_columns]
+    summary = proximity_df.groupby(pair_group_vars).agg(
+        n_cells_detected=(proximity_metric, "size"),
+        **{f"{col}_list": (col, list) for col in value_columns},
+    )
+    summary = summary.reset_index()
+
+    if group_vars:
+        summary = summary.merge(n_cells, on=group_vars, how="left")
+    else:
+        summary["n_cells"] = n_cells
+
+    summary["n_cells_missing"] = summary["n_cells"] - summary["n_cells_detected"]
+    summary["pct_detected"] = summary["n_cells_detected"] / summary["n_cells"]
+
+    if include_missing_obs:
+        for col in value_columns:
+            list_col = f"{col}_list"
+            summary[list_col] = [
+                values + [0] * n_missing
+                for values, n_missing in zip(
+                    summary[list_col], summary["n_cells_missing"]
+                )
+            ]
+
+    metric_list_col = f"{proximity_metric}_list"
+    stat_func = _SUMMARY_STATS[summary_stat]
+    summary_col = f"{summary_stat}_{proximity_metric}"
+    summary[summary_col] = [stat_func(values) for values in summary[metric_list_col]]
+
+    output_columns = [
+        *group_vars,
+        "marker_1",
+        "marker_2",
+        "n_cells_detected",
+        "n_cells",
+        "n_cells_missing",
+        "pct_detected",
+        summary_col,
+    ]
+    if detailed:
+        output_columns += [f"{col}_list" for col in value_columns]
+
+    return summary[output_columns]
 
 
 def _filter_target_data(

--- a/tests/pna/analysis/test_summarize_proximity_scores.py
+++ b/tests/pna/analysis/test_summarize_proximity_scores.py
@@ -1,0 +1,137 @@
+"""Tests for `pixelator.pna.analysis.proximity.summarize_proximity_scores`.
+
+Copyright © 2026 Pixelgen Technologies AB.
+"""
+
+from io import StringIO
+
+import pandas as pd
+import pytest
+from pandas.testing import assert_frame_equal
+
+from pixelator.pna.analysis.proximity import summarize_proximity_scores
+
+# Marker pair detection is intentionally sparse:
+# - M1/M1 is detected in c1 and c2, but not c3
+# - M1/M2 is detected in c1 and c3, but not c2
+# - M2/M2 is detected in c2, but not c1 or c3
+PROXIMITY_DATA = """component,sample,marker_1,marker_2,log2_ratio,join_count_z,join_count,join_count_expected_mean
+c1,A,M1,M1,1.0,2.0,10,5
+c1,A,M1,M2,0.5,1.0,8,6
+c2,A,M1,M1,2.0,3.0,12,4
+c2,A,M2,M2,-1.0,-2.0,2,6
+c3,B,M1,M2,3.0,4.0,20,3
+"""
+
+
+@pytest.fixture
+def proximity_df() -> pd.DataFrame:
+    return pd.read_csv(StringIO(PROXIMITY_DATA))
+
+
+def test_summarize_proximity_scores_default(proximity_df):
+    result = summarize_proximity_scores(proximity_df)
+
+    expected = pd.DataFrame(
+        {
+            "marker_1": ["M1", "M1", "M2"],
+            "marker_2": ["M1", "M2", "M2"],
+            "n_cells_detected": [2, 2, 1],
+            "n_cells": [3, 3, 3],
+            "n_cells_missing": [1, 1, 2],
+            "pct_detected": [2 / 3, 2 / 3, 1 / 3],
+            "mean_log2_ratio": [1.0, 3.5 / 3, -1 / 3],
+        }
+    )
+    assert_frame_equal(result, expected)
+
+
+def test_summarize_proximity_scores_median(proximity_df):
+    result = summarize_proximity_scores(proximity_df, summary_stat="median")
+    assert "median_log2_ratio" in result.columns
+    m1_m2 = result[(result.marker_1 == "M1") & (result.marker_2 == "M2")]
+    # padded values [0.5, 3.0, 0] -> median is 0.5
+    assert m1_m2["median_log2_ratio"].item() == pytest.approx(0.5)
+
+
+def test_summarize_proximity_scores_join_count_z(proximity_df):
+    result = summarize_proximity_scores(proximity_df, proximity_metric="join_count_z")
+    m1_m1 = result[(result.marker_1 == "M1") & (result.marker_2 == "M1")]
+    # padded values [2.0, 3.0, 0] -> mean is 5/3
+    assert m1_m1["mean_join_count_z"].item() == pytest.approx(5 / 3)
+
+
+def test_summarize_proximity_scores_exclude_missing_obs(proximity_df):
+    result = summarize_proximity_scores(proximity_df, include_missing_obs=False)
+
+    m1_m1 = result[(result.marker_1 == "M1") & (result.marker_2 == "M1")]
+    assert m1_m1["mean_log2_ratio"].item() == pytest.approx(1.5)
+
+    m1_m2 = result[(result.marker_1 == "M1") & (result.marker_2 == "M2")]
+    assert m1_m2["mean_log2_ratio"].item() == pytest.approx(1.75)
+
+    m2_m2 = result[(result.marker_2 == "M2") & (result.marker_1 == "M2")]
+    assert m2_m2["mean_log2_ratio"].item() == pytest.approx(-1.0)
+
+
+def test_summarize_proximity_scores_group_vars(proximity_df):
+    result = summarize_proximity_scores(proximity_df, group_vars="sample")
+
+    expected = pd.DataFrame(
+        {
+            "sample": ["A", "A", "A", "B"],
+            "marker_1": ["M1", "M1", "M2", "M1"],
+            "marker_2": ["M1", "M2", "M2", "M2"],
+            "n_cells_detected": [2, 1, 1, 1],
+            "n_cells": [2, 2, 2, 1],
+            "n_cells_missing": [0, 1, 1, 0],
+            "pct_detected": [1.0, 0.5, 0.5, 1.0],
+            "mean_log2_ratio": [1.5, 0.25, -0.5, 3.0],
+        }
+    )
+    assert_frame_equal(result, expected)
+
+
+def test_summarize_proximity_scores_detailed(proximity_df):
+    result = summarize_proximity_scores(proximity_df, detailed=True)
+
+    assert "log2_ratio_list" in result.columns
+    assert "join_count_list" in result.columns
+    assert "join_count_expected_mean_list" in result.columns
+
+    m1_m1 = result[(result.marker_1 == "M1") & (result.marker_2 == "M1")]
+    assert sorted(m1_m1["log2_ratio_list"].item()) == [0, 1.0, 2.0]
+    assert sorted(m1_m1["join_count_list"].item()) == [0, 10, 12]
+
+
+def test_summarize_proximity_scores_invalid_proximity_metric(proximity_df):
+    with pytest.raises(ValueError, match="proximity_metric"):
+        summarize_proximity_scores(proximity_df, proximity_metric="not_a_metric")
+
+
+def test_summarize_proximity_scores_invalid_summary_stat(proximity_df):
+    with pytest.raises(ValueError, match="summary_stat"):
+        summarize_proximity_scores(proximity_df, summary_stat="not_a_stat")
+
+
+def test_summarize_proximity_scores_missing_column(proximity_df):
+    with pytest.raises(ValueError, match="missing required column"):
+        summarize_proximity_scores(proximity_df.drop(columns=["marker_1"]))
+
+
+def test_summarize_proximity_scores_missing_detail_columns(proximity_df):
+    with pytest.raises(ValueError, match="missing required column"):
+        summarize_proximity_scores(
+            proximity_df.drop(columns=["join_count"]), detailed=True
+        )
+
+
+def test_summarize_proximity_scores_missing_group_var(proximity_df):
+    with pytest.raises(ValueError, match="missing required column"):
+        summarize_proximity_scores(proximity_df, group_vars="cell_type")
+
+
+def test_summarize_proximity_scores_duplicate_rows(proximity_df):
+    duplicated = pd.concat([proximity_df, proximity_df.iloc[[0]]], ignore_index=True)
+    with pytest.raises(ValueError, match="duplicate"):
+        summarize_proximity_scores(duplicated)


### PR DESCRIPTION
This is a function to enable mean/median proximity score collapsing, where each marker pair will get the aggregate score of all components. Similar to the pixelatorR implementation, we're going to assign 0 to the proximity score of a marker-pair for components that express either of those markers below the required abundance threshold.  

Fixes: PNA-3392

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce it when relevant.

## PR checklist:

- [X] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [ ] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New analysis helper with tests and docs; no pipeline, I/O, or security-sensitive changes.
> 
> **Overview**
> Adds **`summarize_proximity_scores`** to collapse a long-format proximity table (one row per component and marker pair) into one row per pair, optionally stratified by `group_vars`.
> 
> By default, undetected pairs are padded with **0** before computing mean or median of `log2_ratio` or `join_count_z`, matching the pixelatorR approach. The result includes detection counts (`n_cells_detected`, `n_cells_missing`, `pct_detected`). `detailed=True` also returns the per-component value lists.
> 
> The function is exported from `pixelator.pna.analysis`, documented in the API overview, and covered by unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47c6c0911c5c0347f45d159f9825da27c960a5a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->