### PR TITLE
Pna 2446 compute layouts on the fly in pixelator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   passed directly to native community detection, and the recovered components are unchanged.
 
 ### Fixed
-- `Layouts.to_polars()` / `to_df()` fill marker counts missing from a Component
-  with `0` after concatenating, matching `precomputed_layouts()`.
 - The default number of cores and the fallbacks used when `--cores` is not set now respect the
   CPU affinity mask (via `os.process_cpu_count()` or `os.sched_getaffinity()`) and the cgroup
   CPU bandwidth quota (`docker run --cpus`, Kubernetes `limits.cpu`), taking the most restrictive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   passed directly to native community detection, and the recovered components are unchanged.
 
 ### Fixed
+- `Layouts.to_polars()` / `to_df()` fill marker counts missing from a Component
+  with `0` after concatenating, matching `precomputed_layouts()`.
 - The default number of cores and the fallbacks used when `--cores` is not set now respect the
   CPU affinity mask (via `os.process_cpu_count()` or `os.sched_getaffinity()`) and the cgroup
   CPU bandwidth quota (`docker run --cpus`, Kubernetes `limits.cpu`), taking the most restrictive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `PNAPixelDataset.layouts()` computes Layouts on the fly from Component graphs.
-  Choose the Layout algorithm with `algorithm=` (default `coarsened_pmds_3d`, via
-  `DEFAULT_LAYOUT_ALGORITHM`). The collection supports `.first()`, `.iterator()`,
-  `.to_df()`, and `.to_polars()`.
+- `PNAPixelDataset.layouts()` computes Layouts on the fly, making it easier to work with cell layouts.
 - `pixelator.pna.analysis.summarize_proximity_scores` to collapse a per-component proximity score table into one row per marker pair.
 
 ### Changed
-- Layout algorithm defaults go through `DEFAULT_LAYOUT_ALGORITHM` (`coarsened_pmds_3d`)
-  for `PNAPixelDataset.layouts()`, `layout_coordinates`, and
-  `pixelator single-cell-pna layout`.
 - `density_scatter_plot` now lives in `pixelator.plot` (previously `pixelator.mpx.plot`).
 - `uei_count` is now optional on PNA edgelists in `sample_calling` and the graph component
   recovery path. When the column is absent, sample calling skips it and graph molecule

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `PNAPixelDataset.layouts()` computes Layouts on the fly from Component graphs.
+  Choose the Layout algorithm with `algorithm=` (default `coarsened_pmds_3d`, via
+  `DEFAULT_LAYOUT_ALGORITHM`). The collection supports `.first()`, `.iterator()`,
+  `.to_df()`, and `.to_polars()`.
+
+### Changed
+- Layout algorithm defaults go through `DEFAULT_LAYOUT_ALGORITHM` (`coarsened_pmds_3d`)
+  for `PNAPixelDataset.layouts()`, `layout_coordinates`, and
+  `pixelator single-cell-pna layout`.
+- `density_scatter_plot` now lives in `pixelator.plot` (previously `pixelator.mpx.plot`).
+- `uei_count` is now optional on PNA edgelists in `sample_calling` and the graph component
+  recovery path. When the column is absent, sample calling skips it and graph molecule
+  statistics use the number of edges.
+- Refactor `pixelator.common.utils.__init__.py`
+
+### Deprecated
+- `PNAPixelDataset.precomputed_layouts()` is deprecated. Use `layouts()` to
+  compute Layouts on the fly. The method still reads a stored `layouts` table
+  when one exists.
+
 ### Removed
 - Molecular Pixelation (MPX) support, including the `pixelator.mpx` package, the
   `single-cell-mpx` CLI and MPX assay/panel configuration. To process MPX data,
@@ -17,13 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   returns the original UMIs, so the redundant `create_working_edgelist` /
   `map_working_to_original_umi_names` round-trip has been removed. The filtered edgelist is now
   passed directly to native community detection, and the recovered components are unchanged.
-
-### Changed
-- `density_scatter_plot` now lives in `pixelator.plot` (previously `pixelator.mpx.plot`).
-- `uei_count` is now optional on PNA edgelists in `sample_calling` and the graph component
-  recovery path. When the column is absent, sample calling skips it and graph molecule
-  statistics use the number of edges.
-- Refactor `pixelator.common.utils.__init__.py`
 
 ### Fixed
 - The default number of cores and the fallbacks used when `--cores` is not set now respect the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   passed directly to native community detection, and the recovered components are unchanged.
 
 ### Fixed
+- `coarsened_pmds_layout` sizes PMDS pivots from the full graph when Leiden
+  yields too few communities, so a valid low `pivots` no longer fails
+  `pmds_layout`'s `0.2 * n` lower bound.
 - The default number of cores and the fallbacks used when `--cores` is not set now respect the
   CPU affinity mask (via `os.process_cpu_count()` or `os.sched_getaffinity()`) and the cgroup
   CPU bandwidth quota (`docker run --cpus`, Kubernetes `limits.cpu`), taking the most restrictive

--- a/docs/api/overview.rst
+++ b/docs/api/overview.rst
@@ -17,6 +17,13 @@ for usage examples.
 **PNAPixelDataset**
 
 * :class:`pixelator.pna.pixeldataset.PNAPixelDataset`
+* :meth:`pixelator.pna.pixeldataset.PNAPixelDataset.layouts`
+* :class:`pixelator.pna.pixeldataset.layouts.Layouts`
+
+  :meth:`~pixelator.pna.pixeldataset.PNAPixelDataset.precomputed_layouts` and
+  :class:`~pixelator.pna.pixeldataset.precomputed_layouts.PreComputedLayouts`
+  are deprecated; use :meth:`~pixelator.pna.pixeldataset.PNAPixelDataset.layouts`
+  instead.
 
 **Plotting**
 

--- a/src/pixelator/common/graph/backends/implementations/_networkx.py
+++ b/src/pixelator/common/graph/backends/implementations/_networkx.py
@@ -33,6 +33,7 @@ from networkx.algorithms import bipartite as nx_bipartite
 from scipy.sparse import csr_matrix
 
 from pixelator.common.graph.backends.protocol import (
+    DEFAULT_LAYOUT_ALGORITHM,
     Edge,
     EdgeSequence,
     GraphBackend,
@@ -295,7 +296,7 @@ class NetworkXGraphBackend(GraphBackend):
 
     def _layout_coordinates(
         self,
-        layout_algorithm: SupportedLayoutAlgorithm = "coarsened_pmds_3d",
+        layout_algorithm: SupportedLayoutAlgorithm = DEFAULT_LAYOUT_ALGORITHM,
         random_seed: Optional[int] = None,
         **kwargs,
     ) -> pd.DataFrame:
@@ -381,7 +382,7 @@ class NetworkXGraphBackend(GraphBackend):
 
     def layout_coordinates(
         self,
-        layout_algorithm: SupportedLayoutAlgorithm = "coarsened_pmds_3d",
+        layout_algorithm: SupportedLayoutAlgorithm = DEFAULT_LAYOUT_ALGORITHM,
         only_keep_a_pixels: bool = True,
         get_node_marker_matrix: bool = True,
         random_seed: Optional[int] = None,

--- a/src/pixelator/common/graph/backends/implementations/_networkx.py
+++ b/src/pixelator/common/graph/backends/implementations/_networkx.py
@@ -311,31 +311,33 @@ class NetworkXGraphBackend(GraphBackend):
         if not self._raw:
             raise ValueError("Trying to get layout for empty Graph instance.")
         raw = self._raw  # type: nx.Graph
+        # Public callers use random_seed=; algorithms take seed=. Accept both.
+        seed = kwargs.pop("seed", random_seed)
 
         if layout_algorithm == "kamada_kawai":
             layout_inst = nx.kamada_kawai_layout(
-                raw, pos=nx.random_layout(raw, seed=random_seed)
+                raw, pos=nx.random_layout(raw, seed=seed)
             )
         if layout_algorithm == "kamada_kawai_3d":
             layout_inst = nx.kamada_kawai_layout(
-                raw, pos=nx.random_layout(raw, seed=random_seed, dim=3), dim=3
+                raw, pos=nx.random_layout(raw, seed=seed, dim=3), dim=3
             )
         if layout_algorithm == "fruchterman_reingold":
-            layout_inst = nx.spring_layout(raw, seed=random_seed)
+            layout_inst = nx.spring_layout(raw, seed=seed)
         if layout_algorithm == "fruchterman_reingold_3d":
-            layout_inst = nx.spring_layout(raw, dim=3, seed=random_seed)
+            layout_inst = nx.spring_layout(raw, dim=3, seed=seed)
         if layout_algorithm == "pmds":
-            layout_inst = pmds_layout(raw, seed=random_seed, **kwargs)
+            layout_inst = pmds_layout(raw, seed=seed, **kwargs)
         if layout_algorithm == "pmds_3d":
-            layout_inst = pmds_layout(raw, dim=3, seed=random_seed, **kwargs)
+            layout_inst = pmds_layout(raw, dim=3, seed=seed, **kwargs)
         if layout_algorithm == "wpmds_3d":
             layout_inst = pmds_layout(
-                raw, dim=3, weights="prob_dist", seed=random_seed, **kwargs
+                raw, dim=3, weights="prob_dist", seed=seed, **kwargs
             )
         if layout_algorithm == "coarsened_pmds_3d":
-            layout_inst = coarsened_pmds_layout(raw, seed=random_seed, **kwargs)
+            layout_inst = coarsened_pmds_layout(raw, seed=seed, **kwargs)
         if layout_algorithm == "spectral_3d":
-            layout_inst = spectral_layout(raw, dim=3, seed=random_seed, **kwargs)
+            layout_inst = spectral_layout(raw, dim=3, seed=seed, **kwargs)
 
         coordinates = pd.DataFrame.from_dict(
             layout_inst,

--- a/src/pixelator/common/graph/backends/implementations/_networkx.py
+++ b/src/pixelator/common/graph/backends/implementations/_networkx.py
@@ -874,6 +874,24 @@ def pmds_layout(
     return coordinates
 
 
+def _pmds_layout_normalized(
+    g: nx.Graph,
+    dim: int,
+    pivots: int,
+    seed: Optional[int],
+) -> Dict[Any, np.ndarray]:
+    """Run PMDS on ``g`` and normalize coordinates like coarsened PMDS."""
+    nodes = list(g.nodes)
+    n = len(nodes)
+    pmds_pivots = min(pivots, n)
+    if pmds_pivots >= n and n > dim:
+        pmds_pivots = n - 1
+    coords = pmds_layout(g, dim=dim, pivots=pmds_pivots, seed=seed)
+    xyz = np.vstack([coords[node] for node in nodes])
+    xyz = normalize_layout_coordinates(xyz)
+    return {nodes[i]: xyz[i] for i in range(len(nodes))}
+
+
 def coarsened_pmds_layout(
     g: nx.Graph,
     dim: int = 3,
@@ -905,6 +923,9 @@ def coarsened_pmds_layout(
         their coordinates with a weighted average of their neighbors' coordinates + some random
         jitter (`jitter_sd`).
 
+    When the graph has fewer nodes than ``pivots``, or Leiden produces too few
+    communities to embed, the layout falls back to PMDS on the original graph.
+
     Args:
         g: A connected NetworkX graph.
         dim: Number of output dimensions (default 3).
@@ -925,7 +946,7 @@ def coarsened_pmds_layout(
         ValueError: If the graph is directed.
         ValueError: If the dim is not 2 or 3.
         ValueError: If the resolution is not between 0.01 and 10.
-        ValueError: If pivots is not between 10 and min(#nodes, 1000).
+        ValueError: If pivots is not between 10 and 1000.
         ValueError: If n_iter is not between 1 and 100.
         ValueError: If jitter_sd is not between 0.001 and 0.1.
         ValueError: If weight_edges_by is not "tp" or "crossing_edges".
@@ -938,6 +959,12 @@ def coarsened_pmds_layout(
 
     n_nodes = len(g.nodes)
     n_edges = len(g.edges)
+
+    # Coarsening is for graphs larger than the pivot set. On smaller graphs
+    # the default pivots=200 would previously raise, even though PNA Components
+    # (and filtered subsets) can be well below that size.
+    if pivots >= n_nodes:
+        return _pmds_layout_normalized(g, dim=dim, pivots=n_nodes, seed=seed)
 
     # Normalize resolution parameter to fit PNA graphs
     # Here we use the number of edges to scale the resolution parameter
@@ -966,6 +993,11 @@ def coarsened_pmds_layout(
 
     unique_communities = np.unique(membership)
     n_communities = len(unique_communities)
+
+    if n_communities <= dim:
+        return _pmds_layout_normalized(
+            g, dim=dim, pivots=min(pivots, n_nodes), seed=seed
+        )
 
     community_to_idx = {comm: i for i, comm in enumerate(unique_communities)}
 
@@ -1395,12 +1427,8 @@ def _validate_coarsened_pmds_parameters(
     if not (isinstance(resolution, (float, int)) and 0.01 <= resolution <= 10):
         raise ValueError("resolution must be a float between 0.01 and 10.")
 
-    n_nodes = len(g.nodes)
-    pivots_max = min(n_nodes, 1000)
-    if not (isinstance(pivots, int) and 10 <= pivots <= pivots_max):
-        raise ValueError(
-            f"pivots must be an integer between 10 and {pivots_max} (number of nodes or 1000, whichever is smaller)."
-        )
+    if not (isinstance(pivots, int) and 10 <= pivots <= 1000):
+        raise ValueError("pivots must be an integer between 10 and 1000.")
 
     if not (isinstance(n_iter, int) and 1 <= n_iter <= 100):
         raise ValueError("n_iter must be an integer between 1 and 100.")

--- a/src/pixelator/common/graph/backends/implementations/_networkx.py
+++ b/src/pixelator/common/graph/backends/implementations/_networkx.py
@@ -997,9 +997,10 @@ def coarsened_pmds_layout(
     n_communities = len(unique_communities)
 
     if n_communities <= dim:
-        return _pmds_layout_normalized(
-            g, dim=dim, pivots=min(pivots, n_nodes), seed=seed
-        )
+        # Size pivots from the full graph, as in the small-graph fallback.
+        # Reusing the coarse-level pivot count can fall below pmds_layout's
+        # 0.2 * n lower bound even when the caller passed a valid pivots.
+        return _pmds_layout_normalized(g, dim=dim, pivots=n_nodes, seed=seed)
 
     community_to_idx = {comm: i for i, comm in enumerate(unique_communities)}
 

--- a/src/pixelator/common/graph/backends/protocol.py
+++ b/src/pixelator/common/graph/backends/protocol.py
@@ -39,6 +39,8 @@ SupportedLayoutAlgorithm = Literal[
     "spectral_3d",
 ]
 
+DEFAULT_LAYOUT_ALGORITHM: SupportedLayoutAlgorithm = "coarsened_pmds_3d"
+
 
 class GraphBackend(Protocol):
     """Protocol for graph backends."""
@@ -148,7 +150,7 @@ class GraphBackend(Protocol):
 
     def layout_coordinates(
         self,
-        layout_algorithm: SupportedLayoutAlgorithm = "coarsened_pmds_3d",
+        layout_algorithm: SupportedLayoutAlgorithm = DEFAULT_LAYOUT_ALGORITHM,
         only_keep_a_pixels: bool = True,
         get_node_marker_matrix: bool = True,
         random_seed: Optional[int] = None,

--- a/src/pixelator/common/graph/graph.py
+++ b/src/pixelator/common/graph/graph.py
@@ -18,6 +18,7 @@ from pixelator.common.graph.backends.implementations import (
     graph_backend_from_graph_type,
 )
 from pixelator.common.graph.backends.protocol import (
+    DEFAULT_LAYOUT_ALGORITHM,
     GraphBackend,
     SupportedLayoutAlgorithm,
     VertexClustering,
@@ -170,7 +171,7 @@ class Graph:
 
     def layout_coordinates(
         self,
-        layout_algorithm: SupportedLayoutAlgorithm = "coarsened_pmds_3d",
+        layout_algorithm: SupportedLayoutAlgorithm = DEFAULT_LAYOUT_ALGORITHM,
         only_keep_a_pixels: bool = True,
         get_node_marker_matrix: bool = True,
         cache: bool = False,

--- a/src/pixelator/pna/cli/layout.py
+++ b/src/pixelator/pna/cli/layout.py
@@ -10,7 +10,10 @@ from typing import get_args
 
 import click
 
-from pixelator.common.graph.backends.protocol import SupportedLayoutAlgorithm
+from pixelator.common.graph.backends.protocol import (
+    DEFAULT_LAYOUT_ALGORITHM,
+    SupportedLayoutAlgorithm,
+)
 from pixelator.common.utils import (
     create_output_stage_dir,
     get_sample_name,
@@ -48,8 +51,9 @@ logger = logging.getLogger(__name__)
     "--layout-algorithm",
     required=False,
     multiple=True,
-    default=["coarsened_pmds_3d"],
-    help="Select a layout algorithm to use. This can be specified multiple times to compute multiple layouts. Default: coarsened_pmds_3d",
+    default=[DEFAULT_LAYOUT_ALGORITHM],
+    help="Select a layout algorithm to use. This can be specified multiple times to compute multiple layouts. "
+    f"Default: {DEFAULT_LAYOUT_ALGORITHM}",
     type=click.Choice(get_args(SupportedLayoutAlgorithm)),
 )
 @click.option(

--- a/src/pixelator/pna/graph/__init__.py
+++ b/src/pixelator/pna/graph/__init__.py
@@ -20,6 +20,7 @@ from pixelator.common.graph.backends.implementations._networkx import (
     NetworkXGraphBackend,
 )
 from pixelator.common.graph.backends.protocol import (
+    DEFAULT_LAYOUT_ALGORITHM,
     SupportedLayoutAlgorithm,
     VertexClustering,
 )
@@ -61,7 +62,7 @@ class PNAGraph(BaseGraph):
 
     def layout_coordinates(  # type: ignore
         self,
-        layout_algorithm: SupportedLayoutAlgorithm = "coarsened_pmds_3d",
+        layout_algorithm: SupportedLayoutAlgorithm = DEFAULT_LAYOUT_ALGORITHM,
         get_node_marker_matrix: bool = True,
         random_seed: Optional[int] = None,
         **kwargs,
@@ -72,6 +73,7 @@ class PNAGraph(BaseGraph):
         counts to use that can be used for plotting.
 
         The layout options are:
+        - spectral_3d
         - coarsened_pmds_3d
         - fruchterman_reingold
         - fruchterman_reingold_3d
@@ -80,10 +82,8 @@ class PNAGraph(BaseGraph):
         - pmds
         - pmds_3d
         - wpmds_3d
-        - spectral_3d
 
-        For most cases the `coarsened_pmds_3d`, `wpmds_3d`, and `pmds` options should be
-        preferred. On PNA data they are faster and produce better results.
+        The default is `DEFAULT_LAYOUT_ALGORITHM` (`coarsened_pmds_3d`).
 
         Args:
             layout_algorithm: Layout algorithm to use for coordinate generation.
@@ -198,7 +198,7 @@ class PNAGraphBackend(NetworkXGraphBackend):
 
     def layout_coordinates(  # type: ignore
         self,
-        layout_algorithm: SupportedLayoutAlgorithm = "coarsened_pmds_3d",
+        layout_algorithm: SupportedLayoutAlgorithm = DEFAULT_LAYOUT_ALGORITHM,
         get_node_marker_matrix: bool = True,
         random_seed: Optional[int] = None,
         **kwargs,

--- a/src/pixelator/pna/layout/__init__.py
+++ b/src/pixelator/pna/layout/__init__.py
@@ -156,3 +156,6 @@ class CreateLayout(PerComponentTask):
 
         for fname in data:
             os.remove(Path(fname))
+
+
+__all__ = ["CreateLayout"]

--- a/src/pixelator/pna/pixeldataset/__init__.py
+++ b/src/pixelator/pna/pixeldataset/__init__.py
@@ -23,7 +23,7 @@ names to on-disk ``PxlFile`` instances, and it constructs an
   objects, then wrap it in ``PNAPixelDataset``.
 - ``adata()`` delegates to ``AnnDataHelper.read_adata()`` (which opens the viewer’s DuckDB
   session and runs queries built via ``QueryBuilder`` in the IO package).
-- ``edgelist()``, ``proximity()``, and ``precomputed_layouts()`` take the same ``view`` and
+- ``edgelist()``, ``proximity()``, ``layouts()``, and ``precomputed_layouts()`` take the same ``view`` and
   reuse the dataset’s ``AnnDataHelper`` so AnnData-backed joins stay consistent with the
   active filters.
 - ``metadata()`` queries DuckDB through ``view.open()`` and ``Query`` directly.
@@ -49,6 +49,7 @@ names to on-disk ``PxlFile`` instances, and it constructs an
     ┌────────────────────┐
     │ Edgelist           ├──┐
     │ Proximity          │  ├── view + shared AnnDataHelper (from PNAPixelDataset)
+    │ Layouts            │  │
     │ PreComputedLayouts ├──┘
     └────────────────────┘
 
@@ -62,6 +63,7 @@ from pathlib import Path
 from pixelator.pna.pixeldataset.config import PixelDatasetConfig
 from pixelator.pna.pixeldataset.dataset import PNAPixelDataset
 from pixelator.pna.pixeldataset.edgelist import Edgelist
+from pixelator.pna.pixeldataset.layouts import Layouts
 from pixelator.pna.pixeldataset.precomputed_layouts import PreComputedLayouts
 from pixelator.pna.pixeldataset.proximity import Proximity
 from pixelator.pna.pixeldataset.saver import PixelDatasetSaver
@@ -96,6 +98,7 @@ def read(paths: Path | list[Path] | str | list[str]) -> PNAPixelDataset:
 __all__ = [
     "Component",
     "Edgelist",
+    "Layouts",
     "PixelDatasetConfig",
     "PixelDatasetSaver",
     "PNAPixelDataset",

--- a/src/pixelator/pna/pixeldataset/__init__.py
+++ b/src/pixelator/pna/pixeldataset/__init__.py
@@ -4,8 +4,13 @@ This package defines the high-level
 :class:`~pixelator.pna.pixeldataset.dataset.PNAPixelDataset` API and the
 modality helpers (:class:`~pixelator.pna.pixeldataset.edgelist.Edgelist`,
 :class:`~pixelator.pna.pixeldataset.proximity.Proximity`,
-:class:`~pixelator.pna.pixeldataset.precomputed_layouts.PreComputedLayouts`)
+:class:`~pixelator.pna.pixeldataset.layouts.Layouts`)
 used to read filtered views of data stored in ``.pxl`` DuckDB files.
+
+:class:`~pixelator.pna.pixeldataset.precomputed_layouts.PreComputedLayouts`
+(from :meth:`~pixelator.pna.pixeldataset.PNAPixelDataset.precomputed_layouts`)
+is deprecated; use :meth:`~pixelator.pna.pixeldataset.PNAPixelDataset.layouts`
+instead.
 
 Low-level access to those files (``PxlFile``, ``Query``, ``PixelDataViewer``, writers, and
 :class:`~pixelator.pna.pixeldataset.io.anndata_helper.AnnDataHelper`) lives under
@@ -23,9 +28,9 @@ names to on-disk ``PxlFile`` instances, and it constructs an
   objects, then wrap it in ``PNAPixelDataset``.
 - ``adata()`` delegates to ``AnnDataHelper.read_adata()`` (which opens the viewer’s DuckDB
   session and runs queries built via ``QueryBuilder`` in the IO package).
-- ``edgelist()``, ``proximity()``, ``layouts()``, and ``precomputed_layouts()`` take the same ``view`` and
+- ``edgelist()``, ``proximity()``, and ``layouts()`` take the same ``view`` and
   reuse the dataset’s ``AnnDataHelper`` so AnnData-backed joins stay consistent with the
-  active filters.
+  active filters. ``precomputed_layouts()`` is deprecated.
 - ``metadata()`` queries DuckDB through ``view.open()`` and ``Query`` directly.
 - ``filter()`` returns a new ``PNAPixelDataset`` with a narrowed ``PixelDataViewer`` (when
   filtering samples) and updated active components/markers, rebuilding ``AnnDataHelper``
@@ -50,7 +55,7 @@ names to on-disk ``PxlFile`` instances, and it constructs an
     │ Edgelist           ├──┐
     │ Proximity          │  ├── view + shared AnnDataHelper (from PNAPixelDataset)
     │ Layouts            │  │
-    │ PreComputedLayouts ├──┘
+    │ PreComputedLayouts ├──┘  (deprecated; use Layouts)
     └────────────────────┘
 
 Copyright © 2025 Pixelgen Technologies AB.

--- a/src/pixelator/pna/pixeldataset/dataset.py
+++ b/src/pixelator/pna/pixeldataset/dataset.py
@@ -277,7 +277,7 @@ class PNAPixelDataset:
     ) -> PreComputedLayouts:
         """Return the PreComputedLayouts instance for the dataset.
 
-        Deprecated: prefer :meth:`layouts` to compute Layouts on the fly.
+        Deprecated: prefer :meth:`layouts` to compute Layouts on the fly instead. In the future this method will be removed.
 
         Args:
             add_marker_counts: If True, add the marker counts to the precomputed layouts.
@@ -289,7 +289,7 @@ class PNAPixelDataset:
         """
         warnings.warn(
             "precomputed_layouts() is deprecated; use layouts() to compute "
-            "Layouts on the fly.",
+            "Layouts on the fly. In the future this method will be removed.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/pixelator/pna/pixeldataset/dataset.py
+++ b/src/pixelator/pna/pixeldataset/dataset.py
@@ -7,16 +7,22 @@ from __future__ import annotations
 
 import copy
 import json
+import warnings
 from functools import cache
 from pathlib import Path
 from typing import Iterable
 
 from anndata import AnnData
 
+from pixelator.common.graph.backends.protocol import (
+    DEFAULT_LAYOUT_ALGORITHM,
+    SupportedLayoutAlgorithm,
+)
 from pixelator.pna.pixeldataset.config import PixelDatasetConfig
 from pixelator.pna.pixeldataset.edgelist import Edgelist
 from pixelator.pna.pixeldataset.io import PixelDataViewer, PxlFile, Query
 from pixelator.pna.pixeldataset.io.anndata_helper import AnnDataHelper
+from pixelator.pna.pixeldataset.layouts import Layouts
 from pixelator.pna.pixeldataset.precomputed_layouts import PreComputedLayouts
 from pixelator.pna.pixeldataset.proximity import Proximity
 from pixelator.pna.utils import normalize_input_to_set
@@ -271,6 +277,8 @@ class PNAPixelDataset:
     ) -> PreComputedLayouts:
         """Return the PreComputedLayouts instance for the dataset.
 
+        Deprecated: prefer :meth:`layouts` to compute Layouts on the fly.
+
         Args:
             add_marker_counts: If True, add the marker counts to the precomputed layouts.
             add_spherical_norm: If True, add spherical coordinates to dataframe This will be
@@ -279,12 +287,53 @@ class PNAPixelDataset:
         Returns:
             The PreComputedLayouts instance for the dataset.
         """
+        warnings.warn(
+            "precomputed_layouts() is deprecated; use layouts() to compute "
+            "Layouts on the fly.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return PreComputedLayouts(
             self.view,
             components=self._active_components,
             adata_helper=self._adata_helper,
             add_marker_counts=add_marker_counts,
             add_spherical_norm=add_spherical_norm,
+        )
+
+    def layouts(
+        self,
+        algorithm: SupportedLayoutAlgorithm = DEFAULT_LAYOUT_ALGORITHM,
+        add_marker_counts: bool = True,
+        add_spherical_norm: bool = False,
+        random_seed: int | None = None,
+        **kwargs,
+    ) -> Layouts:
+        """Compute Layouts on the fly for the active Components.
+
+        This always computes coordinates from each Component graph. It does not
+        read Precomputed layouts from the PXL ``layouts`` table.
+
+        Args:
+            algorithm: Layout algorithm to use. Defaults to
+                ``DEFAULT_LAYOUT_ALGORITHM`` (``coarsened_pmds_3d``).
+            add_marker_counts: If True, add per-node marker counts.
+            add_spherical_norm: If True, add spherical unit-vector columns.
+            random_seed: Seed for Layout algorithms with a stochastic element.
+            **kwargs: Forwarded to the underlying Layout algorithm.
+
+        Returns:
+            A lazy Layouts collection.
+        """
+        return Layouts(
+            self.view,
+            components=self._active_components,
+            adata_helper=self._adata_helper,
+            algorithm=algorithm,
+            add_marker_counts=add_marker_counts,
+            add_spherical_norm=add_spherical_norm,
+            random_seed=random_seed,
+            algorithm_kwargs=kwargs,
         )
 
     def metadata(
@@ -317,7 +366,7 @@ class PNAPixelDataset:
         """Filter the dataset to only include the specified samples, components, and markers.
 
         Filtering by components will apply to all data modalities (i.e. adata, edgelist, proximity,
-        and precomputed layouts).
+        layouts, and precomputed layouts).
         However, filtering by markers will only apply to the adata and proximity data modalities,
         since filtering
         by markers in the edgelist and precomputed layouts will cause components to break up.

--- a/src/pixelator/pna/pixeldataset/dataset.py
+++ b/src/pixelator/pna/pixeldataset/dataset.py
@@ -277,7 +277,10 @@ class PNAPixelDataset:
     ) -> PreComputedLayouts:
         """Return the PreComputedLayouts instance for the dataset.
 
-        Deprecated: prefer :meth:`layouts` to compute Layouts on the fly instead. In the future this method will be removed.
+        .. deprecated:: Unreleased
+            Use :meth:`layouts` to compute Layouts on the fly instead. This
+            method still reads a stored ``layouts`` table when one exists, and
+            will be removed in a future release.
 
         Args:
             add_marker_counts: If True, add the marker counts to the precomputed layouts.
@@ -309,10 +312,39 @@ class PNAPixelDataset:
         random_seed: int | None = None,
         **kwargs,
     ) -> Layouts:
-        """Compute Layouts on the fly for the active Components.
+        """Return Layouts for the active Components.
 
-        This always computes coordinates from each Component graph. It does not
-        read Precomputed layouts from the PXL ``layouts`` table.
+        A Layout places each node of a Component graph in 2D or 3D so
+        you can visualize the cell and for example color nodes by marker.
+        Computation runs when you materialize the result (for example
+        :meth:`~pixelator.pna.pixeldataset.layouts.Layouts.to_df`).
+        This replaces the deprecated :meth:`precomputed_layouts`.
+
+        Choose a Layout algorithm with ``algorithm``. The default
+        ``coarsened_pmds_3d`` is the usual choice for PNA: it is fast on large
+        Components and produces a 3D Layout suitable for plotting.
+
+        Available Layout algorithms:
+
+        - ``coarsened_pmds_3d`` (default): 3D layout algorithm that uses a
+          pre-coarsening step. Fast and robust to structural artifacts.
+        - ``wpmds_3d``: 3D weighted PMDS; a good alternative when you want a
+          full (non-coarsened) PMDS Layout.
+        - ``pmds`` / ``pmds_3d``: 2D or 3D PMDS without coarsening.
+        - ``spectral_3d``: 3D spectral Layout. Extremely fast, generates high
+          quality layouts but can be sensitive to structural artifacts.
+        - ``fruchterman_reingold`` / ``fruchterman_reingold_3d``: force-directed;
+          slower on large Components.
+        - ``kamada_kawai`` / ``kamada_kawai_3d``: force-directed; slower on
+          large Components.
+
+        For most cases prefer ``coarsened_pmds_3d``, ``wpmds_3d``, or ``pmds`` (in that order).
+        On PNA data they are faster and produce better results than the
+        force-directed algorithms.
+
+        .. code-block:: python
+
+                df = pxl_dataset.filter(components=component_id).layouts().to_df()
 
         Args:
             algorithm: Layout algorithm to use. Defaults to
@@ -323,7 +355,7 @@ class PNAPixelDataset:
             **kwargs: Forwarded to the underlying Layout algorithm.
 
         Returns:
-            A lazy Layouts collection.
+            A Layouts collection for the active Components.
         """
         return Layouts(
             self.view,

--- a/src/pixelator/pna/pixeldataset/layouts.py
+++ b/src/pixelator/pna/pixeldataset/layouts.py
@@ -24,8 +24,7 @@ from pixelator.pna.utils import normalize_input_to_set
 class Layouts:
     """On-the-fly Layouts for one or more Components.
 
-    Coordinates are always computed from each Component graph. This collection
-    never reads the PXL ``layouts`` table.
+    Coordinates are computed from each Component graph.
     """
 
     def __init__(

--- a/src/pixelator/pna/pixeldataset/layouts.py
+++ b/src/pixelator/pna/pixeldataset/layouts.py
@@ -124,7 +124,10 @@ class Layouts:
         frames = [frame for _, frame in self.iterator(return_polars_df=True)]
         if not frames:
             return pl.DataFrame()
-        return pl.concat(frames, how="diagonal_relaxed")
+        df = pl.concat(frames, how="diagonal_relaxed")
+        if self._add_marker_counts:
+            df = df.with_columns(pl.selectors.unsigned_integer().fill_null(0))
+        return df
 
     def to_df(self) -> pd.DataFrame:
         """Get the Layouts as a pandas DataFrame."""

--- a/src/pixelator/pna/pixeldataset/layouts.py
+++ b/src/pixelator/pna/pixeldataset/layouts.py
@@ -22,9 +22,30 @@ from pixelator.pna.utils import normalize_input_to_set
 
 
 class Layouts:
-    """On-the-fly Layouts for one or more Components.
+    """Collection of layouts for one or more Components.
 
-    Coordinates are computed from each Component graph.
+    A Layout places each pixel (node) of a Component graph in 2D or 3D so you
+    can visualise a representation of the cell (for example a scatter of
+    ``x``/``y``/``z`` points colored by marker abundance).
+    Get a collection from :meth:`~pixelator.pna.pixeldataset.PNAPixelDataset.layouts`; coordinates
+    are computed when you materialize data. Prefer this over the deprecated
+    :meth:`~pixelator.pna.pixeldataset.PNAPixelDataset.precomputed_layouts`.
+
+    Example usage:
+
+    .. code-block:: python
+
+        layouts = pxl_dataset.filter(components=component_id).layouts()
+        df = layouts.to_df()  # pandas: all selected Components
+        first = layouts.first().to_df()  # only the first Component
+        for component_id, frame in layouts.iterator():
+            # one Component at a time (use this for many or large cells)
+            ...
+
+    Use :meth:`to_polars` instead of :meth:`to_df` when you want a polars
+    DataFrame. Each row is one node; columns include ``x``, ``y``, and for 3D
+    algorithms ``z``, plus ``component``, ``sample``, ``layout``, and (by
+    default) per-marker counts.
     """
 
     def __init__(
@@ -38,7 +59,11 @@ class Layouts:
         random_seed: int | None = None,
         algorithm_kwargs: dict | None = None,
     ):
-        """Create a new Layouts collection."""
+        """Create a new Layouts collection.
+
+        Prefer :meth:`~pixelator.pna.pixeldataset.PNAPixelDataset.layouts` over
+        constructing this class directly.
+        """
         self._view = view
         self._components = normalize_input_to_set(components)
         self._adata_helper = (
@@ -71,7 +96,11 @@ class Layouts:
         return set(self._ordered_components())
 
     def first(self) -> Layouts:
-        """Return a Layouts collection with only the first Component."""
+        """Return a Layouts collection with only the first Component.
+
+        Useful when you want to inspect or plot a single component without
+        computing Layouts for every Component in the collection.
+        """
         ordered = self._ordered_components()
         if not ordered:
             raise ValueError("No components available to compute a Layout.")
@@ -119,7 +148,7 @@ class Layouts:
         return df
 
     def to_polars(self) -> pl.DataFrame:
-        """Get the Layouts as a polars DataFrame."""
+        """Return Layouts for all selected Components as a polars DataFrame."""
         frames = [frame for _, frame in self.iterator(return_polars_df=True)]
         if not frames:
             return pl.DataFrame()
@@ -129,13 +158,18 @@ class Layouts:
         return df
 
     def to_df(self) -> pd.DataFrame:
-        """Get the Layouts as a pandas DataFrame."""
+        """Return Layouts for all selected Components as a pandas DataFrame."""
         return self.to_polars().to_pandas()
 
     def iterator(
         self, return_polars_df: bool = False
     ) -> Iterable[tuple[str, pd.DataFrame | pl.DataFrame]]:
-        """Yield (component id, Layout dataframe) pairs, one Component at a time."""
+        """Yield ``(component_id, dataframe)`` pairs, one Component at a time.
+
+        Prefer this over :meth:`to_df` when working with many or large
+        Components so each Layout can be processed without holding all of
+        them in memory.
+        """
         for component_id in self._ordered_components():
             frame = self._compute_component(component_id)
             if return_polars_df:

--- a/src/pixelator/pna/pixeldataset/layouts.py
+++ b/src/pixelator/pna/pixeldataset/layouts.py
@@ -110,14 +110,11 @@ class Layouts:
 
     def _post_process(self, df: pl.DataFrame) -> pl.DataFrame:
         if self._add_spherical_norm:
-            coordinates = df.select(["x", "y", "z"]).to_numpy()
+            coord_cols = [c for c in ("x", "y", "z") if c in df.columns]
+            coordinates = df.select(coord_cols).to_numpy()
             normalized_coordinates = pl.DataFrame(
                 coordinates / (1 * np.linalg.norm(coordinates, axis=1))[:, None],
-                schema={
-                    "x_norm": pl.Float32,
-                    "y_norm": pl.Float32,
-                    "z_norm": pl.Float32,
-                },
+                schema={f"{c}_norm": pl.Float32 for c in coord_cols},
             )
             df = df.hstack(normalized_coordinates)
         return df

--- a/src/pixelator/pna/pixeldataset/layouts.py
+++ b/src/pixelator/pna/pixeldataset/layouts.py
@@ -1,0 +1,170 @@
+"""On-the-fly layouts wrapper for PNA pixel datasets.
+
+Copyright © 2026 Pixelgen Technologies AB.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+import polars as pl
+
+from pixelator.common.graph.backends.protocol import (
+    DEFAULT_LAYOUT_ALGORITHM,
+    SupportedLayoutAlgorithm,
+)
+from pixelator.pna.pixeldataset.edgelist import Edgelist
+from pixelator.pna.pixeldataset.io import PixelDataViewer
+from pixelator.pna.pixeldataset.io.anndata_helper import AnnDataHelper
+from pixelator.pna.utils import normalize_input_to_set
+
+
+class Layouts:
+    """On-the-fly Layouts for one or more Components.
+
+    Coordinates are always computed from each Component graph. This collection
+    never reads the PXL ``layouts`` table.
+    """
+
+    def __init__(
+        self,
+        view: PixelDataViewer,
+        components: str | Iterable[str] | None = None,
+        adata_helper: AnnDataHelper | None = None,
+        algorithm: SupportedLayoutAlgorithm = DEFAULT_LAYOUT_ALGORITHM,
+        add_marker_counts: bool = True,
+        add_spherical_norm: bool = False,
+        random_seed: int | None = None,
+        algorithm_kwargs: dict | None = None,
+    ):
+        """Create a new Layouts collection."""
+        self._view = view
+        self._components = normalize_input_to_set(components)
+        self._adata_helper = (
+            adata_helper
+            if adata_helper is not None
+            else AnnDataHelper(self._view, components=self._components)
+        )
+        self._algorithm = algorithm
+        self._add_marker_counts = add_marker_counts
+        self._add_spherical_norm = add_spherical_norm
+        self._random_seed = random_seed
+        self._algorithm_kwargs = algorithm_kwargs or {}
+
+    def _obs(self):
+        return self._adata_helper.read_adata(
+            add_clr_transform=False, add_log1p_transform=False
+        ).obs
+
+    def _ordered_components(self) -> list[str]:
+        ordered = self._obs().index.to_list()
+        if self._components is None:
+            return ordered
+        return [
+            component_id for component_id in ordered if component_id in self._components
+        ]
+
+    @property
+    def components(self) -> set[str]:
+        """Get the component names."""
+        return set(self._ordered_components())
+
+    def first(self) -> Layouts:
+        """Return a Layouts collection with only the first Component."""
+        ordered = self._ordered_components()
+        if not ordered:
+            raise ValueError("No components available to compute a Layout.")
+        return Layouts(
+            view=self._view,
+            components=[ordered[0]],
+            adata_helper=self._adata_helper,
+            algorithm=self._algorithm,
+            add_marker_counts=self._add_marker_counts,
+            add_spherical_norm=self._add_spherical_norm,
+            random_seed=self._random_seed,
+            algorithm_kwargs=self._algorithm_kwargs,
+        )
+
+    def _compute_component(self, component_id: str) -> pl.DataFrame:
+        edgelist = Edgelist(
+            self._view,
+            components=[component_id],
+            adata_helper=self._adata_helper,
+        )
+        component = next(iter(edgelist.iterator()))
+        coordinates = component.graph.layout_coordinates(
+            layout_algorithm=self._algorithm,
+            get_node_marker_matrix=self._add_marker_counts,
+            random_seed=self._random_seed,
+            **self._algorithm_kwargs,
+        )
+        sample = self._obs().loc[component_id, "sample"]
+        coordinates = coordinates.reset_index(drop=True)
+        coordinates["component"] = component_id
+        coordinates["graph_projection"] = "full"
+        coordinates["layout"] = self._algorithm
+        coordinates["sample"] = sample
+        return self._post_process(pl.from_pandas(coordinates))
+
+    def _post_process(self, df: pl.DataFrame) -> pl.DataFrame:
+        if self._add_spherical_norm:
+            coordinates = df.select(["x", "y", "z"]).to_numpy()
+            normalized_coordinates = pl.DataFrame(
+                coordinates / (1 * np.linalg.norm(coordinates, axis=1))[:, None],
+                schema={
+                    "x_norm": pl.Float32,
+                    "y_norm": pl.Float32,
+                    "z_norm": pl.Float32,
+                },
+            )
+            df = df.hstack(normalized_coordinates)
+        return df
+
+    def to_polars(self) -> pl.DataFrame:
+        """Get the Layouts as a polars DataFrame."""
+        frames = [frame for _, frame in self.iterator(return_polars_df=True)]
+        if not frames:
+            return pl.DataFrame()
+        return pl.concat(frames, how="diagonal_relaxed")
+
+    def to_df(self) -> pd.DataFrame:
+        """Get the Layouts as a pandas DataFrame."""
+        return self.to_polars().to_pandas()
+
+    def iterator(
+        self, return_polars_df: bool = False
+    ) -> Iterable[tuple[str, pd.DataFrame | pl.DataFrame]]:
+        """Yield (component id, Layout dataframe) pairs, one Component at a time."""
+        for component_id in self._ordered_components():
+            frame = self._compute_component(component_id)
+            if return_polars_df:
+                yield component_id, frame
+            else:
+                yield component_id, frame.to_pandas()
+
+    def is_empty(self) -> bool:
+        """Return True when there are no Components to layout."""
+        return not self._ordered_components()
+
+    def describe(self) -> str:
+        """Return a description of the Layouts."""
+        return (
+            f"Layouts({len(self._ordered_components()):,} components, "
+            f"algorithm={self._algorithm})"
+        )
+
+    def __str__(self):
+        """Get a string representation of the Layouts."""
+        return (
+            f"Layouts({len(self._ordered_components()):,} components, "
+            f"algorithm={self._algorithm})"
+        )
+
+    def __repr__(self):
+        """Get a string representation of the Layouts."""
+        return str(self)
+
+    def _ipython_display_(self):
+        return print(self.describe())

--- a/src/pixelator/pna/pixeldataset/layouts.py
+++ b/src/pixelator/pna/pixeldataset/layouts.py
@@ -37,7 +37,11 @@ class Layouts:
 
         layouts = pxl_dataset.filter(components=component_id).layouts()
         df = layouts.to_df()  # pandas: all selected Components
+
+        # Then either for a single Component:
         first = layouts.first().to_df()  # only the first Component
+
+        # Or iterate over all Components in the collection:
         for component_id, frame in layouts.iterator():
             # one Component at a time (use this for many or large cells)
             ...

--- a/src/pixelator/pna/pixeldataset/precomputed_layouts.py
+++ b/src/pixelator/pna/pixeldataset/precomputed_layouts.py
@@ -18,7 +18,13 @@ from pixelator.pna.utils import normalize_input_to_list, normalize_input_to_set
 
 
 class PreComputedLayouts:
-    """Representation of precomputed layouts.
+    """Representation of precomputed layouts stored in a PXL file.
+
+    .. deprecated:: Unreleased
+        Use :class:`~pixelator.pna.pixeldataset.layouts.Layouts` from
+        :meth:`~pixelator.pna.pixeldataset.PNAPixelDataset.layouts` instead.
+        This class reads a stored ``layouts`` table when one exists, and will
+        be removed in a future release.
 
     This contains precomputed layouts for one or more components.
     """

--- a/tests/common/data_generator/reads.py
+++ b/tests/common/data_generator/reads.py
@@ -106,8 +106,8 @@ def _random_qualities(
 ) -> list[str]:
     """Phred+33 quality strings with scores drawn around ``mean_q`` (default Q30)."""
     q = rng.normal(mean_q, std_q, size=(n, length)).round()
-    q = np.clip(q, 2, 40).astype(np.uint8) + 33  # Phred+33 ASCII offset
-    return [row.tobytes().decode("ascii") for row in q]
+    q_ascii = np.clip(q, 2, 40).astype(np.uint8) + 33  # Phred+33 ASCII offset
+    return [row.tobytes().decode("ascii") for row in q_ascii]
 
 
 def _write_fastq_records(

--- a/tests/common/graph/test_layout_coordinates.py
+++ b/tests/common/graph/test_layout_coordinates.py
@@ -1,0 +1,27 @@
+"""Tests for Graph.layout_coordinates.
+
+Copyright © 2026 Pixelgen Technologies AB.
+"""
+
+import networkx as nx
+import pandas as pd
+
+from pixelator.common.graph.graph import Graph
+
+
+def _attributed_cycle(n: int = 40) -> Graph:
+    graph = nx.cycle_graph(n)
+    nx.set_node_attributes(graph, {i: str(i) for i in graph.nodes()}, "name")
+    nx.set_node_attributes(
+        graph, {i: "A" if i % 2 == 0 else "B" for i in graph.nodes()}, "pixel_type"
+    )
+    return Graph.from_raw(graph)
+
+
+def test_layout_coordinates_seed_kwarg_seeds_the_default_algorithm():
+    """``seed=`` is the algorithm parameter and must seed, not TypeError."""
+    graph = _attributed_cycle()
+    common = dict(get_node_marker_matrix=False, only_keep_a_pixels=False)
+    via_seed = graph.layout_coordinates(**common, seed=42)
+    via_random_seed = graph.layout_coordinates(**common, random_seed=42)
+    pd.testing.assert_frame_equal(via_seed, via_random_seed)

--- a/tests/pna/layout/test_coarsened_pmds_layout.py
+++ b/tests/pna/layout/test_coarsened_pmds_layout.py
@@ -72,6 +72,37 @@ def test_coarsened_pmds_layout_accepts_graphs_smaller_than_default_pivots():
     assert np.isfinite(coords).all()
 
 
+def test_coarsened_pmds_layout_falls_back_when_leiden_yields_too_few_communities(
+    monkeypatch,
+):
+    """Valid low pivots must still work when coarsening cannot embed.
+
+    ``coarsened_pmds_layout`` allows ``pivots`` down to 10, but ``pmds_layout``
+    requires at least ``0.2 * n_nodes``. The too-few-communities fallback must
+    size pivots from the full graph, not reuse the coarse-level pivot count.
+    """
+    n_nodes = 80
+    graph = nx.cycle_graph(n_nodes)
+    pivots = 10
+    assert pivots < 0.2 * n_nodes
+
+    def _single_community(edges, **kwargs):
+        nodes = {u for u, v, _weight in edges} | {v for u, v, _weight in edges}
+        return 1.0, {node: 0 for node in nodes}
+
+    monkeypatch.setattr(
+        "pixelator.common.graph.backends.implementations._networkx.leiden",
+        _single_community,
+    )
+
+    layout = coarsened_pmds_layout(graph, pivots=pivots, seed=42)
+
+    assert set(layout.keys()) == set(graph.nodes())
+    coords = np.vstack([layout[node] for node in graph.nodes()])
+    assert coords.shape == (n_nodes, 3)
+    assert np.isfinite(coords).all()
+
+
 @pytest.mark.parametrize("weight_edges_by", WEIGHT_MODES)
 def test_coarsened_pmds_layout_is_deterministic(layout_graph, weight_edges_by):
     """The same seed produces an identical layout across runs."""

--- a/tests/pna/layout/test_coarsened_pmds_layout.py
+++ b/tests/pna/layout/test_coarsened_pmds_layout.py
@@ -29,9 +29,9 @@ WEIGHT_MODES = ["tp", "crossing_edges"]
 def layout_graph() -> nx.Graph:
     """A connected synthetic cell graph with nodes on a unit sphere.
 
-    ``coarsened_pmds_layout`` requires a connected, undirected graph with at
-    least ``pivots`` (default 200) nodes, so we generate a larger graph and keep
-    its largest connected component.
+    ``coarsened_pmds_layout`` coarsens large graphs; tests of neighborhood
+    preservation use a graph bigger than the default pivot count so the
+    coarsening path is exercised.
     """
     edgelist = generate_cell_graph(n_nodes=800, n_edges=2500, min_neighbors=25, rng=42)
     graph = nx.Graph()
@@ -57,6 +57,19 @@ def _sample_non_edges(
         if not graph.has_edge(a, b):
             non_edges.append((a, b))
     return non_edges
+
+
+def test_coarsened_pmds_layout_accepts_graphs_smaller_than_default_pivots():
+    """Default pivots=200 must not reject a connected graph with fewer nodes."""
+    graph = nx.cycle_graph(80)
+    assert graph.number_of_nodes() < 200
+
+    layout = coarsened_pmds_layout(graph, seed=42)
+
+    assert set(layout.keys()) == set(graph.nodes())
+    coords = np.vstack([layout[node] for node in graph.nodes()])
+    assert coords.shape == (graph.number_of_nodes(), 3)
+    assert np.isfinite(coords).all()
 
 
 @pytest.mark.parametrize("weight_edges_by", WEIGHT_MODES)

--- a/tests/pna/pixeldataset/test_layouts.py
+++ b/tests/pna/pixeldataset/test_layouts.py
@@ -159,6 +159,16 @@ class TestLayoutsApi:
         )
         assert len(df) > 0
 
+    def test_seed_kwarg_seeds_the_default_algorithm(self, pxl_dataset: PNAPixelDataset):
+        """`.layouts(seed=42)` must seed the default algorithm, not TypeError."""
+        component_id = _one_component(pxl_dataset)
+        filtered = pxl_dataset.filter(components=component_id)
+        via_seed = filtered.layouts(add_marker_counts=False, seed=42).to_df()
+        via_random_seed = filtered.layouts(
+            add_marker_counts=False, random_seed=42
+        ).to_df()
+        pd.testing.assert_frame_equal(via_seed, via_random_seed)
+
     def test_spherical_norm_adds_norm_columns(self, pxl_dataset: PNAPixelDataset):
         component_id = _one_component(pxl_dataset)
         df = (

--- a/tests/pna/pixeldataset/test_layouts.py
+++ b/tests/pna/pixeldataset/test_layouts.py
@@ -167,6 +167,22 @@ class TestLayoutsApi:
         assert {"x_norm", "y_norm"}.issubset(df.columns)
         assert "z_norm" not in df.columns
 
+    def test_to_polars_fills_missing_marker_counts_with_zero(
+        self, pxl_dataset: PNAPixelDataset
+    ):
+        # Component e7d82bca9694eea7 has MarkerA/MarkerB only; others have MarkerC.
+        df = pxl_dataset.layouts(
+            algorithm=_FAST_ALGORITHM, add_marker_counts=True
+        ).to_polars()
+        marker_cols = ["MarkerA", "MarkerB", "MarkerC"]
+        assert set(marker_cols).issubset(df.columns)
+        for col in marker_cols:
+            assert df[col].null_count() == 0
+
+        missing_c = df.filter(pl.col("component") == "e7d82bca9694eea7")
+        assert missing_c.height > 0
+        assert (missing_c["MarkerC"] == 0).all()
+
 
 class TestPrecomputedLayoutsDeprecation:
     @pytest.mark.filterwarnings("always::DeprecationWarning")

--- a/tests/pna/pixeldataset/test_layouts.py
+++ b/tests/pna/pixeldataset/test_layouts.py
@@ -59,6 +59,28 @@ class TestDefaultLayoutAlgorithm:
 
 
 class TestLayoutsApi:
+    def test_default_algorithm_computes_on_components_smaller_than_default_pivots(
+        self, pxl_dataset: PNAPixelDataset
+    ):
+        """The default algorithm must work on Components smaller than its default pivot count.
+
+        ``coarsened_pmds_3d`` defaults to 200 pivots. Callers migrating from
+        ``precomputed_layouts()`` (which only read stored coordinates) can have
+        valid Components well below that size.
+        """
+        component_id = _one_component(pxl_dataset)
+        n_umi = int(pxl_dataset.adata().obs.loc[component_id, "n_umi"])
+        assert n_umi < 200
+
+        df = (
+            pxl_dataset.filter(components=component_id)
+            .layouts(add_marker_counts=False)
+            .to_df()
+        )
+        assert len(df) > 0
+        assert set(df["layout"].unique()) == {DEFAULT_LAYOUT_ALGORITHM}
+        assert _COORD_COLUMNS.issubset(df.columns)
+
     def test_to_df_has_precomputed_coordinate_columns(
         self, pxl_dataset: PNAPixelDataset
     ):

--- a/tests/pna/pixeldataset/test_layouts.py
+++ b/tests/pna/pixeldataset/test_layouts.py
@@ -20,6 +20,7 @@ from pixelator.pna.pixeldataset.layouts import Layouts
 # Tiny fixture graphs are too small for spectral_3d; use a force-directed
 # algorithm to exercise the public Layouts API quickly.
 _FAST_ALGORITHM: SupportedLayoutAlgorithm = "fruchterman_reingold_3d"
+_FAST_2D_ALGORITHM: SupportedLayoutAlgorithm = "fruchterman_reingold"
 
 _COORD_COLUMNS = {
     "sample",
@@ -148,6 +149,23 @@ class TestLayoutsApi:
             .to_polars()
         )
         assert {"x_norm", "y_norm", "z_norm"}.issubset(df.columns)
+
+    def test_spherical_norm_adds_norm_columns_for_2d_algorithm(
+        self, pxl_dataset: PNAPixelDataset
+    ):
+        component_id = _one_component(pxl_dataset)
+        df = (
+            pxl_dataset.filter(components=component_id)
+            .layouts(
+                algorithm=_FAST_2D_ALGORITHM,
+                add_marker_counts=False,
+                add_spherical_norm=True,
+            )
+            .to_polars()
+        )
+        assert "z" not in df.columns
+        assert {"x_norm", "y_norm"}.issubset(df.columns)
+        assert "z_norm" not in df.columns
 
 
 class TestPrecomputedLayoutsDeprecation:

--- a/tests/pna/pixeldataset/test_layouts.py
+++ b/tests/pna/pixeldataset/test_layouts.py
@@ -1,0 +1,159 @@
+"""Tests for on-the-fly Layouts on PNAPixelDataset.
+
+Copyright © 2026 Pixelgen Technologies AB.
+"""
+
+from inspect import signature
+
+import pandas as pd
+import polars as pl
+import pytest
+
+from pixelator.common.graph.backends.protocol import (
+    DEFAULT_LAYOUT_ALGORITHM,
+    SupportedLayoutAlgorithm,
+)
+from pixelator.pna.graph import PNAGraph
+from pixelator.pna.pixeldataset import PNAPixelDataset
+from pixelator.pna.pixeldataset.layouts import Layouts
+
+# Tiny fixture graphs are too small for spectral_3d; use a force-directed
+# algorithm to exercise the public Layouts API quickly.
+_FAST_ALGORITHM: SupportedLayoutAlgorithm = "fruchterman_reingold_3d"
+
+_COORD_COLUMNS = {
+    "sample",
+    "component",
+    "graph_projection",
+    "index",
+    "layout",
+    "pixel_type",
+    "x",
+    "y",
+    "z",
+}
+
+
+def _one_component(pxl_dataset: PNAPixelDataset) -> str:
+    return pxl_dataset.adata().obs.index[0]
+
+
+class TestDefaultLayoutAlgorithm:
+    def test_default_is_spectral_3d(self):
+        assert DEFAULT_LAYOUT_ALGORITHM == "coarsened_pmds_3d"
+
+    def test_layouts_method_uses_the_shared_default(self):
+        assert (
+            signature(PNAPixelDataset.layouts).parameters["algorithm"].default
+            == DEFAULT_LAYOUT_ALGORITHM
+        )
+
+    def test_layout_coordinates_uses_the_shared_default(self):
+        assert (
+            signature(PNAGraph.layout_coordinates)
+            .parameters["layout_algorithm"]
+            .default
+            == DEFAULT_LAYOUT_ALGORITHM
+        )
+
+
+class TestLayoutsApi:
+    def test_to_df_has_precomputed_coordinate_columns(
+        self, pxl_dataset: PNAPixelDataset
+    ):
+        component_id = _one_component(pxl_dataset)
+        df = (
+            pxl_dataset.filter(components=component_id)
+            .layouts(algorithm=_FAST_ALGORITHM, add_marker_counts=False)
+            .to_df()
+        )
+        assert isinstance(df, pd.DataFrame)
+        assert _COORD_COLUMNS.issubset(df.columns)
+        assert set(df["layout"].unique()) == {_FAST_ALGORITHM}
+        assert set(df["component"].unique()) == {component_id}
+        assert "A" in set(df["pixel_type"])
+        assert "B" in set(df["pixel_type"])
+
+    def test_to_polars_returns_polars(self, pxl_dataset: PNAPixelDataset):
+        component_id = _one_component(pxl_dataset)
+        df = (
+            pxl_dataset.filter(components=component_id)
+            .layouts(algorithm=_FAST_ALGORITHM, add_marker_counts=False)
+            .to_polars()
+        )
+        assert isinstance(df, pl.DataFrame)
+        assert df.height > 0
+
+    def test_first_is_a_layouts_with_one_component(self, pxl_dataset: PNAPixelDataset):
+        layouts = pxl_dataset.layouts(
+            algorithm=_FAST_ALGORITHM, add_marker_counts=False
+        )
+        first = layouts.first()
+        assert isinstance(first, Layouts)
+        df = first.to_df()
+        assert df["component"].nunique() == 1
+        assert df["component"].iloc[0] == pxl_dataset.adata().obs.index[0]
+
+    def test_iterator_yields_one_frame_per_component(
+        self, pxl_dataset: PNAPixelDataset
+    ):
+        layouts = pxl_dataset.layouts(
+            algorithm=_FAST_ALGORITHM, add_marker_counts=False
+        )
+        items = list(layouts.iterator())
+        assert {component_id for component_id, _ in items} == pxl_dataset.components()
+        assert all(isinstance(frame, pd.DataFrame) for _, frame in items)
+
+    def test_always_computes_and_does_not_read_the_layouts_table(
+        self, pxl_dataset: PNAPixelDataset
+    ):
+        component_id = _one_component(pxl_dataset)
+        stored = set(
+            pxl_dataset.filter(components=component_id)
+            .precomputed_layouts(add_marker_counts=False)
+            .to_df()["layout"]
+            .unique()
+        )
+        computed = set(
+            pxl_dataset.filter(components=component_id)
+            .layouts(algorithm=_FAST_ALGORITHM, add_marker_counts=False)
+            .to_df()["layout"]
+            .unique()
+        )
+        assert computed == {_FAST_ALGORITHM}
+        assert computed != stored
+
+    def test_kwargs_are_forwarded(self, pxl_dataset: PNAPixelDataset):
+        component_id = _one_component(pxl_dataset)
+        df = (
+            pxl_dataset.filter(components=component_id)
+            .layouts(
+                algorithm=_FAST_ALGORITHM,
+                add_marker_counts=False,
+                random_seed=1,
+            )
+            .to_df()
+        )
+        assert len(df) > 0
+
+    def test_spherical_norm_adds_norm_columns(self, pxl_dataset: PNAPixelDataset):
+        component_id = _one_component(pxl_dataset)
+        df = (
+            pxl_dataset.filter(components=component_id)
+            .layouts(
+                algorithm=_FAST_ALGORITHM,
+                add_marker_counts=False,
+                add_spherical_norm=True,
+            )
+            .to_polars()
+        )
+        assert {"x_norm", "y_norm", "z_norm"}.issubset(df.columns)
+
+
+class TestPrecomputedLayoutsDeprecation:
+    @pytest.mark.filterwarnings("always::DeprecationWarning")
+    def test_precomputed_layouts_emits_deprecation_warning(
+        self, pxl_dataset: PNAPixelDataset
+    ):
+        with pytest.warns(DeprecationWarning, match="layouts\\(\\)"):
+            pxl_dataset.precomputed_layouts()


### PR DESCRIPTION
<!--

Please fill in the appropriate checklist below (delete whatever is not relevant).

Learn more about contributing: [CONTRIBUTING.md](https://github.com/PixelgenTechnologies/pixelator/blob/main/CONTRIBUTING.md)
-->

## Description

Layouts are now computed on the fly from each Component graph, instead of only being read from a stored `layouts` table ([845fa6a3](https://github.com/PixelgenTechnologies/pixelator/commit/845fa6a304d27bb43a831166ca29027578718395)).

**Before:** `pxl_dataset.precomputed_layouts().to_df()`
**After:** `pxl_dataset.layouts(...).to_df()`

`PNAPixelDataset.layouts()` always computes coordinates from the active Component graphs.  
It never reads the PXL `layouts` table.  
Callers choose the Layout algorithm with `algorithm=` (default `coarsened_pmds_3d`, via `DEFAULT_LAYOUT_ALGORITHM`), optional `random_seed`, and other algorithm kwargs.  
Results export through `.first()`, `.iterator()`, `.to_df()`, and `.to_polars()` with the same column shape as stored layouts (including optional spherical norm and marker counts).

`precomputed_layouts()` left as is and still reads the stored table when it exists, `precomputed_layouts()` is is deprecated and will emit `DeprecationWarning`.  
`pixelator single-cell-pna layout` remains an opt-in writer of Precomputed layouts. 

Layout algorithm defaults for `layouts()`, `layout_coordinates`, and the layout CLI all go through `DEFAULT_LAYOUT_ALGORITHM` ([41c79182](https://github.com/PixelgenTechnologies/pixelator/commit/41c79182d2aa1c236e39284b8b4eea2fd747fdc7)).

<!--
Bugs in the new collection (in scope):
 - concatenating per-Component frames fills missing marker-count columns with 0 ([8375b615](https://github.com/PixelgenTechnologies/pixelator/commit/8375b6157d4fab9a81ab7a98e19528486e4b8546))
 - spherical-norm post-processing works for 2D algorithms (`x_norm` / `y_norm` only) ([2f0b8dfe](https://github.com/PixelgenTechnologies/pixelator/commit/2f0b8dfe743e74e05fc3b311df53ca0545e2ec66))
-->

### Also in this PR, but not specific to on-the-fly computation (cursor bug bot):   
general robustness in `coarsened_pmds_layout` / `layout_coordinates` that we hit because `layouts()` now *runs* the default algorithm on typical Components instead of reading a stored table. These also affect the layout CLI and any other `coarsened_pmds_layout` / `layout_coordinates` caller:

- Graphs smaller than `pivots` (default 200) fall back to normalized PMDS on the full graph, instead of raising ([00dd7c06](https://github.com/PixelgenTechnologies/pixelator/commit/00dd7c06182ac4cc0cd8aa41c9f043f67a00aea8)).
- When Leiden yields too few communities, that fallback sizes pivots from the full graph so a valid low `pivots` does not fail `pmds_layout`'s `0.2 * n` bound ([3b7d4f43](https://github.com/PixelgenTechnologies/pixelator/commit/3b7d4f438905a199be9c7a16d27af6b3249e088e)).
- `layout_coordinates` / `layouts()` accept `seed=` as an alias for `random_seed=` (previously `seed=` TypeError'd because algorithms already take `seed=`) ([730f607b](https://github.com/PixelgenTechnologies/pixelator/commit/730f607be7569b89dfdf9bd7693d2b4c34581cd3)).

Fixes: PNA-2446

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- `tests/pna/pixeldataset/test_layouts.py`: default algorithm constant, `.layouts()` / `.first()` / `.iterator()` / `.to_df()` / `.to_polars()`, column shape vs precomputed layouts, always-compute (does not read the `layouts` table), kwargs forwarding, `seed=` vs `random_seed=`, spherical norms (3D and 2D), missing marker counts filled with 0, `DeprecationWarning` on `precomputed_layouts()`, default `coarsened_pmds_3d` on Components smaller than the default pivot count.
- `tests/pna/layout/test_coarsened_pmds_layout.py`: graphs smaller than default pivots, Leiden too-few-communities fallback with a valid low `pivots`, determinism / validity / neighborhood preservation.
- `tests/common/graph/test_layout_coordinates.py`: `seed=` seeds the default algorithm the same way as `random_seed=`.

To reproduce the new tests:

```shell
uv run pytest tests/pna/pixeldataset/test_layouts.py tests/pna/layout/test_coarsened_pmds_layout.py tests/common/graph/test_layout_coordinates.py
```

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [x] I have checked my code and documentation and corrected any misspellings
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New default analysis path runs layout algorithms on every materialization (performance/cost) and deprecates stored-layout reads; coarsened PMDS fallback changes coordinates for small graphs versus previous failures.
> 
> **Overview**
> **PNA layouts are computed from component graphs at read time** instead of relying on a stored PXL `layouts` table. Callers use `pxl_dataset.layouts(...).to_df()` (or `.iterator()`, `.first()`, `.to_polars()`); `precomputed_layouts()` is deprecated with a `DeprecationWarning` but still reads DuckDB when present. The layout CLI remains the path to write precomputed layouts into files.
> 
> The new **`Layouts`** class builds coordinates per component from the edgelist → `PNAGraph.layout_coordinates`, with optional marker counts and spherical norm columns; multi-component exports fill missing marker-count columns with zero.
> 
> **Shared default:** `DEFAULT_LAYOUT_ALGORITHM` (`coarsened_pmds_3d`) is used by the dataset API, graph backends, and `single-cell-pna layout` CLI.
> 
> **`coarsened_pmds_layout` / `layout_coordinates` hardening** (needed because the default algorithm now runs on typical cell sizes): graphs with fewer nodes than `pivots` or Leiden with ≤ `dim` communities fall back to normalized full-graph PMDS; `layout_coordinates` accepts `seed=` as an alias for `random_seed=`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3806da7b1e746b4081deff2d55698762d411db67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->