### PR TITLE
feat: add checks for single sample identifier when writing .pxl file to disk

### DIFF
--- a/src/pixelator/pna/pixeldataset/io/pixel_file_writer.py
+++ b/src/pixelator/pna/pixeldataset/io/pixel_file_writer.py
@@ -105,14 +105,43 @@ class PixelFileWriter:
             },
         )
 
+    def _assert_single_sample(self, table_name: str) -> None:
+        """Ensure that the ``sample`` column, if present, has a single unique value.
+
+        Args:
+            table_name: The name of the table to check.
+
+        Raises:
+            ValueError: If the table contains a ``sample`` column with more
+                than one unique value.
+        """
+        columns = self._connection.sql(f'DESCRIBE "{table_name}"').pl()["column_name"]
+        if "sample" not in columns:
+            return
+
+        samples = (
+            self._connection.sql(f'SELECT DISTINCT "sample" FROM "{table_name}"')
+            .pl()["sample"]
+            .to_list()
+        )
+        if len(samples) > 1:
+            raise ValueError(
+                f"Table {table_name!r} contains data for multiple samples "
+                f"({samples}), but a PXL file may only contain a single sample."
+            )
+
     def write_edgelist(self, edgelist: Path | pl.DataFrame) -> None:
         """Write the edgelist to the PXL file.
 
         Args:
             edgelist: The path to the edgelist parquet file.
+
+        Raises:
+            ValueError: If the edgelist contains data for more than one sample.
         """
         if isinstance(edgelist, Path):
             self._write_parquet_file_to_table("edgelist", edgelist)
+            self._assert_single_sample("edgelist")
             return
 
         try:
@@ -122,6 +151,7 @@ class PixelFileWriter:
                 self._write_parquet_file_to_table("edgelist", file_path)
         except AttributeError:
             raise ValueError(f"Invalid input type for edgelist: {type(edgelist)}")
+        self._assert_single_sample("edgelist")
 
     def _clean_existing_adata_tables(self):
         tables = self._connection.sql("SHOW ALL TABLES")
@@ -136,7 +166,18 @@ class PixelFileWriter:
 
         Args:
             adata: The AnnData object to write.
+
+        Raises:
+            ValueError: If ``adata.obs`` contains data for more than one sample.
         """
+        if "sample" in adata.obs.columns:
+            samples = adata.obs["sample"].unique().tolist()
+            if len(samples) > 1:
+                raise ValueError(
+                    f"`adata.obs` contains data for multiple samples ({samples}), "
+                    "but a PXL file may only contain a single sample."
+                )
+
         self._clean_existing_adata_tables()
 
         X = adata.to_df().reset_index(names="index")

--- a/src/pixelator/pna/pixeldataset/io/pixel_file_writer.py
+++ b/src/pixelator/pna/pixeldataset/io/pixel_file_writer.py
@@ -105,29 +105,40 @@ class PixelFileWriter:
             },
         )
 
-    def _assert_single_sample(self, table_name: str) -> None:
+    def _assert_single_sample(self, edgelist: Path | pl.DataFrame) -> None:
         """Ensure that the ``sample`` column, if present, has a single unique value.
 
         Args:
-            table_name: The name of the table to check.
+            edgelist: The path to the edgelist parquet file, or a DataFrame.
 
         Raises:
-            ValueError: If the table contains a ``sample`` column with more
+            ValueError: If the edgelist contains a ``sample`` column with more
                 than one unique value.
         """
-        columns = self._connection.sql(f'DESCRIBE "{table_name}"').pl()["column_name"]
-        if "sample" not in columns:
-            return
+        if isinstance(edgelist, Path):
+            columns = self._connection.sql(
+                "SELECT * FROM read_parquet($parquet_file) LIMIT 0",
+                params={"parquet_file": str(edgelist)},
+            ).columns
+            if "sample" not in columns:
+                return
+            samples = (
+                self._connection.sql(
+                    'SELECT DISTINCT "sample" FROM read_parquet($parquet_file)',
+                    params={"parquet_file": str(edgelist)},
+                )
+                .pl()["sample"]
+                .to_list()
+            )
+        else:
+            if "sample" not in edgelist.columns:
+                return
+            samples = edgelist["sample"].unique().to_list()
 
-        samples = (
-            self._connection.sql(f'SELECT DISTINCT "sample" FROM "{table_name}"')
-            .pl()["sample"]
-            .to_list()
-        )
         if len(samples) > 1:
             raise ValueError(
-                f"Table {table_name!r} contains data for multiple samples "
-                f"({samples}), but a PXL file may only contain a single sample."
+                f"Edgelist contains data for multiple samples ({samples}), "
+                "but a PXL file may only contain a single sample."
             )
 
     def write_edgelist(self, edgelist: Path | pl.DataFrame) -> None:
@@ -139,11 +150,10 @@ class PixelFileWriter:
         Raises:
             ValueError: If the edgelist contains data for more than one sample.
         """
+        self._assert_single_sample(edgelist)
         if isinstance(edgelist, Path):
             self._write_parquet_file_to_table("edgelist", edgelist)
-            self._assert_single_sample("edgelist")
             return
-
         try:
             with tempfile.NamedTemporaryFile(suffix=".parquet") as f:
                 file_path = Path(f.name)
@@ -151,7 +161,6 @@ class PixelFileWriter:
                 self._write_parquet_file_to_table("edgelist", file_path)
         except AttributeError:
             raise ValueError(f"Invalid input type for edgelist: {type(edgelist)}")
-        self._assert_single_sample("edgelist")
 
     def _clean_existing_adata_tables(self):
         tables = self._connection.sql("SHOW ALL TABLES")

--- a/src/pixelator/pna/sample_calling/__init__.py
+++ b/src/pixelator/pna/sample_calling/__init__.py
@@ -245,6 +245,12 @@ def _build_post_sample_calling_anndata(
     new_adata = new_adata[:, non_hashing_markers].copy()
 
     new_adata = add_missing_adata_info(new_adata, old_adata)
+    # `sample` is a reserved, transient column added when reading a
+    # multi-file view (see AnnDataHelper) and reflects the *original*
+    # physical input file(s) i.e. pool(s) names, which may no longer match the single
+    # dehashed `sample_name` this output file represents. Drop it here
+    # so each written PXL file only ever contains a single sample.
+    new_adata.obs = new_adata.obs.drop(columns=["sample"], errors="ignore")
     new_adata.obs = new_adata.obs.join(
         hash_info.select(["component", "hash_enrichment_factor"])
         .to_pandas()

--- a/tests/pna/pixeldataset/test_pixel_file_writer.py
+++ b/tests/pna/pixeldataset/test_pixel_file_writer.py
@@ -2,6 +2,9 @@
 
 from pathlib import Path
 
+import polars as pl
+import pytest
+
 from pixelator.pna.pixeldataset.io import PixelFileWriter
 
 
@@ -65,6 +68,35 @@ class TestPixelFileWriter:
         target = tmp_path / "file.pxl"
         with PixelFileWriter(target) as writer:
             writer.write_adata(adata_data)
+
+    def test_write_adata_multiple_samples_raises(self, tmp_path, adata_data):
+        """Verify write adata raises when obs contains multiple samples.
+
+        Args:
+            tmp_path: tmp path.
+            adata_data: adata data.
+        """
+        adata_data = adata_data.copy()
+        adata_data.obs["sample"] = "sample_1"
+        adata_data.obs.iloc[0, adata_data.obs.columns.get_loc("sample")] = "sample_2"
+        target = tmp_path / "file.pxl"
+        with PixelFileWriter(target) as writer:
+            with pytest.raises(ValueError, match="multiple samples"):
+                writer.write_adata(adata_data)
+
+    def test_write_edgelist_multiple_samples_raises(self, tmp_path, edgelist_dataframe):
+        """Verify write edgelist raises when the edgelist contains multiple samples.
+
+        Args:
+            tmp_path: tmp path.
+            edgelist_dataframe: edgelist dataframe.
+        """
+        edgelist_dataframe = edgelist_dataframe.with_columns(sample=pl.lit("sample_1"))
+        edgelist_dataframe[0, "sample"] = "sample_2"
+        target = tmp_path / "file.pxl"
+        with PixelFileWriter(target) as writer:
+            with pytest.raises(ValueError, match="multiple samples"):
+                writer.write_edgelist(edgelist_dataframe)
 
     def test_write_metadata(self, tmp_path):
         """Verify write metadata.


### PR DESCRIPTION
<!--

Please fill in the appropriate checklist below (delete whatever is not relevant).

Learn more about contributing: [CONTRIBUTING.md](https://github.com/PixelgenTechnologies/pixelator/blob/main/CONTRIBUTING.md)
-->

## Description

`.pxl` files are expected to contain data for exactly one sample (identified
via `metadata["sample_name"]`), but `PixelFileWriter` never enforced this.
`write_adata()` and `write_edgelist()` now raise a `ValueError` if a `sample`
column is present and contains more than one unique value.

This surfaced a real violation in the dehashing/sample-calling pipeline:
`_build_post_sample_calling_anndata` copied a stale `sample` column from the
multi-file input view, which can legitimately hold multiple values (a called
sample can combine components from several physical input files). This
column is now dropped before writing, since it no longer reflects the output
file's identity.

Fixes: PNA-3558

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Added unit tests asserting `write_adata()`/`write_edgelist()` raise
  `ValueError` for multi-sample input.
- Ran the full `tests/pna` suite — all tests pass.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [x] I have checked my code and documentation and corrected any misspellings
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes data-validation at write time and alters obs columns in the dehashing path; incorrect drops or checks could break downstream consumers that relied on `obs.sample` in written files.
> 
> **Overview**
> **PXL files are now required to represent a single sample.** `PixelFileWriter` rejects writes when a `sample` column exists with more than one distinct value in the edgelist or in `adata.obs`, via `_assert_single_sample` and a matching check in `write_adata`.
> 
> The sample-calling pipeline was carrying a stale **`sample`** column from multi-file views (pool names that can differ from the dehashed output’s `sample_name`). That column is **dropped** in `_build_post_sample_calling_anndata` before writing so each `.dehashed.pxl` stays single-sample.
> 
> Unit tests cover `ValueError` on multi-sample `write_adata` and `write_edgelist`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d53875352d3143b3f861e347241ea274c96e14fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->