### PR TITLE
feat: add filter_proximity_scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `PNAPixelDataset.layouts()` computes Layouts on the fly, making it easier to work with cell layouts.
 - `pixelator.pna.analysis.summarize_proximity_scores` to collapse a per-component proximity score table into one row per marker pair.
+- `pixelator.pna.analysis.filter_proximity_scores` to filter a proximity score table by marker abundance (Python analog of pixelatorR `FilterProximityScores`).
 
 ### Changed
 - `density_scatter_plot` now lives in `pixelator.plot` (previously `pixelator.mpx.plot`).

--- a/docs/api/overview.rst
+++ b/docs/api/overview.rst
@@ -37,4 +37,5 @@ for usage examples.
 **Analysis**
 
 * :func:`pixelator.pna.analysis.calculate_differential_proximity`
+* :func:`pixelator.pna.analysis.filter_proximity_scores`
 * :func:`pixelator.pna.analysis.summarize_proximity_scores`

--- a/src/pixelator/pna/analysis/__init__.py
+++ b/src/pixelator/pna/analysis/__init__.py
@@ -5,10 +5,15 @@ Copyright © 2024 Pixelgen Technologies AB.
 
 from pixelator.pna.analysis.proximity import (
     calculate_differential_proximity,
+    filter_proximity_scores,
     summarize_proximity_scores,
 )
 
-__all__ = ["calculate_differential_proximity", "summarize_proximity_scores"]
+__all__ = [
+    "calculate_differential_proximity",
+    "filter_proximity_scores",
+    "summarize_proximity_scores",
+]
 
 # Note: pixelator.pna.analysis.comparison is intentionally not imported here.
 # It depends on pixelator.pna.pixeldataset, which itself imports

--- a/src/pixelator/pna/analysis/proximity.py
+++ b/src/pixelator/pna/analysis/proximity.py
@@ -404,55 +404,80 @@ def filter_proximity_scores(
     background_threshold_count: float | None = None,
     min_cells_count: int | None = None,
 ) -> pd.DataFrame:
-    """Filter a long-format proximity score table by abundance and detection.
+    """Remove marker pairs with too little signal from a proximity score table.
 
-    Python analog of pixelatorR ``FilterProximityScores``. At least one
-    threshold must be set. Filters are applied in this order:
+    Proximity scores are reported for every marker pair detected in a cell,
+    including pairs where one or both markers are barely present. Such pairs
+    may reflect background and can distort downstream summaries and
+    heatmaps, so it is usually worth dropping them before further analysis.
 
-    1. ``background_threshold_pct`` — keep rows where
-       ``min(p1, p2) >= background_threshold_pct`` (fractions of UMI counts
-       in the component).
-    2. ``background_threshold_count`` — keep rows where
-       ``min(count_1, count_2) >= background_threshold_count``.
-    3. ``min_cells_count`` — keep marker pairs detected in at least this many
-       components.
+    At least one threshold must be given. When several are given, they are
+    applied in this order:
 
-    Tutorials typically use only ``background_threshold_pct`` (for example the
-    isotype-control fraction cutoff). That filter does not depend on cell
-    size, unlike a raw UMI count cutoff.
+    1. ``background_threshold_pct`` keeps a pair only if both of its markers
+       make up at least this fraction of the cell's UMI counts. The isotype
+       control fraction for your panel is a good choice of cutoff.
+    2. ``background_threshold_count`` keeps a pair only if both of its markers
+       have at least this many UMI counts.
+    3. ``min_cells_count`` keeps a marker pair only if it is detected in at
+       least this many cells.
 
-    Proportion and count columns may use either the R names from
-    ``ProximityScores(..., add_marker_proportions = TRUE)`` (``p1`` / ``p2``,
-    ``count_1`` / ``count_2``) or the Python names from
-    ``Proximity.to_df()`` with ``add_marker_counts=True`` (the default):
-    ``marker_1_freq`` / ``marker_2_freq`` and ``marker_1_count`` /
-    ``marker_2_count``.
+    Using ``background_threshold_pct`` on its own is usually enough. Unlike
+    a raw count cutoff, a fraction does not depend on how many molecules a
+    cell has, so the same threshold is meaningful for both small and large cells.
+
+    The filters need the per-cell marker abundance columns that
+    :meth:`~pixelator.pna.pixeldataset.proximity.Proximity.to_df` adds by
+    default (``add_marker_counts=True``): ``marker_1_freq`` and
+    ``marker_2_freq`` for the fraction filter, ``marker_1_count`` and
+    ``marker_2_count`` for the count filter. Proximity tables exported from
+    pixelatorR also work, where the same columns are named ``p1`` and ``p2``,
+    and ``count_1`` and ``count_2``.
 
     Args:
-        proximity_df: A long-format proximity score table, e.g. from
-            ``Proximity.to_df``, with one row per ``component`` and marker
-            pair.
-        background_threshold_pct: Minimum UMI fraction that both markers in a
-            pair must reach. Must be in ``[0, 1]``. Requires ``p1`` and
-            ``p2``, or ``marker_1_freq`` and ``marker_2_freq``.
-        background_threshold_count: Minimum UMI count that both markers in a
-            pair must reach. Requires ``count_1`` and ``count_2``, or
-            ``marker_1_count`` and ``marker_2_count``.
-        min_cells_count: Minimum number of components in which a marker pair
-            must be detected. Requires ``marker_1`` and ``marker_2``.
+        proximity_df: Proximity scores with one row per cell (``component``)
+            and marker pair, for example from
+            ``dataset.proximity().to_df()``.
+        background_threshold_pct: Minimum fraction of a cell's UMI counts that
+            both markers in a pair must reach, as a value between 0 and 1. For
+            example, 0.001 in a cell with 20,000 molecules requires at least
+            20 counts for both markers.
+        background_threshold_count: Minimum number of UMI counts that both
+            markers in a pair must reach. This is an absolute cutoff, so it
+            removes more pairs in small cells than in large ones.
+        min_cells_count: Minimum number of cells a marker pair must be
+            detected in. Useful for dropping pairs seen in only a handful of
+            cells.
 
     Returns:
-        A DataFrame with the same columns as ``proximity_df``, containing
-        only the rows that pass every requested filter.
+        The rows of ``proximity_df`` that pass every threshold you set, with
+        the columns unchanged.
 
     Raises:
         ValueError: If no threshold is set, if a threshold is outside its
-            allowed range, or if columns required by a requested filter are
-            missing.
+            allowed range, or if the table lacks the columns a requested
+            filter needs.
+
+    Examples:
+        Keep the marker pairs where both markers are above the isotype
+        control fraction, and see how much of the table that leaves::
+
+            from pixelator.pna.analysis import filter_proximity_scores
+            from pixelator.pna.pixeldataset import read
+
+            dataset = read("sample.pxl")
+            proximity_table = dataset.proximity().to_df()
+            filtered = filter_proximity_scores(
+                proximity_table,
+                background_threshold_pct=0.001,
+            )
+            pct_rows_kept = round(
+                len(filtered) / len(proximity_table) * 100, 2
+            )
 
     See Also:
-        FilterProximityScores in pixelatorR
-        (`R/filter_and_summarize_proximity_scores.R`).
+        ``FilterProximityScores`` in pixelatorR, the equivalent function for
+        R users.
     """
     _validate_optional_threshold(
         "background_threshold_pct",
@@ -488,9 +513,8 @@ def filter_proximity_scores(
             filtered,
             _PCT_COLUMN_PAIRS,
             "background_threshold_pct",
-            "Fetch proximity with add_marker_counts=True "
-            "(Python Proximity.to_df) or add_marker_proportions=TRUE "
-            "(R ProximityScores).",
+            "Read the proximity table with dataset.proximity().to_df() and "
+            "add_marker_counts=True (the default) to include them.",
         )
         filtered = filtered[
             np.minimum(filtered[p1_col], filtered[p2_col]) >= background_threshold_pct
@@ -501,9 +525,8 @@ def filter_proximity_scores(
             filtered,
             _COUNT_COLUMN_PAIRS,
             "background_threshold_count",
-            "Fetch proximity with add_marker_counts=True "
-            "(Python Proximity.to_df) or add_marker_proportions=TRUE "
-            "(R ProximityScores).",
+            "Read the proximity table with dataset.proximity().to_df() and "
+            "add_marker_counts=True (the default) to include them.",
         )
         filtered = filtered[
             np.minimum(filtered[c1_col], filtered[c2_col]) >= background_threshold_count

--- a/src/pixelator/pna/analysis/proximity.py
+++ b/src/pixelator/pna/analysis/proximity.py
@@ -19,6 +19,10 @@ _SUMMARY_STATS: dict[str, Callable[[np.ndarray], float]] = {
     "mean": np.mean,
     "median": np.median,
 }
+# R FilterProximityScores uses p1/p2 and count_1/count_2. Python Proximity.to_df()
+# with add_marker_counts=True emits marker_*_freq and marker_*_count.
+_PCT_COLUMN_PAIRS = (("p1", "p2"), ("marker_1_freq", "marker_2_freq"))
+_COUNT_COLUMN_PAIRS = (("count_1", "count_2"), ("marker_1_count", "marker_2_count"))
 
 
 def get_join_counts(edgelist: pl.DataFrame) -> pd.DataFrame:
@@ -332,6 +336,192 @@ def summarize_proximity_scores(
         output_columns += [f"{col}_list" for col in value_columns]
 
     return summary[output_columns]
+
+
+def _resolve_column_pair(
+    proximity_df: pd.DataFrame,
+    column_pairs: tuple[tuple[str, str], ...],
+    filter_name: str,
+    missing_hint: str,
+) -> tuple[str, str]:
+    """Return the first column pair present in ``proximity_df``.
+
+    Args:
+        proximity_df: Proximity score table to inspect.
+        column_pairs: Candidate (left, right) column name pairs, in preference
+            order.
+        filter_name: Name of the filter that requires the columns, used in the
+            error message.
+        missing_hint: Extra guidance included in the error message.
+
+    Returns:
+        The first pair of column names that both exist in ``proximity_df``.
+
+    Raises:
+        ValueError: If none of the candidate pairs are fully present.
+    """
+    for left, right in column_pairs:
+        if left in proximity_df.columns and right in proximity_df.columns:
+            return left, right
+
+    expected = " or ".join(f"{left!r} and {right!r}" for left, right in column_pairs)
+    raise ValueError(f"{filter_name} requires columns {expected}. {missing_hint}")
+
+
+def _validate_optional_threshold(
+    name: str,
+    value: float | int | None,
+    *,
+    minimum: float,
+    maximum: float | None = None,
+) -> None:
+    """Validate an optional numeric threshold.
+
+    Args:
+        name: Argument name, used in the error message.
+        value: Threshold value, or ``None`` if the filter is unused.
+        minimum: Inclusive lower bound when ``value`` is not ``None``.
+        maximum: Inclusive upper bound when not ``None``.
+
+    Raises:
+        ValueError: If ``value`` is not a real number or is outside the
+            allowed range.
+    """
+    if value is None:
+        return
+    if isinstance(value, bool) or not isinstance(
+        value, (int, float, np.integer, np.floating)
+    ):
+        raise ValueError(f"{name} must be a number, got {value!r}.")
+    if value < minimum or (maximum is not None and value > maximum):
+        bounds = f"[{minimum}, {maximum}]" if maximum is not None else f">= {minimum}"
+        raise ValueError(f"{name} must be within {bounds}, got {value!r}.")
+
+
+def filter_proximity_scores(
+    proximity_df: pd.DataFrame,
+    background_threshold_pct: float | None = None,
+    background_threshold_count: float | None = None,
+    min_cells_count: int | None = None,
+) -> pd.DataFrame:
+    """Filter a long-format proximity score table by abundance and detection.
+
+    Python analog of pixelatorR ``FilterProximityScores``. At least one
+    threshold must be set. Filters are applied in this order:
+
+    1. ``background_threshold_pct`` — keep rows where
+       ``min(p1, p2) >= background_threshold_pct`` (fractions of UMI counts
+       in the component).
+    2. ``background_threshold_count`` — keep rows where
+       ``min(count_1, count_2) >= background_threshold_count``.
+    3. ``min_cells_count`` — keep marker pairs detected in at least this many
+       components.
+
+    Tutorials typically use only ``background_threshold_pct`` (for example the
+    isotype-control fraction cutoff). That filter does not depend on cell
+    size, unlike a raw UMI count cutoff.
+
+    Proportion and count columns may use either the R names from
+    ``ProximityScores(..., add_marker_proportions = TRUE)`` (``p1`` / ``p2``,
+    ``count_1`` / ``count_2``) or the Python names from
+    ``Proximity.to_df()`` with ``add_marker_counts=True`` (the default):
+    ``marker_1_freq`` / ``marker_2_freq`` and ``marker_1_count`` /
+    ``marker_2_count``.
+
+    Args:
+        proximity_df: A long-format proximity score table, e.g. from
+            ``Proximity.to_df``, with one row per ``component`` and marker
+            pair.
+        background_threshold_pct: Minimum UMI fraction that both markers in a
+            pair must reach. Must be in ``[0, 1]``. Requires ``p1`` and
+            ``p2``, or ``marker_1_freq`` and ``marker_2_freq``.
+        background_threshold_count: Minimum UMI count that both markers in a
+            pair must reach. Requires ``count_1`` and ``count_2``, or
+            ``marker_1_count`` and ``marker_2_count``.
+        min_cells_count: Minimum number of components in which a marker pair
+            must be detected. Requires ``marker_1`` and ``marker_2``.
+
+    Returns:
+        A DataFrame with the same columns as ``proximity_df``, containing
+        only the rows that pass every requested filter.
+
+    Raises:
+        ValueError: If no threshold is set, if a threshold is outside its
+            allowed range, or if columns required by a requested filter are
+            missing.
+
+    See Also:
+        FilterProximityScores in pixelatorR
+        (`R/filter_and_summarize_proximity_scores.R`).
+    """
+    _validate_optional_threshold(
+        "background_threshold_pct",
+        background_threshold_pct,
+        minimum=0,
+        maximum=1,
+    )
+    _validate_optional_threshold(
+        "background_threshold_count",
+        background_threshold_count,
+        minimum=0,
+    )
+    _validate_optional_threshold(
+        "min_cells_count",
+        min_cells_count,
+        minimum=0,
+    )
+
+    if (
+        background_threshold_pct is None
+        and background_threshold_count is None
+        and min_cells_count is None
+    ):
+        raise ValueError(
+            "At least one of background_threshold_pct, "
+            "background_threshold_count, or min_cells_count must be set."
+        )
+
+    filtered = proximity_df
+
+    if background_threshold_pct is not None:
+        p1_col, p2_col = _resolve_column_pair(
+            filtered,
+            _PCT_COLUMN_PAIRS,
+            "background_threshold_pct",
+            "Fetch proximity with add_marker_counts=True "
+            "(Python Proximity.to_df) or add_marker_proportions=TRUE "
+            "(R ProximityScores).",
+        )
+        filtered = filtered[
+            np.minimum(filtered[p1_col], filtered[p2_col]) >= background_threshold_pct
+        ]
+
+    if background_threshold_count is not None:
+        c1_col, c2_col = _resolve_column_pair(
+            filtered,
+            _COUNT_COLUMN_PAIRS,
+            "background_threshold_count",
+            "Fetch proximity with add_marker_counts=True "
+            "(Python Proximity.to_df) or add_marker_proportions=TRUE "
+            "(R ProximityScores).",
+        )
+        filtered = filtered[
+            np.minimum(filtered[c1_col], filtered[c2_col]) >= background_threshold_count
+        ]
+
+    if min_cells_count is not None:
+        missing = {"marker_1", "marker_2"} - set(filtered.columns)
+        if missing:
+            raise ValueError(
+                "min_cells_count requires columns 'marker_1' and "
+                f"'marker_2'. Missing: {sorted(missing)}."
+            )
+        n_cells = filtered.groupby(["marker_1", "marker_2"], sort=False)[
+            "marker_1"
+        ].transform("size")
+        filtered = filtered[n_cells >= min_cells_count]
+
+    return filtered.copy()
 
 
 def _filter_target_data(

--- a/tests/pna/analysis/test_filter_proximity_scores.py
+++ b/tests/pna/analysis/test_filter_proximity_scores.py
@@ -1,0 +1,100 @@
+"""Tests for `pixelator.pna.analysis.proximity.filter_proximity_scores`.
+
+Copyright © 2026 Pixelgen Technologies AB.
+"""
+
+from io import StringIO
+
+import pandas as pd
+import pytest
+from pandas.testing import assert_frame_equal
+
+from pixelator.pna.analysis.proximity import filter_proximity_scores
+
+# Sparse pairs with known min(p1, p2) / min(count_1, count_2):
+# - M1/M1 c1: pct min=0.02, count min=20
+# - M1/M2 c1: pct min=0.005, count min=5
+# - M1/M1 c2: pct min=0.01, count min=10
+# - M2/M2 c2: pct min=0.03, count min=30
+# - M1/M2 c3: pct min=0.008, count min=8
+PROXIMITY_DATA = """component,marker_1,marker_2,p1,p2,count_1,count_2,log2_ratio
+c1,M1,M1,0.02,0.02,20,20,1.0
+c1,M1,M2,0.02,0.005,20,5,0.5
+c2,M1,M1,0.01,0.04,10,40,2.0
+c2,M2,M2,0.03,0.03,30,30,-1.0
+c3,M1,M2,0.008,0.05,8,50,3.0
+"""
+
+PYTHON_NAMED_DATA = """component,marker_1,marker_2,marker_1_freq,marker_2_freq,marker_1_count,marker_2_count
+c1,M1,M1,0.02,0.02,20,20
+c1,M1,M2,0.02,0.005,20,5
+"""
+
+
+@pytest.fixture
+def proximity_df() -> pd.DataFrame:
+    return pd.read_csv(StringIO(PROXIMITY_DATA))
+
+
+def test_filter_proximity_scores_pct(proximity_df):
+    result = filter_proximity_scores(proximity_df, background_threshold_pct=0.01)
+
+    expected = proximity_df.iloc[[0, 2, 3]].reset_index(drop=True)
+    assert_frame_equal(result.reset_index(drop=True), expected)
+
+
+def test_filter_proximity_scores_pct_python_column_names():
+    proximity_df = pd.read_csv(StringIO(PYTHON_NAMED_DATA))
+    result = filter_proximity_scores(proximity_df, background_threshold_pct=0.01)
+
+    expected = proximity_df.iloc[[0]].reset_index(drop=True)
+    assert_frame_equal(result.reset_index(drop=True), expected)
+
+
+def test_filter_proximity_scores_count(proximity_df):
+    result = filter_proximity_scores(proximity_df, background_threshold_count=10)
+
+    expected = proximity_df.iloc[[0, 2, 3]].reset_index(drop=True)
+    assert_frame_equal(result.reset_index(drop=True), expected)
+
+
+def test_filter_proximity_scores_min_cells_count(proximity_df):
+    result = filter_proximity_scores(proximity_df, min_cells_count=2)
+
+    expected = proximity_df.iloc[[0, 1, 2, 4]].reset_index(drop=True)
+    assert_frame_equal(result.reset_index(drop=True), expected)
+
+
+def test_filter_proximity_scores_pct_then_min_cells(proximity_df):
+    result = filter_proximity_scores(
+        proximity_df, background_threshold_pct=0.01, min_cells_count=2
+    )
+
+    expected = proximity_df.iloc[[0, 2]].reset_index(drop=True)
+    assert_frame_equal(result.reset_index(drop=True), expected)
+
+
+def test_filter_proximity_scores_no_threshold_raises(proximity_df):
+    with pytest.raises(ValueError, match="At least one of"):
+        filter_proximity_scores(proximity_df)
+
+
+def test_filter_proximity_scores_pct_missing_columns_raises(proximity_df):
+    with pytest.raises(ValueError, match="background_threshold_pct"):
+        filter_proximity_scores(
+            proximity_df.drop(columns=["p1", "p2"]),
+            background_threshold_pct=0.01,
+        )
+
+
+def test_filter_proximity_scores_count_missing_columns_raises(proximity_df):
+    with pytest.raises(ValueError, match="background_threshold_count"):
+        filter_proximity_scores(
+            proximity_df.drop(columns=["count_1", "count_2"]),
+            background_threshold_count=10,
+        )
+
+
+def test_filter_proximity_scores_pct_out_of_range_raises(proximity_df):
+    with pytest.raises(ValueError, match="background_threshold_pct"):
+        filter_proximity_scores(proximity_df, background_threshold_pct=1.5)


### PR DESCRIPTION
## Description

Add `pixelator.pna.analysis.filter_proximity_scores`, a Python analog of pixelatorR `FilterProximityScores`.

Proximity tables include marker pairs where one or both markers are barely present. Those pairs mostly reflect background and can distort summaries and heatmaps. This helper drops them using the same filters as R, in the same order:

1. `background_threshold_pct` — both markers must reach this fraction of the cell’s UMI counts (`marker_1_freq` / `marker_2_freq`, or R names `p1` / `p2`)
2. `background_threshold_count` — both markers must reach this UMI count (`marker_1_count` / `marker_2_count`, or R names `count_1` / `count_2`)
3. `min_cells_count` — the pair must be detected in enough cells

At least one threshold is required. Tutorials should use the pct filter only (e.g. the isotype-control fraction). Marker abundance columns come from `dataset.proximity().to_df()` with `add_marker_counts=True` (the default).

Fixes: PNA-3525

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Synthetic-table unit tests in `tests/pna/analysis/test_filter_proximity_scores.py`:

- `test_filter_proximity_scores_pct`
- `test_filter_proximity_scores_pct_python_column_names`
- `test_filter_proximity_scores_count`
- `test_filter_proximity_scores_min_cells_count`
- `test_filter_proximity_scores_pct_then_min_cells`
- `test_filter_proximity_scores_no_threshold_raises`
- `test_filter_proximity_scores_pct_missing_columns_raises`
- `test_filter_proximity_scores_count_missing_columns_raises`
- `test_filter_proximity_scores_pct_out_of_range_raises`

Reproduce:

```bash
pytest tests/pna/analysis/test_filter_proximity_scores.py
```

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If a new tool or package is included, I have updated dependencies in `pyproject.toml` and [cited it properly](../CITATIONS.md)
- [x] I have checked my code and documentation and corrected any misspellings
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive analysis API with input validation and tests; no changes to pipelines, persistence, or security-sensitive paths.
> 
> **Overview**
> Adds **`pixelator.pna.analysis.filter_proximity_scores`**, a Python counterpart to pixelatorR **`FilterProximityScores`**, for long-format proximity tables (one row per cell and marker pair).
> 
> Callers can drop low-signal pairs using optional **`background_threshold_pct`** (min of both marker UMI fractions), **`background_threshold_count`** (min of both counts), and **`min_cells_count`** (pair must appear in enough cells). When several thresholds are set, they apply in that order. The helper accepts Python column names from **`Proximity.to_df()`** (`marker_*_freq` / `marker_*_count`) or R export names (`p1`/`p2`, `count_1`/`count_2`), with validation and clear errors when thresholds or columns are missing.
> 
> The function is exported from **`pixelator.pna.analysis`**, listed in **`docs/api/overview.rst`** and **`CHANGELOG.md`**, with unit tests in **`tests/pna/analysis/test_filter_proximity_scores.py`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11133d7f225838f399430e646c92897dc973f7aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->