### PR TITLE
DO NOT MERGE - random test

### DIFF
--- a/src/pixelator/pna/collapse/independent/collapser.py
+++ b/src/pixelator/pna/collapse/independent/collapser.py
@@ -789,6 +789,15 @@ class RegionCollapser:
                 uei=uei_data,
             ).drop(["molecule"])
 
+            if drop_count := new_data.filter(pl.col("read_count").ge(2**16)).height:
+                logger.info(
+                    "Dropping of %s entries with too many reads (>=2^16) for %s, markers %s",
+                    drop_count,
+                    self.region_id,
+                    marker_name,
+                )
+                new_data = new_data.filter(pl.col("read_count").lt(2**16))
+
             table = new_data.to_arrow()
 
             corrected_name = self._region_id_choice("corrected_umi1", "corrected_umi2")

--- a/src/pixelator/pna/collapse/independent/collapser.py
+++ b/src/pixelator/pna/collapse/independent/collapser.py
@@ -89,6 +89,8 @@ class MarkerCorrectionStats(pydantic.BaseModel):
         corrected_unique_umis: The total number of unique UMIs of type `region_id` that were
             modified by the error correction process.
         output_unique_umis: The total number of unique UMIs of type `region_id` after correction.
+        output_reads: The number of reads written after overflow filtering.
+        output_molecules: The number of molecules written after overflow filtering.
     """
 
     marker: str
@@ -102,15 +104,19 @@ class MarkerCorrectionStats(pydantic.BaseModel):
     corrected_unique_umis: int = 0
 
     output_unique_umis: int = 0
+    output_reads: int = 0
+    output_molecules: int = 0
 
-    @pydantic.computed_field(return_type=int)  # type: ignore
-    @property
-    def output_reads(self) -> int:
-        """The total number of reads after correction.
-
-        This is always the same as `input_reads_count` but is included for consistency.
-        """
-        return self.input_reads
+    @pydantic.model_validator(mode="before")
+    @classmethod
+    def _default_output_counts(cls, data: typing.Any) -> typing.Any:
+        """Mirror input counts when output counts are omitted."""
+        if isinstance(data, dict):
+            if data.get("output_reads") is None:
+                data["output_reads"] = data.get("input_reads", 0)
+            if data.get("output_molecules") is None:
+                data["output_molecules"] = data.get("input_molecules", 0)
+        return data
 
     @pydantic.computed_field(return_type=float)  # type: ignore
     @property
@@ -173,6 +179,27 @@ class SingleUMICollapseSampleReport(SampleReport):
         description="The number of unique UMIs after correction.",
     )
 
+    output_reads: int = pydantic.Field(
+        default=0,
+        description="The number of reads written after uint16 overflow filtering.",
+    )
+
+    output_molecules: int = pydantic.Field(
+        default=0,
+        description="The number of molecules written after uint16 overflow filtering.",
+    )
+
+    @pydantic.model_validator(mode="before")
+    @classmethod
+    def _default_output_counts(cls, data: typing.Any) -> typing.Any:
+        """Mirror input counts when output counts are omitted (legacy reports)."""
+        if isinstance(data, dict):
+            if data.get("output_reads") is None:
+                data["output_reads"] = data.get("input_reads", 0)
+            if data.get("output_molecules") is None:
+                data["output_molecules"] = data.get("input_molecules", 0)
+        return data
+
     corrected_unique_umis: int = pydantic.Field(
         ...,
         description="The number of UMIs with errors that were corrected.",
@@ -205,6 +232,8 @@ class IndependentCollapseStatisticsCollector:
         corrected_reads: int
         corrected_unique_umis: int
         output_unique_umis: int
+        output_reads: int
+        output_molecules: int
 
     def __init__(self, region_id: CollapsibleRegion) -> None:
         """Initialize the statistics collector."""
@@ -293,6 +322,8 @@ class IndependentCollapseStatisticsCollector:
             "corrected_reads",
             "corrected_unique_umis",
             "output_unique_umis",
+            "output_reads",
+            "output_molecules",
         ]
 
         sums = df[aggregate_cols].sum()
@@ -580,7 +611,7 @@ class RegionCollapser:
         # Warn when required shared memory exceeds available (avoids Bus error in Docker).
         shm_bytes = (
             num_unique_umis * (vector_length * np.dtype(np.uint8).itemsize)
-            + num_unique_umis * np.dtype(np.uint16).itemsize
+            + num_unique_umis * np.dtype(np.uint64).itemsize
         )
         available = _get_shm_available_bytes()
         logger.debug(
@@ -605,16 +636,19 @@ class RegionCollapser:
         for idx, umi in enumerate(unique_umis):
             db[idx, 0 : len(umi)] = np.frombuffer(umi, dtype=np.uint8)
 
+        # Unique-UMI weights can exceed the per-molecule uint16 output schema
+        # (many molecules may share a UMI). Store them in uint64 so counts at or
+        # above 2**16 cannot wrap before directional collapse.
         read_counts = self._memory.allocate_array(
-            "read_counts", shape=(num_unique_umis,), dtype=np.uint16, zero_init=False
+            "read_counts", shape=(num_unique_umis,), dtype=np.uint64, zero_init=True
         )
 
         # Sum the read counts for all molecules that map to the same unique umi.
-        # These read_counts are than used as weights in the network based deduplication.
-        read_counts[:] = np.bincount(
+        # These read_counts are then used as weights in the network based deduplication.
+        np.add.at(
+            read_counts,
             self._db_to_molecule_idx,
-            weights=data["read_count"],
-            minlength=num_unique_umis,
+            np.asarray(data["read_count"], dtype=np.uint64),
         )
 
         yield db, read_counts
@@ -789,7 +823,9 @@ class RegionCollapser:
                 uei=uei_data,
             ).drop(["molecule"])
 
-            table = self._build_output_table(new_data, corrected_umis, marker_name)
+            table = self._build_output_table(
+                new_data, corrected_umis, marker_name, cluster_stats
+            )
 
             logger.info("Streaming %s records to parquet", len(table))
             writer.write_table(table)
@@ -810,16 +846,19 @@ class RegionCollapser:
         new_data: pl.DataFrame,
         corrected_umis: pa.Array,
         marker_name: str,
+        stats: MarkerCorrectionStats,
     ) -> pa.Table:
         """Assemble the parquet output table, dropping uint16-overflowing read counts.
 
         The corrected UMI array is joined onto ``new_data`` before any row filtering so
-        that overflow drops cannot desynchronize the two.
+        that overflow drops cannot desynchronize the two. ``stats.output_reads`` and
+        ``stats.output_molecules`` are set to the rows that are actually streamed.
 
         Args:
             new_data: Collapsed molecule rows without the corrected UMI column.
             corrected_umis: Corrected UMI values, one per row of ``new_data``.
             marker_name: Marker name for logging.
+            stats: Marker statistics to update with streamed output counts.
 
         Returns:
             An Arrow table matching ``self._output_schema``.
@@ -835,6 +874,9 @@ class RegionCollapser:
                 marker_name,
             )
             new_data = new_data.filter(pl.col("read_count").lt(2**16))
+
+        stats.output_molecules = new_data.height
+        stats.output_reads = int(new_data["read_count"].sum() or 0)
 
         return new_data.to_arrow().cast(self._output_schema)
 

--- a/src/pixelator/pna/collapse/independent/collapser.py
+++ b/src/pixelator/pna/collapse/independent/collapser.py
@@ -789,24 +789,7 @@ class RegionCollapser:
                 uei=uei_data,
             ).drop(["molecule"])
 
-            if drop_count := new_data.filter(pl.col("read_count").ge(2**16)).height:
-                logger.info(
-                    "Dropping of %s entries with too many reads (>=2^16) for %s, markers %s",
-                    drop_count,
-                    self.region_id,
-                    marker_name,
-                )
-                new_data = new_data.filter(pl.col("read_count").lt(2**16))
-
-            table = new_data.to_arrow()
-
-            corrected_name = self._region_id_choice("corrected_umi1", "corrected_umi2")
-            table = table.add_column(
-                6,
-                self._output_schema.field(corrected_name),
-                corrected_umis,
-            )
-            table = table.cast(self._output_schema)
+            table = self._build_output_table(new_data, corrected_umis, marker_name)
 
             logger.info("Streaming %s records to parquet", len(table))
             writer.write_table(table)
@@ -821,6 +804,39 @@ class RegionCollapser:
             )
 
         return cluster_stats
+
+    def _build_output_table(
+        self,
+        new_data: pl.DataFrame,
+        corrected_umis: pa.Array,
+        marker_name: str,
+    ) -> pa.Table:
+        """Assemble the parquet output table, dropping uint16-overflowing read counts.
+
+        The corrected UMI array is joined onto ``new_data`` before any row filtering so
+        that overflow drops cannot desynchronize the two.
+
+        Args:
+            new_data: Collapsed molecule rows without the corrected UMI column.
+            corrected_umis: Corrected UMI values, one per row of ``new_data``.
+            marker_name: Marker name for logging.
+
+        Returns:
+            An Arrow table matching ``self._output_schema``.
+        """
+        corrected_name = self._region_id_choice("corrected_umi1", "corrected_umi2")
+        new_data = new_data.with_columns(pl.Series(corrected_name, corrected_umis))
+
+        if drop_count := new_data.filter(pl.col("read_count").ge(2**16)).height:
+            self._logger.info(
+                "Dropping of %s entries with too many reads (>=2^16) for %s, markers %s",
+                drop_count,
+                self.region_id,
+                marker_name,
+            )
+            new_data = new_data.filter(pl.col("read_count").lt(2**16))
+
+        return new_data.to_arrow().cast(self._output_schema)
 
     def _process_molecule_graph(
         self, csgraph, marker_name: str, local_stats: MarkerCorrectionStats

--- a/src/pixelator/pna/collapse/independent/combine_collapse.py
+++ b/src/pixelator/pna/collapse/independent/combine_collapse.py
@@ -261,6 +261,8 @@ def combine_independent_report_files(
             "input_molecules",
             "input_unique_umis",
             "output_unique_umis",
+            "output_reads",
+            "output_molecules",
             "corrected_unique_umis",
             "corrected_reads",
         )
@@ -300,6 +302,7 @@ def combine_independent_report_files(
         markers=umi1_markers + umi2_markers,
         input_reads=umi1_summary_stats["input_reads"],
         input_molecules=umi1_summary_stats["input_molecules"],
+        output_reads=umi1_summary_stats["output_reads"],
         corrected_reads=stats.corrected_reads,
         output_molecules=stats.output_molecules,
         umi1_degree_distribution=stats.umi1_degree_distribution,

--- a/src/pixelator/pna/collapse/independent/report.py
+++ b/src/pixelator/pna/collapse/independent/report.py
@@ -3,6 +3,8 @@
 Copyright © 2024 Pixelgen Technologies AB
 """
 
+import typing
+
 import pydantic
 
 from pixelator.pna.collapse.independent.collapser import MarkerCorrectionStats
@@ -26,17 +28,6 @@ class IndependentCollapseSampleReport(SampleReport):
     output_molecules: int = pydantic.Field(
         ..., description="The total number of error-corrected molecules detected."
     )
-
-    @pydantic.computed_field(  # type: ignore
-        description="The number of output reads.", return_type=int
-    )
-    @property
-    def output_reads(self) -> int:
-        """The total number of error-corrected output reads.
-
-        This is an alias for the input reads as no reads are removed during the collapse step.
-        """
-        return self.input_reads
 
     @pydantic.computed_field(  # type: ignore
         description="The number of UMI1 reads that had error and were corrected.",
@@ -72,3 +63,16 @@ class IndependentCollapseSampleReport(SampleReport):
     umi2_degree_distribution: dict[int, int] = pydantic.Field(
         ..., description="The degree distribution of the umi2."
     )
+
+    output_reads: int = pydantic.Field(
+        default=0,
+        description="The number of reads written after uint16 overflow filtering.",
+    )
+
+    @pydantic.model_validator(mode="before")
+    @classmethod
+    def _default_output_reads(cls, data: typing.Any) -> typing.Any:
+        """Mirror input reads when output reads are omitted (legacy reports)."""
+        if isinstance(data, dict) and data.get("output_reads") is None:
+            data["output_reads"] = data.get("input_reads", 0)
+        return data

--- a/tests/pna/collapse/snapshots/test_combine_collapse/test_combine_independent_reports/combine_independent_reports
+++ b/tests/pna/collapse/snapshots/test_combine_collapse/test_combine_independent_reports/combine_independent_reports
@@ -17,6 +17,7 @@
             "corrected_unique_umis": 93,
             "output_unique_umis": 1120,
             "output_reads": 15565,
+            "output_molecules": 9350,
             "corrected_reads_fraction": 0.006810150979762287,
             "corrected_unique_umis_fraction": 0.07666941467436109
         },
@@ -30,6 +31,7 @@
             "corrected_unique_umis": 5,
             "output_unique_umis": 51,
             "output_reads": 760,
+            "output_molecules": 462,
             "corrected_reads_fraction": 0.006578947368421052,
             "corrected_unique_umis_fraction": 0.08928571428571429
         },
@@ -43,6 +45,7 @@
             "corrected_unique_umis": 2,
             "output_unique_umis": 41,
             "output_reads": 390,
+            "output_molecules": 238,
             "corrected_reads_fraction": 0.005128205128205128,
             "corrected_unique_umis_fraction": 0.046511627906976744
         },
@@ -56,6 +59,7 @@
             "corrected_unique_umis": 2,
             "output_unique_umis": 83,
             "output_reads": 868,
+            "output_molecules": 500,
             "corrected_reads_fraction": 0.002304147465437788,
             "corrected_unique_umis_fraction": 0.023529411764705882
         },
@@ -69,6 +73,7 @@
             "corrected_unique_umis": 49,
             "output_unique_umis": 610,
             "output_reads": 5795,
+            "output_molecules": 3541,
             "corrected_reads_fraction": 0.008973252804141501,
             "corrected_unique_umis_fraction": 0.07435508345978756
         },
@@ -82,6 +87,7 @@
             "corrected_unique_umis": 6,
             "output_unique_umis": 51,
             "output_reads": 581,
+            "output_molecules": 364,
             "corrected_reads_fraction": 0.010327022375215147,
             "corrected_unique_umis_fraction": 0.10526315789473684
         },
@@ -95,6 +101,7 @@
             "corrected_unique_umis": 3,
             "output_unique_umis": 41,
             "output_reads": 456,
+            "output_molecules": 291,
             "corrected_reads_fraction": 0.013157894736842105,
             "corrected_unique_umis_fraction": 0.06818181818181818
         },
@@ -108,6 +115,7 @@
             "corrected_unique_umis": 1,
             "output_unique_umis": 17,
             "output_reads": 196,
+            "output_molecules": 120,
             "corrected_reads_fraction": 0.00510204081632653,
             "corrected_unique_umis_fraction": 0.05555555555555555
         },
@@ -121,6 +129,7 @@
             "corrected_unique_umis": 2,
             "output_unique_umis": 21,
             "output_reads": 303,
+            "output_molecules": 186,
             "corrected_reads_fraction": 0.006600660066006601,
             "corrected_unique_umis_fraction": 0.08695652173913043
         },
@@ -134,6 +143,7 @@
             "corrected_unique_umis": 4,
             "output_unique_umis": 76,
             "output_reads": 704,
+            "output_molecules": 421,
             "corrected_reads_fraction": 0.005681818181818182,
             "corrected_unique_umis_fraction": 0.05
         },
@@ -147,6 +157,7 @@
             "corrected_unique_umis": 4,
             "output_unique_umis": 38,
             "output_reads": 407,
+            "output_molecules": 243,
             "corrected_reads_fraction": 0.009828009828009828,
             "corrected_unique_umis_fraction": 0.09523809523809523
         },
@@ -160,6 +171,7 @@
             "corrected_unique_umis": 9,
             "output_unique_umis": 104,
             "output_reads": 1320,
+            "output_molecules": 800,
             "corrected_reads_fraction": 0.009848484848484848,
             "corrected_unique_umis_fraction": 0.07964601769911504
         },
@@ -173,6 +185,7 @@
             "corrected_unique_umis": 3,
             "output_unique_umis": 34,
             "output_reads": 381,
+            "output_molecules": 234,
             "corrected_reads_fraction": 0.007874015748031496,
             "corrected_unique_umis_fraction": 0.08108108108108109
         },
@@ -186,6 +199,7 @@
             "corrected_unique_umis": 10,
             "output_unique_umis": 73,
             "output_reads": 982,
+            "output_molecules": 592,
             "corrected_reads_fraction": 0.01120162932790224,
             "corrected_unique_umis_fraction": 0.12048192771084337
         },
@@ -199,6 +213,7 @@
             "corrected_unique_umis": 39,
             "output_unique_umis": 259,
             "output_reads": 3957,
+            "output_molecules": 2378,
             "corrected_reads_fraction": 0.012130401819560273,
             "corrected_unique_umis_fraction": 0.13087248322147652
         },
@@ -212,6 +227,7 @@
             "corrected_unique_umis": 8,
             "output_unique_umis": 107,
             "output_reads": 1164,
+            "output_molecules": 717,
             "corrected_reads_fraction": 0.006872852233676976,
             "corrected_unique_umis_fraction": 0.06956521739130435
         },
@@ -225,6 +241,7 @@
             "corrected_unique_umis": 0,
             "output_unique_umis": 20,
             "output_reads": 149,
+            "output_molecules": 91,
             "corrected_reads_fraction": 0.0,
             "corrected_unique_umis_fraction": 0.0
         },
@@ -238,6 +255,7 @@
             "corrected_unique_umis": 0,
             "output_unique_umis": 16,
             "output_reads": 161,
+            "output_molecules": 105,
             "corrected_reads_fraction": 0.0,
             "corrected_unique_umis_fraction": 0.0
         },
@@ -251,6 +269,7 @@
             "corrected_unique_umis": 18,
             "output_unique_umis": 202,
             "output_reads": 2125,
+            "output_molecules": 1248,
             "corrected_reads_fraction": 0.009411764705882352,
             "corrected_unique_umis_fraction": 0.08181818181818182
         },
@@ -264,6 +283,7 @@
             "corrected_unique_umis": 0,
             "output_unique_umis": 9,
             "output_reads": 104,
+            "output_molecules": 62,
             "corrected_reads_fraction": 0.0,
             "corrected_unique_umis_fraction": 0.0
         },
@@ -277,6 +297,7 @@
             "corrected_unique_umis": 17,
             "output_unique_umis": 235,
             "output_reads": 2529,
+            "output_molecules": 1545,
             "corrected_reads_fraction": 0.00830367734282325,
             "corrected_unique_umis_fraction": 0.06746031746031746
         },
@@ -290,6 +311,7 @@
             "corrected_unique_umis": 4,
             "output_unique_umis": 28,
             "output_reads": 356,
+            "output_molecules": 220,
             "corrected_reads_fraction": 0.011235955056179775,
             "corrected_unique_umis_fraction": 0.125
         },
@@ -303,6 +325,7 @@
             "corrected_unique_umis": 1,
             "output_unique_umis": 18,
             "output_reads": 150,
+            "output_molecules": 91,
             "corrected_reads_fraction": 0.02,
             "corrected_unique_umis_fraction": 0.05263157894736842
         },
@@ -316,6 +339,7 @@
             "corrected_unique_umis": 8,
             "output_unique_umis": 108,
             "output_reads": 1355,
+            "output_molecules": 826,
             "corrected_reads_fraction": 0.007380073800738007,
             "corrected_unique_umis_fraction": 0.06896551724137931
         },
@@ -329,6 +353,7 @@
             "corrected_unique_umis": 30,
             "output_unique_umis": 316,
             "output_reads": 4077,
+            "output_molecules": 2465,
             "corrected_reads_fraction": 0.008094186902133923,
             "corrected_unique_umis_fraction": 0.08670520231213873
         },
@@ -342,6 +367,7 @@
             "corrected_unique_umis": 3,
             "output_unique_umis": 28,
             "output_reads": 390,
+            "output_molecules": 224,
             "corrected_reads_fraction": 0.007692307692307693,
             "corrected_unique_umis_fraction": 0.0967741935483871
         },
@@ -355,6 +381,7 @@
             "corrected_unique_umis": 8,
             "output_unique_umis": 47,
             "output_reads": 676,
+            "output_molecules": 389,
             "corrected_reads_fraction": 0.011834319526627219,
             "corrected_unique_umis_fraction": 0.14545454545454545
         },
@@ -368,6 +395,7 @@
             "corrected_unique_umis": 14,
             "output_unique_umis": 143,
             "output_reads": 1784,
+            "output_molecules": 1070,
             "corrected_reads_fraction": 0.008408071748878924,
             "corrected_unique_umis_fraction": 0.08917197452229299
         },
@@ -381,6 +409,7 @@
             "corrected_unique_umis": 5,
             "output_unique_umis": 37,
             "output_reads": 383,
+            "output_molecules": 238,
             "corrected_reads_fraction": 0.013054830287206266,
             "corrected_unique_umis_fraction": 0.11904761904761904
         },
@@ -394,6 +423,7 @@
             "corrected_unique_umis": 1,
             "output_unique_umis": 8,
             "output_reads": 90,
+            "output_molecules": 56,
             "corrected_reads_fraction": 0.011111111111111112,
             "corrected_unique_umis_fraction": 0.1111111111111111
         },
@@ -407,6 +437,7 @@
             "corrected_unique_umis": 3,
             "output_unique_umis": 63,
             "output_reads": 833,
+            "output_molecules": 477,
             "corrected_reads_fraction": 0.003601440576230492,
             "corrected_unique_umis_fraction": 0.045454545454545456
         },
@@ -420,6 +451,7 @@
             "corrected_unique_umis": 32,
             "output_unique_umis": 79,
             "output_reads": 1170,
+            "output_molecules": 703,
             "corrected_reads_fraction": 0.02905982905982906,
             "corrected_unique_umis_fraction": 0.2882882882882883
         },
@@ -433,6 +465,7 @@
             "corrected_unique_umis": 18,
             "output_unique_umis": 63,
             "output_reads": 877,
+            "output_molecules": 486,
             "corrected_reads_fraction": 0.027366020524515394,
             "corrected_unique_umis_fraction": 0.2222222222222222
         },
@@ -446,6 +479,7 @@
             "corrected_unique_umis": 143,
             "output_unique_umis": 495,
             "output_reads": 7907,
+            "output_molecules": 4816,
             "corrected_reads_fraction": 0.02036170481851524,
             "corrected_unique_umis_fraction": 0.22413793103448276
         },
@@ -459,6 +493,7 @@
             "corrected_unique_umis": 23,
             "output_unique_umis": 100,
             "output_reads": 1099,
+            "output_molecules": 688,
             "corrected_reads_fraction": 0.02183803457688808,
             "corrected_unique_umis_fraction": 0.18699186991869918
         },
@@ -472,6 +507,7 @@
             "corrected_unique_umis": 171,
             "output_unique_umis": 603,
             "output_reads": 9821,
+            "output_molecules": 5883,
             "corrected_reads_fraction": 0.02005905712249262,
             "corrected_unique_umis_fraction": 0.22093023255813954
         },
@@ -485,6 +521,7 @@
             "corrected_unique_umis": 39,
             "output_unique_umis": 183,
             "output_reads": 2076,
+            "output_molecules": 1251,
             "corrected_reads_fraction": 0.0197495183044316,
             "corrected_unique_umis_fraction": 0.17567567567567569
         },
@@ -498,6 +535,7 @@
             "corrected_unique_umis": 10,
             "output_unique_umis": 52,
             "output_reads": 598,
+            "output_molecules": 360,
             "corrected_reads_fraction": 0.023411371237458192,
             "corrected_unique_umis_fraction": 0.16129032258064516
         },
@@ -511,6 +549,7 @@
             "corrected_unique_umis": 6,
             "output_unique_umis": 45,
             "output_reads": 633,
+            "output_molecules": 391,
             "corrected_reads_fraction": 0.011058451816745656,
             "corrected_unique_umis_fraction": 0.11764705882352941
         },
@@ -524,6 +563,7 @@
             "corrected_unique_umis": 3,
             "output_unique_umis": 19,
             "output_reads": 285,
+            "output_molecules": 166,
             "corrected_reads_fraction": 0.010526315789473684,
             "corrected_unique_umis_fraction": 0.13636363636363635
         },
@@ -537,6 +577,7 @@
             "corrected_unique_umis": 12,
             "output_unique_umis": 28,
             "output_reads": 377,
+            "output_molecules": 227,
             "corrected_reads_fraction": 0.034482758620689655,
             "corrected_unique_umis_fraction": 0.3
         },
@@ -550,6 +591,7 @@
             "corrected_unique_umis": 14,
             "output_unique_umis": 71,
             "output_reads": 901,
+            "output_molecules": 548,
             "corrected_reads_fraction": 0.01553829078801332,
             "corrected_unique_umis_fraction": 0.16470588235294117
         },
@@ -563,6 +605,7 @@
             "corrected_unique_umis": 12,
             "output_unique_umis": 64,
             "output_reads": 996,
+            "output_molecules": 590,
             "corrected_reads_fraction": 0.01706827309236948,
             "corrected_unique_umis_fraction": 0.15789473684210525
         },
@@ -576,6 +619,7 @@
             "corrected_unique_umis": 15,
             "output_unique_umis": 58,
             "output_reads": 702,
+            "output_molecules": 420,
             "corrected_reads_fraction": 0.021367521367521368,
             "corrected_unique_umis_fraction": 0.2054794520547945
         },
@@ -589,6 +633,7 @@
             "corrected_unique_umis": 13,
             "output_unique_umis": 48,
             "output_reads": 721,
+            "output_molecules": 444,
             "corrected_reads_fraction": 0.020804438280166437,
             "corrected_unique_umis_fraction": 0.21311475409836064
         },
@@ -602,6 +647,7 @@
             "corrected_unique_umis": 16,
             "output_unique_umis": 46,
             "output_reads": 643,
+            "output_molecules": 388,
             "corrected_reads_fraction": 0.03110419906687403,
             "corrected_unique_umis_fraction": 0.25806451612903225
         },
@@ -615,6 +661,7 @@
             "corrected_unique_umis": 5,
             "output_unique_umis": 33,
             "output_reads": 429,
+            "output_molecules": 273,
             "corrected_reads_fraction": 0.018648018648018648,
             "corrected_unique_umis_fraction": 0.13157894736842105
         },
@@ -628,6 +675,7 @@
             "corrected_unique_umis": 14,
             "output_unique_umis": 54,
             "output_reads": 661,
+            "output_molecules": 409,
             "corrected_reads_fraction": 0.02118003025718608,
             "corrected_unique_umis_fraction": 0.20588235294117646
         },
@@ -641,6 +689,7 @@
             "corrected_unique_umis": 10,
             "output_unique_umis": 37,
             "output_reads": 444,
+            "output_molecules": 270,
             "corrected_reads_fraction": 0.02252252252252252,
             "corrected_unique_umis_fraction": 0.2127659574468085
         },
@@ -654,6 +703,7 @@
             "corrected_unique_umis": 49,
             "output_unique_umis": 180,
             "output_reads": 2550,
+            "output_molecules": 1574,
             "corrected_reads_fraction": 0.02392156862745098,
             "corrected_unique_umis_fraction": 0.21397379912663755
         },
@@ -667,6 +717,7 @@
             "corrected_unique_umis": 13,
             "output_unique_umis": 19,
             "output_reads": 391,
+            "output_molecules": 229,
             "corrected_reads_fraction": 0.03324808184143223,
             "corrected_unique_umis_fraction": 0.40625
         },
@@ -680,6 +731,7 @@
             "corrected_unique_umis": 15,
             "output_unique_umis": 117,
             "output_reads": 1277,
+            "output_molecules": 750,
             "corrected_reads_fraction": 0.014878621769772905,
             "corrected_unique_umis_fraction": 0.11363636363636363
         },
@@ -693,6 +745,7 @@
             "corrected_unique_umis": 8,
             "output_unique_umis": 15,
             "output_reads": 231,
+            "output_molecules": 138,
             "corrected_reads_fraction": 0.05194805194805195,
             "corrected_unique_umis_fraction": 0.34782608695652173
         },
@@ -706,6 +759,7 @@
             "corrected_unique_umis": 3,
             "output_unique_umis": 19,
             "output_reads": 185,
+            "output_molecules": 115,
             "corrected_reads_fraction": 0.016216216216216217,
             "corrected_unique_umis_fraction": 0.13636363636363635
         },
@@ -719,6 +773,7 @@
             "corrected_unique_umis": 2,
             "output_unique_umis": 21,
             "output_reads": 209,
+            "output_molecules": 123,
             "corrected_reads_fraction": 0.009569377990430622,
             "corrected_unique_umis_fraction": 0.08695652173913043
         },
@@ -732,6 +787,7 @@
             "corrected_unique_umis": 76,
             "output_unique_umis": 416,
             "output_reads": 4283,
+            "output_molecules": 2573,
             "corrected_reads_fraction": 0.02124678963343451,
             "corrected_unique_umis_fraction": 0.15447154471544716
         },
@@ -745,6 +801,7 @@
             "corrected_unique_umis": 8,
             "output_unique_umis": 36,
             "output_reads": 478,
+            "output_molecules": 305,
             "corrected_reads_fraction": 0.01882845188284519,
             "corrected_unique_umis_fraction": 0.18181818181818182
         },
@@ -758,6 +815,7 @@
             "corrected_unique_umis": 12,
             "output_unique_umis": 42,
             "output_reads": 484,
+            "output_molecules": 304,
             "corrected_reads_fraction": 0.024793388429752067,
             "corrected_unique_umis_fraction": 0.2222222222222222
         },
@@ -771,6 +829,7 @@
             "corrected_unique_umis": 73,
             "output_unique_umis": 340,
             "output_reads": 3321,
+            "output_molecules": 2071,
             "corrected_reads_fraction": 0.022884673291177358,
             "corrected_unique_umis_fraction": 0.17675544794188863
         },
@@ -784,6 +843,7 @@
             "corrected_unique_umis": 21,
             "output_unique_umis": 64,
             "output_reads": 650,
+            "output_molecules": 411,
             "corrected_reads_fraction": 0.03538461538461538,
             "corrected_unique_umis_fraction": 0.24705882352941178
         },
@@ -797,6 +857,7 @@
             "corrected_unique_umis": 7,
             "output_unique_umis": 28,
             "output_reads": 298,
+            "output_molecules": 180,
             "corrected_reads_fraction": 0.02348993288590604,
             "corrected_unique_umis_fraction": 0.2
         },
@@ -810,6 +871,7 @@
             "corrected_unique_umis": 1,
             "output_unique_umis": 13,
             "output_reads": 184,
+            "output_molecules": 106,
             "corrected_reads_fraction": 0.005434782608695652,
             "corrected_unique_umis_fraction": 0.07142857142857142
         }

--- a/tests/pna/collapse/test_independent_collapse.py
+++ b/tests/pna/collapse/test_independent_collapse.py
@@ -64,6 +64,45 @@ class TestRegionCollapserInternals:
 
         assert umi2_seq == umi2_seq2
 
+    def _sample_output_rows(self, read_counts):
+        n = len(read_counts)
+        return (
+            pl.DataFrame(
+                {
+                    "marker_1": ["CD8"] * n,
+                    "marker_2": ["CD3e"] * n,
+                    "read_count": read_counts,
+                    "original_umi1": list(range(n)),
+                    "original_umi2": list(range(10, 10 + n)),
+                    "uei": list(range(20, 20 + n)),
+                }
+            ),
+            pa.array(list(range(100, 100 + n)), type=pa.uint64()),
+        )
+
+    def test_build_output_table_drops_overflow_reads_and_keeps_corrected_umis_aligned(
+        self, caplog
+    ):
+        new_data, corrected_umis = self._sample_output_rows([1, 2**16, 3, 2**16 + 1])
+
+        with caplog.at_level("INFO", logger="collapse"):
+            table = self.collapser._build_output_table(new_data, corrected_umis, "CD8")
+
+        assert len(table) == 2
+        assert table.schema.equals(self.collapser._output_schema)
+        assert table.column("read_count").to_pylist() == [1, 3]
+        assert table.column("corrected_umi1").to_pylist() == [100, 102]
+        assert "Dropping of 2 entries with too many reads (>=2^16)" in caplog.text
+
+    def test_build_output_table_keeps_all_rows_when_read_counts_fit_uint16(self):
+        new_data, corrected_umis = self._sample_output_rows([1, 2**16 - 1, 3])
+
+        table = self.collapser._build_output_table(new_data, corrected_umis, "CD8")
+
+        assert len(table) == 3
+        assert table.column("read_count").to_pylist() == [1, 2**16 - 1, 3]
+        assert table.column("corrected_umi1").to_pylist() == [100, 101, 102]
+
 
 def _fake_allocate_array(self, name, shape, dtype, zero_init=True):
     """Return in-memory numpy arrays so tests don't need real shared memory."""

--- a/tests/pna/collapse/test_independent_collapse.py
+++ b/tests/pna/collapse/test_independent_collapse.py
@@ -4,6 +4,8 @@ from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
+import polars as pl
+import pyarrow as pa
 import pytest
 
 from pixelator.pna.cli.collapse import process_independent_files
@@ -282,6 +284,8 @@ class TestIndependentCollapseStatisticsCollector:
             "corrected_reads": 19868,
             "corrected_unique_umis": 17028,
             "output_unique_umis": 122205,
+            "output_reads": 1414029,
+            "output_molecules": 897116,
         }
 
     def test_to_sample_report(self):
@@ -295,6 +299,8 @@ class TestIndependentCollapseStatisticsCollector:
         assert report.report_type == "collapse-umi"
         assert report.region_id == "umi-1"
         assert len(report.markers) == 2
+        assert report.output_reads == 1414029
+        assert report.output_molecules == 897116
 
     def test_to_dict(self):
         stats = IndependentCollapseStatisticsCollector(region_id="umi-1")
@@ -317,6 +323,7 @@ class TestIndependentCollapseStatisticsCollector:
                     "corrected_unique_umis": 17028,
                     "output_unique_umis": 122104,
                     "output_reads": 1413845,
+                    "output_molecules": 896960,
                     "corrected_reads_fraction": 0.014052459781659234,
                     "corrected_unique_umis_fraction": 0.12238737314205216,
                 },
@@ -330,6 +337,7 @@ class TestIndependentCollapseStatisticsCollector:
                     "corrected_unique_umis": 0,
                     "output_unique_umis": 101,
                     "output_reads": 184,
+                    "output_molecules": 156,
                     "corrected_reads_fraction": 0.0,
                     "corrected_unique_umis_fraction": 0.0,
                 },
@@ -340,4 +348,105 @@ class TestIndependentCollapseStatisticsCollector:
             "corrected_reads": 19868,
             "corrected_unique_umis": 17028,
             "output_unique_umis": 122205,
+            "output_reads": 1414029,
+            "output_molecules": 897116,
         }
+
+
+def _make_region_collapser(region_id="umi-1") -> RegionCollapser:
+    assay = pna_config.get_assay("proxiome-v1")
+    panel = pna_config.get_panel("proxiome-v1-immuno-155-v1.1")
+    return RegionCollapser(
+        assay=assay,
+        panel=panel,
+        region_id=region_id,
+        threads=1,
+        max_mismatches=1,
+    )
+
+
+def _output_rows(read_counts: list[int]) -> pl.DataFrame:
+    n = len(read_counts)
+    return pl.DataFrame(
+        {
+            "marker_1": ["CD8"] * n,
+            "marker_2": ["CD3"] * n,
+            "read_count": read_counts,
+            "original_umi1": np.arange(n, dtype=np.uint64),
+            "original_umi2": np.arange(n, dtype=np.uint64) + 10,
+            "uei": np.arange(n, dtype=np.uint64) + 20,
+        }
+    )
+
+
+class TestUniqueUmiReadCountWeights:
+    """Unique-UMI weights must not wrap at 2**16 before directional collapse."""
+
+    def test_unique_umi_weights_use_uint64_and_do_not_wrap(self, umi1_partition):
+        overflow_count = 2**16
+        read_counts = np.zeros(len(umi1_partition), dtype=np.uint64)
+        read_counts[0] = overflow_count
+        data = umi1_partition.with_columns(pl.Series("read_count", read_counts))
+
+        class _FakeMemory:
+            def allocate_array(self, name, shape, dtype, zero_init=True):
+                return np.zeros(shape, dtype=dtype)
+
+            def unlink_buffer(self, name):
+                return None
+
+        collapser = _make_region_collapser()
+        collapser._memory = _FakeMemory()
+        with collapser._init_shared_memory(data) as (_db, unique_umi_weights):
+            assert unique_umi_weights.dtype == np.uint64
+            assert unique_umi_weights.max() == overflow_count
+            expected = np.zeros_like(unique_umi_weights)
+            np.add.at(expected, collapser._db_to_molecule_idx, read_counts)
+            np.testing.assert_array_equal(unique_umi_weights, expected)
+
+
+class TestBuildOutputTableStats:
+    """Overflow drops must be reflected in streamed output statistics."""
+
+    def test_overflow_rows_are_excluded_from_output_stats(self):
+        collapser = _make_region_collapser()
+        read_counts = [1, 2**16, 2]
+        new_data = _output_rows(read_counts)
+        corrected = pa.array(
+            np.arange(len(read_counts), dtype=np.uint64), type=pa.uint64()
+        )
+        stats = MarkerCorrectionStats(
+            marker="CD8",
+            region_id="umi-1",
+            input_reads=sum(read_counts),
+            input_molecules=len(read_counts),
+        )
+
+        table = collapser._build_output_table(new_data, corrected, "CD8", stats)
+
+        assert stats.output_molecules == 2
+        assert stats.output_reads == 3
+        assert stats.input_molecules == 3
+        assert stats.input_reads == sum(read_counts)
+        assert table.num_rows == 2
+        assert table.column("read_count").to_pylist() == [1, 2]
+
+    def test_no_overflow_keeps_output_stats_equal_to_input(self):
+        collapser = _make_region_collapser()
+        read_counts = [1, 4, 7]
+        new_data = _output_rows(read_counts)
+        corrected = pa.array(
+            np.arange(len(read_counts), dtype=np.uint64), type=pa.uint64()
+        )
+        stats = MarkerCorrectionStats(
+            marker="CD8",
+            region_id="umi-1",
+            input_reads=sum(read_counts),
+            input_molecules=len(read_counts),
+        )
+
+        table = collapser._build_output_table(new_data, corrected, "CD8", stats)
+
+        assert stats.output_molecules == 3
+        assert stats.output_reads == 12
+        assert table.num_rows == 3

--- a/tests/pna/collapse/test_independent_collapse.py
+++ b/tests/pna/collapse/test_independent_collapse.py
@@ -83,25 +83,47 @@ class TestRegionCollapserInternals:
     def test_build_output_table_drops_overflow_reads_and_keeps_corrected_umis_aligned(
         self, caplog
     ):
-        new_data, corrected_umis = self._sample_output_rows([1, 2**16, 3, 2**16 + 1])
+        read_counts = [1, 2**16, 3, 2**16 + 1]
+        new_data, corrected_umis = self._sample_output_rows(read_counts)
+        stats = MarkerCorrectionStats(
+            marker="CD8",
+            region_id="umi-1",
+            input_reads=sum(read_counts),
+            input_molecules=len(read_counts),
+        )
 
         with caplog.at_level("INFO", logger="collapse"):
-            table = self.collapser._build_output_table(new_data, corrected_umis, "CD8")
+            table = self.collapser._build_output_table(
+                new_data, corrected_umis, "CD8", stats
+            )
 
         assert len(table) == 2
         assert table.schema.equals(self.collapser._output_schema)
         assert table.column("read_count").to_pylist() == [1, 3]
         assert table.column("corrected_umi1").to_pylist() == [100, 102]
+        assert stats.output_molecules == 2
+        assert stats.output_reads == 4
         assert "Dropping of 2 entries with too many reads (>=2^16)" in caplog.text
 
     def test_build_output_table_keeps_all_rows_when_read_counts_fit_uint16(self):
-        new_data, corrected_umis = self._sample_output_rows([1, 2**16 - 1, 3])
+        read_counts = [1, 2**16 - 1, 3]
+        new_data, corrected_umis = self._sample_output_rows(read_counts)
+        stats = MarkerCorrectionStats(
+            marker="CD8",
+            region_id="umi-1",
+            input_reads=sum(read_counts),
+            input_molecules=len(read_counts),
+        )
 
-        table = self.collapser._build_output_table(new_data, corrected_umis, "CD8")
+        table = self.collapser._build_output_table(
+            new_data, corrected_umis, "CD8", stats
+        )
 
         assert len(table) == 3
         assert table.column("read_count").to_pylist() == [1, 2**16 - 1, 3]
         assert table.column("corrected_umi1").to_pylist() == [100, 101, 102]
+        assert stats.output_molecules == 3
+        assert stats.output_reads == sum(read_counts)
 
 
 def _fake_allocate_array(self, name, shape, dtype, zero_init=True):


### PR DESCRIPTION
<!--

Please fill in the appropriate checklist below (delete whatever is not relevant).

Learn more about contributing: [CONTRIBUTING.md](https://github.com/PixelgenTechnologies/pixelator/blob/main/CONTRIBUTING.md)
-->

## Description

# DO NOT MERGE THIS!

I'm testing to drop high read support umis that would otherwise lead to uint16 overflow error and loud error
These will not be present in a normal dataset.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes collapse output by silently excluding high-support molecules and alter core read-weight math; downstream counts may differ from input on edge-case datasets even though typical runs are unchanged.
> 
> **Overview**
> Independent collapse now **drops molecule rows whose `read_count` is ≥ 2¹⁶** before writing parquet (output schema still uses `uint16`), via new `_build_output_table` that joins corrected UMIs first so filtering cannot misalign rows. **Logged output stats** (`output_reads`, `output_molecules`) reflect what is actually streamed, not input totals.
> 
> **Internal UMI weight aggregation** switches shared-memory read weights from `uint16` to `uint64` and uses `np.add.at` so many molecules sharing one UMI cannot wrap before directional collapse.
> 
> **Reports** replace computed `output_reads` aliases with explicit fields plus legacy validators that default missing values to input counts; combine/aggregate paths include the new output fields. Tests cover overflow drops, alignment, and uint64 weights.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 866af36ce783079eae9c8950c88aed3e92aeeabc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->